### PR TITLE
Add version header to API requests

### DIFF
--- a/app/adapters/base.js
+++ b/app/adapters/base.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import RESTAdapter from 'ember-data/adapters/rest';
 import ghostPaths from 'ghost/utils/ghost-paths';
 import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
+import config from 'ghost/config/environment';
 
 const {
     inject: {service}
@@ -14,6 +15,10 @@ export default RESTAdapter.extend(DataAdapterMixin, {
     namespace: ghostPaths().apiRoot.slice(1),
 
     session: service(),
+
+    headers: {
+        'X-Ghost-Version': config.APP.version
+    },
 
     shouldBackgroundReloadRecord() {
         return false;

--- a/app/services/ajax.js
+++ b/app/services/ajax.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import AjaxService from 'ember-ajax/services/ajax';
 import {AjaxError} from 'ember-ajax/errors';
+import config from 'ghost/config/environment';
 
 const {inject, computed} = Ember;
 
@@ -24,18 +25,17 @@ export default AjaxService.extend({
 
     headers: computed('session.isAuthenticated', function () {
         let session = this.get('session');
+        let headers = {};
+
+        headers['X-Ghost-Version'] = config.APP.version;
 
         if (session.get('isAuthenticated')) {
-            let headers = {};
-
             session.authorize('authorizer:oauth2', (headerName, headerValue) => {
                 headers[headerName] = headerValue;
             });
-
-            return headers;
-        } else {
-            return [];
         }
+
+        return headers;
     }),
 
     handleResponse(status, headers, payload) {

--- a/config/environment.js
+++ b/config/environment.js
@@ -15,8 +15,13 @@ module.exports = function (environment) {
         },
 
         APP: {
-              // Here you can pass flags/options to your application instance
-              // when it is created
+            // Here you can pass flags/options to your application instance
+            // when it is created
+
+            // override the default version string which contains git info from
+            // https://github.com/cibernox/git-repo-version. Only include the
+            // `major.minor` version numbers
+            version: require('../package.json').version.replace(/\.\d+$/, '')
         },
 
         'ember-simple-auth': {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost",
-  "version": "0.0.0",
+  "version": "0.8.0",
   "description": "Small description for ghost goes here",
   "private": true,
   "directories": {

--- a/tests/integration/services/store-test.js
+++ b/tests/integration/services/store-test.js
@@ -1,0 +1,46 @@
+import { expect } from 'chai';
+import {
+    describeModule,
+    it
+} from 'ember-mocha';
+import Pretender from 'pretender';
+import config from 'ghost/config/environment';
+
+describeModule(
+    'service:store',
+    'Integration: Service: store',
+    {
+        integration: true
+    },
+    function () {
+        let server;
+
+        beforeEach(function () {
+            server = new Pretender();
+        });
+
+        afterEach(function () {
+            server.shutdown();
+        });
+
+        it('adds Ghost version header to requests', function (done) {
+            let {version} = config.APP;
+            let store = this.subject();
+
+            server.get('/ghost/api/v0.1/posts/1/', function () {
+                return [
+                    404,
+                    {'Content-Type': 'application/json'},
+                    JSON.stringify({})
+                ];
+            });
+
+            store.find('post', 1).catch(() => {
+                let [request] = server.handledRequests;
+                console.log(request);
+                expect(request.requestHeaders['X-Ghost-Version']).to.equal(version);
+                done();
+            });
+        });
+    }
+);


### PR DESCRIPTION
no issue
- modifies the version info included in `env.APP.version` to only include the `major.minor` version numbers
- update base adapter to include `X-Ghost-Version` header
- update `ajax` service to include `X-Ghost-Version` header