### PR TITLE
Match .gitignore and .editorconfig with Ghost repo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.hbs]
+insert_final_newline = false
+
+[{package,bower}.json]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.yml]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,37 @@
+b-cov
+*.seed
+*.log
+*.csv
+*.dat
+*.out
+*.pid
+*.gz
+
+pids
+logs
+results
+
+npm-debug.log
+.bowerrc
+.idea/*
+*.iml
+*.sublime-*
+projectFilesBackup
+
+.DS_Store
+
+# vim-related
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+*.un~
+Session.vim
+.netrwhist
+.vimrc
+*~
+
+# TernJS
+.tern-project
+
 # See http://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output


### PR DESCRIPTION
no issue
- as it's more likely that Ghost-Admin will be checked out separately it makes sense that it has its own `.gitignore` and `.editorconfig` that match the core repository