### PR TITLE
Scheduler UI

### DIFF
--- a/app/components/gh-editor-save-button.js
+++ b/app/components/gh-editor-save-button.js
@@ -10,28 +10,85 @@ export default Component.extend({
     isNew: null,
     isPublished: null,
     willPublish: null,
+    willSchedule: null,
+    timeScheduled: null,
     postOrPage: null,
     submitting: false,
+    statusFreeze: null,
+    scheduledWillPublish: false,
 
     // Tracks whether we're going to change the state of the post on save
-    isDangerous: computed('isPublished', 'willPublish', function () {
-        return this.get('isPublished') !== this.get('willPublish');
+    isDangerous: computed('isPublished', 'willPublish', 'willSchedule', 'isScheduled', 'scheduledWillPublish', 'statusFreeze', function () {
+        if (this.get('scheduledWillPublish')) {
+            if (this.get('willPublish') !== this.get('willSchedule')) {
+                return false;
+            } else {
+                return true;
+            }
+        } else {
+            if (this.get('isPublished') !== this.get('willPublish')) {
+                return true;
+            } else if (this.get('isScheduled') !== this.get('willSchedule')) {
+                return true;
+            } else if (this.get('statusFreeze')) {
+                // always show the save button in red, when we're 2 minutes before the scheduled date
+                return true;
+            } else {
+                return false;
+            }
+        }
     }),
 
-    publishText: computed('isPublished', 'postOrPage', function () {
-        return this.get('isPublished') ? `Update ${this.get('postOrPage')}` : 'Publish Now';
+    // Text for non-scheduled Posts
+    publishText: computed('isPublished', 'postOrPage', 'scheduledWillPublish', function () {
+        if (this.get('scheduledWillPublish')) {
+            return (this.get('willPublish') || this.get('willSchedule')) ? `Update ${this.get('postOrPage')}` : 'Publish Now';
+        } else {
+            return this.get('isPublished') ? `Update ${this.get('postOrPage')}` : 'Publish Now';
+        }
     }),
 
-    draftText: computed('isPublished', function () {
-        return this.get('isPublished') ? 'Unpublish' : 'Save Draft';
+    draftText: computed('isPublished', 'scheduledWillPublish', function () {
+        if (this.get('scheduledWillPublish')) {
+            return (!this.get('willPublish') || !this.get('willSchedule')) ? 'Unpublish' : 'Save Draft';
+        } else {
+            return this.get('isPublished') ? 'Unpublish' : 'Save Draft';
+        }
+    }),
+
+    savePostText: computed('willPublish', 'publishText', 'postOrPage', 'draftText', 'scheduledWillPublish', 'willSchedule', function () {
+        // we have to show the menu for a published post when a scheduled post gets published while the user is in the
+        // editor and didn't refresh yet. To do so, we use the 'scheduledWillPublish' CP helper
+        if (this.get('scheduledWillPublish')) {
+            if (this.get('willSchedule') || this.get('willPublish')) {
+                return `Update ${this.get('postOrPage')}`;
+            } else {
+                return 'Unpublish';
+            }
+        } else {
+            return this.get('willPublish') ? this.get('publishText') : this.get('draftText');
+        }
+    }),
+
+    // Text for scheduled Posts
+    scheduleText: computed('isScheduled', 'postOrPage', function () {
+        return this.get('isScheduled') ? `Update ${this.get('postOrPage')}` : 'Schedule Post';
+    }),
+
+    unscheduleText: computed('isScheduled', function () {
+        return this.get('isScheduled') ? 'Unschedule' : 'Save Draft';
+    }),
+
+    saveScheduleText: computed('willSchedule', 'scheduleText', 'unscheduleText', function () {
+        return this.get('willSchedule') ? this.get('scheduleText') : this.get('unscheduleText');
     }),
 
     deleteText: computed('postOrPage', function () {
         return `Delete ${this.get('postOrPage')}`;
     }),
 
-    saveText: computed('willPublish', 'publishText', 'draftText', function () {
-        return this.get('willPublish') ? this.get('publishText') : this.get('draftText');
+    activeClass: computed('willPublish', 'willSchedule', function () {
+        return this.get('willPublish') || this.get('willSchedule') ? true : false;
     }),
 
     actions: {

--- a/app/components/gh-posts-list-item.js
+++ b/app/components/gh-posts-list-item.js
@@ -7,9 +7,12 @@ const {
     Component,
     String: {htmlSafe},
     computed,
-    inject: {service}
+    inject: {service},
+    ObjectProxy,
+    PromiseProxyMixin
 } = Ember;
 const {alias, equal} = computed;
+const ObjectPromiseProxy = ObjectProxy.extend(PromiseProxyMixin);
 
 export default Component.extend(ActiveLinkWrapper, {
     tagName: 'li',
@@ -21,8 +24,10 @@ export default Component.extend(ActiveLinkWrapper, {
     isFeatured: alias('post.featured'),
     isPage: alias('post.page'),
     isPublished: equal('post.status', 'published'),
+    isScheduled: equal('post.status', 'scheduled'),
 
     ghostPaths: service(),
+    timeZone: service(),
 
     authorName: computed('post.author.name', 'post.author.email', function () {
         return this.get('post.author.name') || this.get('post.author.email');
@@ -34,6 +39,12 @@ export default Component.extend(ActiveLinkWrapper, {
 
     authorAvatarBackground: computed('authorAvatar', function () {
         return htmlSafe(`background-image: url(${this.get('authorAvatar')})`);
+    }),
+
+    blogTimezone: computed('timeZone.blogTimezone', function () {
+        return ObjectPromiseProxy.create({
+            promise: this.get('timeZone.blogTimezone')
+        });
     }),
 
     click() {

--- a/app/components/gh-spin-button.js
+++ b/app/components/gh-spin-button.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-const {Component, computed, observer, run} = Ember;
+const {Component, computed, observer, run, testing} = Ember;
 const {equal} = computed;
 
 export default Component.extend({
@@ -28,6 +28,7 @@ export default Component.extend({
     toggleSpinner: observer('submitting', function () {
         let submitting = this.get('submitting');
         let timeout = this.get('showSpinnerTimeout');
+        let delay = testing ? 10 : 1000;
 
         if (submitting) {
             this.set('showSpinner', true);
@@ -36,7 +37,7 @@ export default Component.extend({
                     this.set('showSpinner', false);
                 }
                 this.set('showSpinnerTimeout', null);
-            }, 1000));
+            }, delay));
         } else if (!submitting && timeout === null) {
             this.set('showSpinner', false);
         }

--- a/app/controllers/posts.js
+++ b/app/controllers/posts.js
@@ -9,7 +9,7 @@ const {
 const {equal} = computed;
 
 // a custom sort function is needed in order to sort the posts list the same way the server would:
-//     status: ASC
+//     status: scheduled, draft, published
 //     publishedAt: DESC
 //     updatedAt: DESC
 //     id: DESC
@@ -32,7 +32,7 @@ function comparator(item1, item2) {
     }
 
     idResult = compare(parseInt(item1.get('id')), parseInt(item2.get('id')));
-    statusResult = compare(item1.get('status'), item2.get('status'));
+    statusResult = statusCompare(item1, item2);
     updatedAtResult = compare(updated1.valueOf(), updated2.valueOf());
     publishedAtResult = publishedAtCompare(item1, item2);
 
@@ -50,6 +50,38 @@ function comparator(item1, item2) {
     }
 
     return statusResult;
+}
+
+function statusCompare(item1, item2) {
+    let status1 = item1.get('status');
+    let status2 = item2.get('status');
+
+    // if any of those is empty
+    if (!status1 && !status2) {
+        return 0;
+    }
+
+    if (!status1 && status2) {
+        return -1;
+    }
+
+    if (!status2 && status1) {
+        return 1;
+    }
+
+    // We have to make sure, that scheduled posts will be listed first
+    // after that, draft and published will be sorted alphabetically and don't need
+    // any manual comparison.
+
+    if (status1 === 'scheduled' && (status2 === 'draft' || status2 === 'published')) {
+        return -1;
+    }
+
+    if (status2 === 'scheduled' && (status1 === 'draft' || status1 === 'published')) {
+        return 1;
+    }
+
+    return compare(status1.valueOf(), status2.valueOf());
 }
 
 function publishedAtCompare(item1, item2) {

--- a/app/helpers/gh-format-time-scheduled.js
+++ b/app/helpers/gh-format-time-scheduled.js
@@ -1,0 +1,20 @@
+import Ember from 'ember';
+
+const {Helper} = Ember;
+
+export function timeToSchedule(params) {
+    if (!params || !params.length) {
+        return;
+    }
+
+    let [ , blogTimezone] = params;
+    let [time] = params;
+
+    if (blogTimezone.get('isFulfilled')) {
+        return moment.utc(time).tz(blogTimezone.get('content')).format('DD MMM YYYY, HH:mm');
+    }
+}
+
+export default Helper.helper(function (params) {
+    return timeToSchedule(params);
+});

--- a/app/helpers/gh-format-timeago.js
+++ b/app/helpers/gh-format-timeago.js
@@ -7,9 +7,8 @@ export function timeAgo(params) {
         return;
     }
     let [timeago] = params;
-    let utc = moment.utc();
 
-    return moment(timeago).from(utc);
+    return moment(timeago).from(moment.utc());
 }
 
 export default Helper.helper(function (params) {

--- a/app/mirage/factories/post.js
+++ b/app/mirage/factories/post.js
@@ -10,7 +10,7 @@ export default Mirage.Factory.extend({
     image(i) { return  `/content/images/2015/10/post-${i}.jpg`; },
     featured() { return  false; },
     page() { return  false; },
-    status(i) { return  faker.list.cycle('draft', 'published')(i); },
+    status(i) { return faker.list.cycle('draft', 'published', 'scheduled')(i); },
     meta_description(i) { return  `Meta description for post ${i}.`; },
     meta_title(i) { return  `Meta Title for post ${i}`; },
     author_id() { return  1; },

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -43,6 +43,7 @@ export default Model.extend(ValidationEngine, {
     config: service(),
     ghostPaths: service(),
     timeZone: service(),
+    clock: service(),
 
     absoluteUrl: computed('url', 'ghostPaths.url', 'config.blogUrl', function () {
         let blogUrl = this.get('config.blogUrl');
@@ -69,6 +70,16 @@ export default Model.extend(ValidationEngine, {
     isPublished: equal('status', 'published'),
     isDraft: equal('status', 'draft'),
     internalTags: filterBy('tags', 'isInternal', true),
+    isScheduled: equal('status', 'scheduled'),
+
+    // TODO: move this into gh-posts-list-item component
+    // Checks every second, if we reached the scheduled date
+    timeScheduled: computed('publishedAt', 'clock.second', function () {
+        let publishedAt = this.get('publishedAt') || moment.utc(new Date());
+        this.get('clock.second');
+
+        return publishedAt.diff(moment.utc(new Date()), 'hours', true) > 0 ? true : false;
+    }),
 
     // remove client-generated tags, which have `id: null`.
     // Ember Data won't recognize/update them automatically
@@ -85,5 +96,4 @@ export default Model.extend(ValidationEngine, {
     isAuthoredByUser(user) {
         return parseInt(user.get('id'), 10) === parseInt(this.get('authorId'), 10);
     }
-
 });

--- a/app/services/clock.js
+++ b/app/services/clock.js
@@ -21,6 +21,7 @@ export default Service.extend({
 
     tick() {
         let now = moment().utc();
+
         this.setProperties({
             second: now.seconds(),
             minute: now.minutes(),

--- a/app/styles/components/notifications.css
+++ b/app/styles/components/notifications.css
@@ -103,6 +103,21 @@
     background: color(var(--green) lightness(+40%));
 }
 
+/* Schedule notification top
+/* ---------------------------------------------------------- */
+
+.gh-notification-schedule {
+    display: inline-block;
+    margin: 0;
+    padding: 7px 10px;
+    width: auto;
+    border: var(--lightgrey) 1px solid;
+    border-radius: 2px;
+    box-shadow: none;
+    vertical-align: middle;
+    line-height: 1.3em;
+}
+
 /* Alerts
 /* ---------------------------------------------------------- */
 

--- a/app/styles/layouts/content.css
+++ b/app/styles/layouts/content.css
@@ -111,7 +111,7 @@
 }
 
 .content-list .status .scheduled {
-    color: var(--orange);
+    color: var(--green);
 }
 
 .content-list ol {

--- a/app/templates/components/gh-editor-save-button.hbs
+++ b/app/templates/components/gh-editor-save-button.hbs
@@ -1,22 +1,55 @@
-{{#gh-spin-button type="button" classNameBindings=":btn :btn-sm :js-publish-button isDangerous:btn-red:btn-blue" action="save" submitting=submitting}}{{saveText}}{{/gh-spin-button}}
+{{#if statusFreeze}}
+    {{#gh-spin-button type="button" classNameBindings=":btn :btn-sm :js-publish-button isDangerous:btn-red:btn-blue" action="save" submitting=submitting}}
+        Unschedule
+    {{/gh-spin-button}}
+{{else}}
+    {{#gh-spin-button type="button" classNameBindings=":btn :btn-sm :js-publish-button isDangerous:btn-red:btn-blue" action="save" submitting=submitting}}
+    {{#if timeScheduled}}
+        {{saveScheduleText}}
+    {{else}}
+        {{savePostText}}
+    {{/if}}
+    {{/gh-spin-button}}
+{{/if}}
 
-{{#gh-dropdown-button dropdownName="post-save-menu" classNameBindings=":btn :btn-sm isDangerous:btn-red:btn-blue btnopen:active :dropdown-toggle :up"}}
-    <i class="options icon-arrow2"></i>
-    <span class="sr-only">Toggle Settings Menu</span>
-{{/gh-dropdown-button}}
-{{#gh-dropdown name="post-save-menu" closeOnClick="true" classNames="editor-options"}}
-    <ul class="dropdown-menu dropdown-triangle-bottom-right">
-        <li class="post-save-publish {{if willPublish 'active'}}">
-            <a {{action "setSaveType" "publish"}} href="#">{{publishText}}</a>
-        </li>
-        <li class="post-save-draft {{unless willPublish 'active'}}">
-            <a {{action "setSaveType" "draft"}} href="#">{{draftText}}</a>
-        </li>
-        {{#unless isNew}}
-            <li class="divider delete"></li>
-            <li class="delete">
-                <a {{action "delete"}} href="#">{{deleteText}}</a>
-            </li>
-        {{/unless}}
-    </ul>
-{{/gh-dropdown}}
+{{#unless statusFreeze}}
+    {{#gh-dropdown-button dropdownName="post-save-menu" classNameBindings=":btn :btn-sm isDangerous:btn-red:btn-blue btnopen:active :dropdown-toggle :up"}}
+        <i class="options icon-arrow2"></i>
+        <span class="sr-only">Toggle Settings Menu</span>
+    {{/gh-dropdown-button}}
+    {{#gh-dropdown name="post-save-menu" closeOnClick="true" classNames="editor-options"}}
+        <ul class="dropdown-menu dropdown-triangle-bottom-right">
+            {{#if timeScheduled}}
+                <li class="post-save-schedule {{if activeClass 'active'}}">
+                    <a {{action "setSaveType" "schedule"}} href="#">{{scheduleText}}</a>
+                </li>
+                <li class="post-save-draft {{unless activeClass 'active'}}">
+                    <a {{action "setSaveType" "draft"}} href="#">{{unscheduleText}}</a>
+                </li>
+            {{else}}
+                {{#if scheduledWillPublish}}
+                    <li class="post-save-publish {{if activeClass 'active'}}">
+                        <a {{action "setSaveType" "publish"}} href="#">{{publishText}}</a>
+                    </li>
+                    <li class="post-save-draft {{unless activeClass 'active'}}">
+                        <a {{action "setSaveType" "draft"}} href="#">{{draftText}}</a>
+                    </li>
+                {{else}}
+                    <li class="post-save-publish {{if activeClass 'active'}}">
+                        <a {{action "setSaveType" "publish"}} href="#">{{publishText}}</a>
+                    </li>
+                    <li class="post-save-draft {{unless activeClass 'active'}}">
+                        <a {{action "setSaveType" "draft"}} href="#">{{draftText}}</a>
+                    </li>
+                {{/if}}
+            {{/if}}
+
+            {{#unless isNew}}
+                <li class="divider delete"></li>
+                <li class="delete">
+                    <a {{action "delete"}} href="#">{{deleteText}}</a>
+                </li>
+            {{/unless}}
+        </ul>
+    {{/gh-dropdown}}
+{{/unless}}

--- a/app/templates/editor/edit.hbs
+++ b/app/templates/editor/edit.hbs
@@ -3,13 +3,23 @@
         {{#gh-view-title classNames="gh-editor-title" openMobileMenu="openMobileMenu"}}
             {{gh-trim-focus-input type="text" id="entry-title" placeholder="Your Post Title" value=model.titleScratch tabindex="1" focus=shouldFocusTitle focus-out="updateTitle" }}
         {{/gh-view-title}}
+        {{#if scheduleCountdown}}
+            <time datetime="{{post.publishedAt}}" class="gh-notification gh-notification-schedule">
+                Post will be published {{scheduleCountdown}}.
+            </time>
+        {{/if}}
         <section class="view-actions">
             <button type="button" class="post-settings" title="Post Settings" {{action "openSettingsMenu"}}>
                 <i class="icon-settings"></i>
             </button>
             {{gh-editor-save-button
                 isPublished=model.isPublished
+                isScheduled=model.isScheduled
                 willPublish=willPublish
+                willSchedule=willSchedule
+                statusFreeze=statusFreeze
+                scheduledWillPublish=scheduledWillPublish
+                timeScheduled=model.timeScheduled
                 postOrPage=postOrPage
                 isNew=model.isNew
                 save="save"

--- a/app/templates/post-settings-menu.hbs
+++ b/app/templates/post-settings-menu.hbs
@@ -31,7 +31,11 @@
             </div>
 
             {{#gh-form-group errors=model.errors property="post-setting-date"}}
-                <label for="post-setting-date">Publish Date</label>
+                {{#if model.timeScheduled}}
+                    <label for="post-setting-date">Scheduled Date</label>
+                {{else}}
+                    <label for="post-setting-date">Publish Date</label>
+                {{/if}}
                 {{gh-datetime-input value=model.publishedAt
                                     update=(action "setPublishedAt")
                                     inputClass="post-setting-date"

--- a/app/templates/posts.hbs
+++ b/app/templates/posts.hbs
@@ -24,12 +24,19 @@
                                         {{#if post.page}}
                                             <span class="page">Page</span>
                                         {{else}}
-                                            <time datetime="{{post.publishedAt}}" class="date published">
-                                                Published {{gh-format-timeago post.publishedAt}}
+                                            <time datetime="{{post.publishedAt}}" class="date published">{{gh-format-timeago post.publishedAt}}
                                             </time>
                                         {{/if}}
                                     {{else}}
-                                        <span class="draft">Draft</span>
+                    					{{#if component.isScheduled}}
+                    						<span class="scheduled">Scheduled</span>
+                                            <span>&ndash;
+                                                <time datetime="{{post.publishedAt}}" class-="date scheduled">{{gh-format-time-scheduled post.publishedAt component.blogTimezone}}
+                                                </time>
+                                            </span>
+                    					{{else}}
+                                            <span class="draft">Draft</span>
+                    					{{/if}}
                                     {{/if}}
                                 </span>
                                 {{#if feature.internalTags}}

--- a/tests/acceptance/posts/post-test.js
+++ b/tests/acceptance/posts/post-test.js
@@ -37,17 +37,23 @@ describe('Acceptance: Posts - Post', function() {
         });
 
         it('can visit post route', function () {
-            let posts = server.createList('post', 3);
+            let posts = server.createList('post', 6);
 
             visit('/');
 
             andThen(() => {
-                expect(find('.posts-list li').length, 'post list count').to.equal(3);
+                expect(find('.posts-list li').length, 'post list count').to.equal(6);
 
                 // if we're in "desktop" size, we should redirect and highlight
                 if (find('.content-preview:visible').length) {
                     expect(currentURL(), 'currentURL').to.equal(`/${posts[0].id}`);
                     // expect(find('.posts-list li').first().hasClass('active'), 'highlights latest post').to.be.true;
+                    expect(find('.posts-list li:nth-child(1) .status span').first().hasClass('scheduled'), 'first post in list is a scheduled one')
+                        .to.be.true;
+                    expect(find('.posts-list li:nth-child(3) .status span').first().hasClass('draft'), 'third post in list is a draft')
+                        .to.be.true;
+                    expect(find('.posts-list li:nth-child(5) .status time').first().hasClass('published'), 'fifth post in list is a published one')
+                        .to.be.true;
                 }
             });
 

--- a/tests/unit/helpers/gh-format-time-scheduled-test.js
+++ b/tests/unit/helpers/gh-format-time-scheduled-test.js
@@ -1,0 +1,39 @@
+/* jshint expr:true */
+import Ember from 'ember';
+import {expect} from 'chai';
+import {
+    describe,
+    it
+} from 'mocha';
+import {
+    timeToSchedule
+} from 'ghost-admin/helpers/gh-format-time-scheduled';
+import sinon from 'sinon';
+
+const {Object: EmberObject} = Ember;
+
+describe('Unit: Helper: gh-format-time-scheduled', function () {
+    let mockDate;
+    let mockTimezone;
+
+    it('renders the date with the bog timezone', function () {
+        mockDate = '2016-05-30T10:00:00.000Z';
+        mockTimezone = EmberObject.create({
+                content: 'Africa/Cairo',
+                isFulfilled: true
+            });
+
+        let result = timeToSchedule([mockDate, mockTimezone]);
+        expect(result).to.be.equal('30 May 2016, 12:00');
+    });
+    it('returns only when the timezone promise is fulfilled', function () {
+        mockDate = '2016-05-30T10:00:00.000Z';
+        mockTimezone = EmberObject.create({
+                content: undefined,
+                isFulfilled: false
+            });
+
+        let result = timeToSchedule([mockDate, mockTimezone]);
+        expect(result).to.be.equal(undefined);
+    });
+});

--- a/tests/unit/models/post-test.js
+++ b/tests/unit/models/post-test.js
@@ -23,19 +23,29 @@ describeModel(
             expect(model.validationType).to.equal('post');
         });
 
-        it('isPublished and isDraft are correct', function () {
+        it('isPublished, isDraft and isScheduled are correct', function () {
             let model = this.subject({
                 status: 'published'
             });
 
             expect(model.get('isPublished')).to.be.ok;
             expect(model.get('isDraft')).to.not.be.ok;
+            expect(model.get('isScheduled')).to.not.be.ok;
 
             run(function () {
                 model.set('status', 'draft');
 
                 expect(model.get('isPublished')).to.not.be.ok;
                 expect(model.get('isDraft')).to.be.ok;
+                expect(model.get('isScheduled')).to.not.be.ok;
+            });
+
+            run(function () {
+                model.set('status', 'scheduled');
+
+                expect(model.get('isScheduled')).to.be.ok;
+                expect(model.get('isPublished')).to.not.be.ok;
+                expect(model.get('isDraft')).to.not.be.ok;
             });
         });
 


### PR DESCRIPTION
refs TryGhost/Ghost#6413 and TryGhost/Ghost#6870

needs TryGhost/Ghost#6861

- **Post Settings Menu (PSM)**:'Publish Date' input accepts a date from now, min. 2 minutes to allow scheduler processing on the server. Also, there will always be some delay between typing the date and clicking on the 'Schedule Post' button. If the user types a future date for an already published post, the date will be reseted and he sees the message, that the post needs to be unpublished first. Once, the date is accepted, the label will change to 'Scheduled Date'.

- adds a CP 'timeScheduled' to post model, which will return `true` if the publish time is currently in the future.

- **Changes to the button flow in editor**:
- if the the CP `timeScheduled` returns true, a different drop-down-menu will be shown: 'Schedule Post' replaces 'Publish Now' and 'Unschedule' replaces 'Unpublish'.

- Covering the _edge cases_, especially when a scheduled post is about to be published, while the user is in the editor.
	- First, a new CP `scheduleCountdown` will return the remaining time, when the estimated publish time is 15 minutes from now. A notification with this live-ticker is shown next to the save button. Once, we reach a 2 minutes limit, another CP `statusFreeze` will return true and causes the save button to only show `Unschedule` in a red state, until we reach the publish time
	- Once the publish time is reached, a CP `scheduledWillPublish` causes the buttons and the existing code to pretend we're already dealing with a publish post. At the moment, there's no way to make a background-fetch of the now serverside-scheduled post model from the server, so Ember doesn't know about the changed state at that time.
	- Changes in the editor, which are done during this 'status freeze'-process will be saved back correctly, once the user hits 'Update Post' after the buttons changed back. A click on 'Unpublish' will change the status back to a draft.

- adds CP `isScheduled` for scheduled posts
- adds CP `offset` to component `gh-posts-list-item` and helper `gh-format-time-scheduled` to show schedule date in content overview.

TODOs:
- [x] new sort order for posts (1. scheduled, 2. draft, 3. published) (refs TryGhost/Ghost#6932)
- [ ] Write Issue to move posts sorting from posts controller to model and refactor to use `Ember.comparable` mixin and create own component for save button
- [x] Flows for draft -> scheduled -> published like described in TryGhost/Ghost#6870 incl. edge cases and button behaviour
- [x] Tests
- [x] new PSM behaviour for time/date in future
- [x] display publishedAt date with timezone offset on posts overview