### PR TITLE
Bower dependency updates

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
     "moment": "2.13.0",
     "normalize.css": "3.0.3",
     "password-generator": "2.0.2",
-    "pretender": "1.0.0",
+    "pretender": "1.1.0",
     "rangyinputs": "1.2.0",
     "selectize": "~0.12.1",
     "showdown-ghost": "0.3.6",

--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "fastclick": "1.0.6",
     "google-caja": "6005.0.0",
     "jquery-deparam": "0.5.1",
-    "jquery-file-upload": "9.5.6",
+    "jquery-file-upload": "9.12.3",
     "jquery-ui": "1.11.4",
     "jqueryui-touch-punch": "furf/jquery-ui-touch-punch#4bc009145202d9c7483ba85f3a236a8f3470354d",
     "jquery.simulate.drag-sortable": "0.1.0",

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "jquery.simulate.drag-sortable": "0.1.0",
     "keymaster": "1.6.3",
     "lodash": "3.7.0",
-    "moment": "2.12.0",
+    "moment": "2.13.0",
     "normalize.css": "3.0.3",
     "password-generator": "2.0.2",
     "pretender": "1.0.0",

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "ember-mocha": "0.8.11",
     "Faker": "3.1.0",
     "fastclick": "1.0.6",
-    "google-caja": "5669.0.0",
+    "google-caja": "6005.0.0",
     "jquery-deparam": "0.5.1",
     "jquery-file-upload": "9.5.6",
     "jquery-ui": "1.11.4",


### PR DESCRIPTION
no issue 

Update all of our bower dependencies to the latest compatible versions.
- codemirror@5.15.2
- google-caja@6005.0.0
- jquery-file-upload@9.12.3
- moment@2.13.0
- pretender@1.1.0

`validator-js` was skipped as it will move to an `npm` dependency.