### PR TITLE
[WIP] Set up grunt tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ language: node_js
 node_js:
   - "0.10"
 
+matrix:
+  include:
+    - node_js: "0.10"
+      env: TEST_SUITE=lint
+
 cache:
   directories:
     - node_modules
@@ -30,4 +35,4 @@ before_script:
   - export DISPLAY=:99; sh -e /etc/init.d/xvfb start; sleep 3;
 
 script:
-  - npm test
+  - if [ "$TEST_SUITE" == "lint" ]; then grunt lint; else npm test; fi

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,75 @@
+/* global module, require, process */
+/* jscs:disable */
+var path = require('path'),
+
+    escapeChar = process.platform.match(/^win/) ? '^' : '\\',
+    cwd        = process.cwd().replace(/( |\(|\))/g, escapeChar + '$1');
+
+module.exports = function(grunt) {
+
+    // Find all of the task which start with `grunt-` and load them, rather than explicitly declaring them all
+    require('matchdep').filterDev(['grunt-*', '!grunt-cli']).forEach(grunt.loadNpmTasks);
+
+    grunt.initConfig({
+        jshint: {
+            options: {
+                jshintrc: true,
+                ignores: [
+                    'node_modules/**',
+                    'bower_components/**',
+                    'tmp/**',
+                    'dist/**',
+                    'vendor/**'
+                ]
+            },
+
+            all: ['**/*.js']
+        },
+
+        jscs: {
+            app: {
+                options: {
+                    config: '.jscsrc',
+                    excludeFiles: [
+                        'node_modules/**',
+                        'bower_components/**',
+                        'tests/**',
+                        'tmp/**',
+                        'dist/**',
+                        'vendor/**'
+                    ]
+                },
+
+                files: {
+                    src: ['**/*.js']
+                }
+            },
+
+            tests: {
+                options: {
+                    config: 'tests/.jscsrc'
+                },
+
+                files: {
+                    src: [
+                        'tests/**/*.js'
+                    ]
+                }
+            }
+        },
+
+        shell: {
+            csscombfix: {
+                command: path.resolve(cwd + '/node_modules/.bin/csscomb -c app/styles/csscomb.json -v app/styles')
+            },
+
+            csscomblint: {
+                command: path.resolve(cwd + '/node_modules/.bin/csscomb -c app/styles/csscomb.json -lv app/styles')
+            }
+        }
+    });
+
+    grunt.registerTask('lint', 'Run the code style checks and linter',
+        ['jshint', 'jscs', 'shell:csscomblint']
+    );
+};

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ghost-admin",
+  "name": "ghost",
   "version": "0.8.0",
   "description": "Ember.js admin client for Ghost",
   "author": "Ghost Foundation",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,18 @@
 {
-  "name": "ghost",
-  "version": "0.0.0",
-  "description": "Small description for ghost goes here",
+  "name": "ghost-admin",
+  "version": "0.8.0",
+  "description": "Ember.js admin client for Ghost",
+  "author": "Ghost Foundation",
+  "homepage": "http://ghost.org",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/TryGhost/Ghost-Admin.git"
+  },
+  "bugs": "https://github.com/TryGhost/Ghost/issues",
+  "contributors": "https://github.com/TryGhost/Ghost-Admin/graphs/contributors",
+  "license": "MIT",
   "private": true,
   "directories": {
-    "doc": "doc",
     "test": "tests"
   },
   "scripts": {
@@ -12,12 +20,9 @@
     "build": "ember build",
     "test": "ember test"
   },
-  "repository": "",
   "engines": {
     "node": ">= 0.10.0"
   },
-  "author": "",
-  "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "2.4.2",
     "ember-ajax": "0.7.1",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "broccoli-asset-rev": "2.4.2",
+    "csscomb": "3.1.8",
     "ember-ajax": "0.7.1",
     "ember-cli": "2.5.1",
     "ember-cli-app-version": "1.0.0",
@@ -63,9 +64,14 @@
     "emberx-file-input": "1.0.0",
     "fs-extra": "0.30.0",
     "glob": "^7.0.3",
+    "grunt": "1.0.1",
+    "grunt-contrib-jshint": "1.0.0",
+    "grunt-jscs": "2.8.0",
+    "grunt-shell": "1.3.0",
     "liquid-fire": "0.23.1",
     "liquid-tether": "1.1.1",
     "loader.js": "4.0.7",
+    "matchdep": "1.0.1",
     "walk-sync": "^0.2.6"
   },
   "ember-addon": {


### PR DESCRIPTION
refs TryGhost/Ghost#6909
- moves client-related tasks from [Ghost's Gruntfile.js](https://github.com/TryGhost/Ghost/blob/master/Gruntfile.js) into Ghost-Admin ready for removal or use via `subgrunt` in the parent repository.
- adds tasks to ease install 

TODO:
- [x] `grunt init`
  - [x] install dependencies (npm & bower, if used outside of Ghost `npm install` would still need to be run first but it does give us a single point to hook into for extra setup)
  - [x] `buildAboutPage` (as this generates a file for use in the admin client it seems sensible to keep it here)
- [x] `grunt lint` (#36)
  - [x] add to Travis build matrix
- [ ] `grunt dev` (needed to run `csscomb` alongside `ember server`)