### PR TITLE
Remove outline from search input

### DIFF
--- a/app/styles/layouts/main.css
+++ b/app/styles/layouts/main.css
@@ -120,31 +120,8 @@ body > .ember-view:not(.liquid-target-container) {
     margin: 0 15px 10px;
 }
 
-.gh-nav-search .selectize-control {
-    display: flex;
-}
-
-.gh-nav-search-input .selectize-input {
-    padding: 4px 8px;
-    padding-right: 30px;
-    height: auto;
-}
-.gh-nav-search-input .selectize-input,
-.gh-nav-search-input .selectize-input input,
-.gh-nav-search-input .selectize-dropdown {
-    font-size: 1.3rem;
-}
-
-.gh-nav-search .selectize-input.dropdown-active {
-    border-bottom: #fff 1px solid;
-}
-
-.gh-nav-search .selectize-input.dropdown-active:before {
-    display: none;
-}
-
-.gh-nav-search .selectize-dropdown-content {
-    max-height: calc(100vh - 150px);
+.gh-nav-search .ember-power-select-trigger {
+    outline: 0;
 }
 
 .gh-nav-search-button {


### PR DESCRIPTION
no issue
- remove the outline that is shown on the search input once the dropdown box has closed
- remove unused styles for the old selectize-based search input

Before:
![search-before](https://cloud.githubusercontent.com/assets/415/15535795/d56c4224-2266-11e6-94f7-7e65d70ff631.gif)

After:
![search-after](https://cloud.githubusercontent.com/assets/415/15535807/db3b7f62-2266-11e6-91a6-dd255890f587.gif)
