### PR TITLE
Minor version header fixes

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -21,7 +21,7 @@ module.exports = function (environment) {
             // override the default version string which contains git info from
             // https://github.com/cibernox/git-repo-version. Only include the
             // `major.minor` version numbers
-            version: require('../package.json').version.replace(/\.\d+$/, '')
+            version: require('../package.json').version.match(/^(\d+\.)?(\d+)/)[0]
         },
 
         'ember-simple-auth': {

--- a/tests/integration/services/store-test.js
+++ b/tests/integration/services/store-test.js
@@ -37,7 +37,6 @@ describeModule(
 
             store.find('post', 1).catch(() => {
                 let [request] = server.handledRequests;
-                console.log(request);
                 expect(request.requestHeaders['X-Ghost-Version']).to.equal(version);
                 done();
             });


### PR DESCRIPTION
refs #38
- use same version regex as `safeVersion` does on the server
- remove errant `console.log` from store service test