### PR TITLE
deps: ember-ajax@2.4.1

### DIFF
--- a/app/components/gh-file-uploader.js
+++ b/app/components/gh-file-uploader.js
@@ -1,8 +1,8 @@
 import Ember from 'ember';
 import { invoke, invokeAction } from 'ember-invoke-action';
 import {
-    RequestEntityTooLargeError,
-    UnsupportedMediaTypeError
+    isRequestEntityTooLargeError,
+    isUnsupportedMediaTypeError
 } from 'ghost-admin/services/ajax';
 
 const {
@@ -130,9 +130,9 @@ export default Component.extend({
     _uploadFailed(error) {
         let message;
 
-        if (error instanceof UnsupportedMediaTypeError) {
+        if (isUnsupportedMediaTypeError(error)) {
             message = 'The file type you uploaded is not supported.';
-        } else if (error instanceof RequestEntityTooLargeError) {
+        } else if (isRequestEntityTooLargeError(error)) {
             message = 'The file you uploaded was larger than the maximum file size your server allows.';
         } else if (error.errors && !isBlank(error.errors[0].message)) {
             message = error.errors[0].message;

--- a/app/components/gh-image-uploader.js
+++ b/app/components/gh-image-uploader.js
@@ -1,6 +1,9 @@
 import Ember from 'ember';
 import ghostPaths from 'ghost-admin/utils/ghost-paths';
-import {RequestEntityTooLargeError, UnsupportedMediaTypeError} from 'ghost-admin/services/ajax';
+import {
+    isRequestEntityTooLargeError,
+    isUnsupportedMediaTypeError
+} from 'ghost-admin/services/ajax';
 
 const {
     Component,
@@ -143,9 +146,9 @@ export default Component.extend({
     uploadFailed(error) {
         let message;
 
-        if (error instanceof UnsupportedMediaTypeError) {
+        if (isUnsupportedMediaTypeError(error)) {
             message = 'The image type you uploaded is not supported. Please use .PNG, .JPG, .GIF, .SVG.';
-        } else if (error instanceof RequestEntityTooLargeError) {
+        } else if (isRequestEntityTooLargeError(error)) {
             message = 'The image you uploaded was larger than the maximum file size your server allows.';
         } else if (error.errors && !isBlank(error.errors[0].message)) {
             message = error.errors[0].message;

--- a/app/components/gh-profile-image.js
+++ b/app/components/gh-profile-image.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import AjaxService from 'ember-ajax/services/ajax';
-import {NotFoundError} from 'ghost-admin/services/ajax';
+import {isNotFoundError} from 'ember-ajax/errors';
 
 const {
     Component,
@@ -76,7 +76,7 @@ export default Component.extend({
                 .catch((error) => {
                     let defaultImageUrl = `url("${this.get('ghostPaths.subdir')}/ghost/img/user-image.png")`;
 
-                    if (error instanceof NotFoundError) {
+                    if (isNotFoundError(error)) {
                         this.$('.placeholder-img')[0].style.backgroundImage = Ember.String.htmlSafe(defaultImageUrl);
                     } else {
                         this.$('.placeholder-img')[0].style.backgroundImage = 'url()';

--- a/app/services/notifications.js
+++ b/app/services/notifications.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import {AjaxError} from 'ember-ajax/errors';
+import {isAjaxError} from 'ember-ajax/errors';
 
 const {
     Service,
@@ -115,7 +115,7 @@ export default Service.extend({
 
         options.defaultErrorText = options.defaultErrorText || 'There was a problem on the server, please try again.';
 
-        if (resp instanceof AjaxError) {
+        if (isAjaxError(resp)) {
             resp = resp.errors;
         }
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "2.4.2",
     "csscomb": "3.1.8",
-    "ember-ajax": "0.7.1",
+    "ember-ajax": "2.4.1",
     "ember-cli": "2.5.1",
     "ember-cli-app-version": "1.0.0",
     "ember-cli-babel": "5.1.6",

--- a/tests/integration/services/ajax-test.js
+++ b/tests/integration/services/ajax-test.js
@@ -4,8 +4,14 @@ import {
     it
 } from 'ember-mocha';
 import Pretender from 'pretender';
-import {AjaxError, UnauthorizedError} from 'ember-ajax/errors';
-import {RequestEntityTooLargeError, UnsupportedMediaTypeError} from 'ghost-admin/services/ajax';
+import {
+    isAjaxError,
+    isUnauthorizedError
+} from 'ember-ajax/errors';
+import {
+    isRequestEntityTooLargeError,
+    isUnsupportedMediaTypeError
+} from 'ghost-admin/services/ajax';
 import config from 'ghost-admin/config/environment';
 
 function stubAjaxEndpoint(server, response = {}, code = 200) {
@@ -85,7 +91,10 @@ describeModule(
             ajax.request('/test/').then(() => {
                 expect(false).to.be.true();
             }).catch((error) => {
-                expect(error.errors).to.deep.equal(['First Error', 'Second Error']);
+                expect(error.errors).to.deep.equal([
+                    {message: 'First Error'},
+                    {message: 'Second Error'}
+                ]);
                 done();
             });
         });
@@ -98,12 +107,12 @@ describeModule(
             ajax.request('/test/').then(() => {
                 expect(false).to.be.true;
             }).catch((error) => {
-                expect(error).to.be.instanceOf(AjaxError);
+                expect(isAjaxError(error)).to.be.true;
                 done();
             });
         });
 
-        it('returns known error object for built-in errors', function (done) {
+        it('handles error checking for built-in errors', function (done) {
             stubAjaxEndpoint(server, '', 401);
 
             let ajax = this.subject();
@@ -111,12 +120,12 @@ describeModule(
             ajax.request('/test/').then(() => {
                 expect(false).to.be.true;
             }).catch((error) => {
-                expect(error).to.be.instanceOf(UnauthorizedError);
+                expect(isUnauthorizedError(error)).to.be.true;
                 done();
             });
         });
 
-        it('returns RequestEntityTooLargeError object for 413 errors', function (done) {
+        it('handles error checking for RequestEntityTooLargeError on 413 errors', function (done) {
             stubAjaxEndpoint(server, {}, 413);
 
             let ajax = this.subject();
@@ -124,12 +133,12 @@ describeModule(
             ajax.request('/test/').then(() => {
                 expect(false).to.be.true;
             }).catch((error) => {
-                expect(error).to.be.instanceOf(RequestEntityTooLargeError);
+                expect(isRequestEntityTooLargeError(error)).to.be.true;
                 done();
             });
         });
 
-        it('returns UnsupportedMediaTypeError object for 415 errors', function (done) {
+        it('handles error checking for UnsupportedMediaTypeError on 415 errors', function (done) {
             stubAjaxEndpoint(server, {}, 415);
 
             let ajax = this.subject();
@@ -137,7 +146,7 @@ describeModule(
             ajax.request('/test/').then(() => {
                 expect(false).to.be.true;
             }).catch((error) => {
-                expect(error).to.be.instanceOf(UnsupportedMediaTypeError);
+                expect(isUnsupportedMediaTypeError(error)).to.be.true;
                 done();
             });
         });


### PR DESCRIPTION
no issue
- update ember-ajax
- update error handling to match recommended approach
- update error normalization for handling a returned array of strings

~~This is currently failing because the current version of `ember-ajax` strips the trailing-slashes from provided URLs. I suggest holding off on the upgrade until https://github.com/ember-cli/ember-ajax/pull/96 is merged so that we don't lose performance through a 301 redirect on every API request.~~