### PR TITLE
Update package.json details, rename module to `ghost-admin`

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,4 +1,4 @@
-import EmbeddedRelationAdapter from 'ghost/adapters/embedded-relation-adapter';
+import EmbeddedRelationAdapter from 'ghost-admin/adapters/embedded-relation-adapter';
 
 export default EmbeddedRelationAdapter.extend({
 

--- a/app/adapters/base.js
+++ b/app/adapters/base.js
@@ -1,8 +1,8 @@
 import Ember from 'ember';
 import RESTAdapter from 'ember-data/adapters/rest';
-import ghostPaths from 'ghost/utils/ghost-paths';
+import ghostPaths from 'ghost-admin/utils/ghost-paths';
 import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
-import config from 'ghost/config/environment';
+import config from 'ghost-admin/config/environment';
 
 const {
     inject: {service}

--- a/app/adapters/embedded-relation-adapter.js
+++ b/app/adapters/embedded-relation-adapter.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import BaseAdapter from 'ghost/adapters/base';
+import BaseAdapter from 'ghost-admin/adapters/base';
 
 const {get, isNone} = Ember;
 

--- a/app/adapters/setting.js
+++ b/app/adapters/setting.js
@@ -1,4 +1,4 @@
-import ApplicationAdapter from 'ghost/adapters/application';
+import ApplicationAdapter from 'ghost-admin/adapters/application';
 
 export default ApplicationAdapter.extend({
     updateRecord(store, type, record) {

--- a/app/adapters/tag.js
+++ b/app/adapters/tag.js
@@ -1,4 +1,4 @@
-import ApplicationAdapter from 'ghost/adapters/application';
-import SlugUrl from 'ghost/mixins/slug-url';
+import ApplicationAdapter from 'ghost-admin/adapters/application';
+import SlugUrl from 'ghost-admin/mixins/slug-url';
 
 export default ApplicationAdapter.extend(SlugUrl);

--- a/app/adapters/user.js
+++ b/app/adapters/user.js
@@ -1,5 +1,5 @@
-import ApplicationAdapter from 'ghost/adapters/application';
-import SlugUrl from 'ghost/mixins/slug-url';
+import ApplicationAdapter from 'ghost-admin/adapters/application';
+import SlugUrl from 'ghost-admin/mixins/slug-url';
 
 export default ApplicationAdapter.extend(SlugUrl, {
     find(store, type, id) {

--- a/app/app.js
+++ b/app/app.js
@@ -1,8 +1,8 @@
 import Ember from 'ember';
 import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
-import 'ghost/utils/link-component';
-import 'ghost/utils/text-field';
+import 'ghost-admin/utils/link-component';
+import 'ghost-admin/utils/text-field';
 import config from './config/environment';
 
 const {Application} = Ember;

--- a/app/components/gh-datetime-input.js
+++ b/app/components/gh-datetime-input.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
-import TextInputMixin from 'ghost/mixins/text-input';
-import boundOneWay from 'ghost/utils/bound-one-way';
-import {formatDate} from 'ghost/utils/date-formatting';
+import TextInputMixin from 'ghost-admin/mixins/text-input';
+import boundOneWay from 'ghost-admin/utils/bound-one-way';
+import {formatDate} from 'ghost-admin/utils/date-formatting';
 import {invokeAction} from 'ember-invoke-action';
 
 const {

--- a/app/components/gh-dropdown-button.js
+++ b/app/components/gh-dropdown-button.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import DropdownMixin from 'ghost/mixins/dropdown-mixin';
+import DropdownMixin from 'ghost-admin/mixins/dropdown-mixin';
 
 const {
     Component,

--- a/app/components/gh-dropdown.js
+++ b/app/components/gh-dropdown.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import DropdownMixin from 'ghost/mixins/dropdown-mixin';
+import DropdownMixin from 'ghost-admin/mixins/dropdown-mixin';
 
 const {
     Component,

--- a/app/components/gh-ed-editor.js
+++ b/app/components/gh-ed-editor.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
-import EditorAPI from 'ghost/mixins/ed-editor-api';
-import EditorShortcuts from 'ghost/mixins/ed-editor-shortcuts';
-import EditorScroll from 'ghost/mixins/ed-editor-scroll';
+import EditorAPI from 'ghost-admin/mixins/ed-editor-api';
+import EditorShortcuts from 'ghost-admin/mixins/ed-editor-shortcuts';
+import EditorScroll from 'ghost-admin/mixins/ed-editor-scroll';
 import {invokeAction} from 'ember-invoke-action';
 
 const {TextArea, run} = Ember;

--- a/app/components/gh-ed-preview.js
+++ b/app/components/gh-ed-preview.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import {formatMarkdown} from 'ghost/helpers/gh-format-markdown';
+import {formatMarkdown} from 'ghost-admin/helpers/gh-format-markdown';
 
 const {
     Component,

--- a/app/components/gh-editor.js
+++ b/app/components/gh-editor.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
-import ShortcutsMixin from 'ghost/mixins/shortcuts';
-import imageManager from 'ghost/utils/ed-image-manager';
-import editorShortcuts from 'ghost/utils/editor-shortcuts';
+import ShortcutsMixin from 'ghost-admin/mixins/shortcuts';
+import imageManager from 'ghost-admin/utils/ed-image-manager';
+import editorShortcuts from 'ghost-admin/utils/editor-shortcuts';
 import {invokeAction} from 'ember-invoke-action';
 
 const {Component, computed, run} = Ember;

--- a/app/components/gh-file-uploader.js
+++ b/app/components/gh-file-uploader.js
@@ -3,7 +3,7 @@ import { invoke, invokeAction } from 'ember-invoke-action';
 import {
     RequestEntityTooLargeError,
     UnsupportedMediaTypeError
-} from 'ghost/services/ajax';
+} from 'ghost-admin/services/ajax';
 
 const {
     Component,

--- a/app/components/gh-form-group.js
+++ b/app/components/gh-form-group.js
@@ -1,4 +1,4 @@
-import ValidationStatusContainer from 'ghost/components/gh-validation-status-container';
+import ValidationStatusContainer from 'ghost-admin/components/gh-validation-status-container';
 
 export default ValidationStatusContainer.extend({
     classNames: 'form-group'

--- a/app/components/gh-image-uploader.js
+++ b/app/components/gh-image-uploader.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
-import ghostPaths from 'ghost/utils/ghost-paths';
-import {RequestEntityTooLargeError, UnsupportedMediaTypeError} from 'ghost/services/ajax';
+import ghostPaths from 'ghost-admin/utils/ghost-paths';
+import {RequestEntityTooLargeError, UnsupportedMediaTypeError} from 'ghost-admin/services/ajax';
 
 const {
     Component,

--- a/app/components/gh-infinite-scroll.js
+++ b/app/components/gh-infinite-scroll.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import InfiniteScrollMixin from 'ghost/mixins/infinite-scroll';
+import InfiniteScrollMixin from 'ghost-admin/mixins/infinite-scroll';
 
 const {Component} = Ember;
 

--- a/app/components/gh-input.js
+++ b/app/components/gh-input.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import TextInputMixin from 'ghost/mixins/text-input';
+import TextInputMixin from 'ghost-admin/mixins/text-input';
 
 const {TextField} = Ember;
 

--- a/app/components/gh-navitem.js
+++ b/app/components/gh-navitem.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import ValidationState from 'ghost/mixins/validation-state';
+import ValidationState from 'ghost-admin/mixins/validation-state';
 import SortableItem from 'ember-sortable/mixins/sortable-item';
 
 const {Component, computed, run} = Ember;

--- a/app/components/gh-popover-button.js
+++ b/app/components/gh-popover-button.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import DropdownButton from 'ghost/components/gh-dropdown-button';
+import DropdownButton from 'ghost-admin/components/gh-dropdown-button';
 
 const {
     inject: {service}

--- a/app/components/gh-popover.js
+++ b/app/components/gh-popover.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import GhostDropdown from 'ghost/components/gh-dropdown';
+import GhostDropdown from 'ghost-admin/components/gh-dropdown';
 
 const {
     inject: {service}

--- a/app/components/gh-posts-list-item.js
+++ b/app/components/gh-posts-list-item.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import ActiveLinkWrapper from 'ghost/mixins/active-link-wrapper';
+import ActiveLinkWrapper from 'ghost-admin/mixins/active-link-wrapper';
 import {invokeAction} from 'ember-invoke-action';
 
 const {

--- a/app/components/gh-profile-image.js
+++ b/app/components/gh-profile-image.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import AjaxService from 'ember-ajax/services/ajax';
-import {NotFoundError} from 'ghost/services/ajax';
+import {NotFoundError} from 'ghost-admin/services/ajax';
 
 const {
     Component,

--- a/app/components/gh-tag-settings-form.js
+++ b/app/components/gh-tag-settings-form.js
@@ -1,6 +1,6 @@
 /* global key */
 import Ember from 'ember';
-import boundOneWay from 'ghost/utils/bound-one-way';
+import boundOneWay from 'ghost-admin/utils/bound-one-way';
 import {invokeAction} from 'ember-invoke-action';
 
 const {

--- a/app/components/gh-textarea.js
+++ b/app/components/gh-textarea.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import TextInputMixin from 'ghost/mixins/text-input';
+import TextInputMixin from 'ghost-admin/mixins/text-input';
 
 const {TextArea} = Ember;
 

--- a/app/components/gh-validation-status-container.js
+++ b/app/components/gh-validation-status-container.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import ValidationStateMixin from 'ghost/mixins/validation-state';
+import ValidationStateMixin from 'ghost-admin/mixins/validation-state';
 
 const {Component, computed} = Ember;
 

--- a/app/components/modals/copy-html.js
+++ b/app/components/modals/copy-html.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import ModalComponent from 'ghost/components/modals/base';
+import ModalComponent from 'ghost-admin/components/modals/base';
 
 const {computed} = Ember;
 const {alias} = computed;

--- a/app/components/modals/delete-all.js
+++ b/app/components/modals/delete-all.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import ModalComponent from 'ghost/components/modals/base';
+import ModalComponent from 'ghost-admin/components/modals/base';
 
 const {
     inject: {service}

--- a/app/components/modals/delete-post.js
+++ b/app/components/modals/delete-post.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import ModalComponent from 'ghost/components/modals/base';
+import ModalComponent from 'ghost-admin/components/modals/base';
 
 const {
     computed,

--- a/app/components/modals/delete-subscriber.js
+++ b/app/components/modals/delete-subscriber.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import ModalComponent from 'ghost/components/modals/base';
+import ModalComponent from 'ghost-admin/components/modals/base';
 import {invokeAction} from 'ember-invoke-action';
 
 const {computed} = Ember;

--- a/app/components/modals/delete-tag.js
+++ b/app/components/modals/delete-tag.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import ModalComponent from 'ghost/components/modals/base';
+import ModalComponent from 'ghost-admin/components/modals/base';
 import {invokeAction} from 'ember-invoke-action';
 
 const {computed} = Ember;

--- a/app/components/modals/delete-user.js
+++ b/app/components/modals/delete-user.js
@@ -1,4 +1,4 @@
-import ModalComponent from 'ghost/components/modals/base';
+import ModalComponent from 'ghost-admin/components/modals/base';
 import {invokeAction} from 'ember-invoke-action';
 
 export default ModalComponent.extend({

--- a/app/components/modals/import-subscribers.js
+++ b/app/components/modals/import-subscribers.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import { invokeAction } from 'ember-invoke-action';
-import ModalComponent from 'ghost/components/modals/base';
-import ghostPaths from 'ghost/utils/ghost-paths';
+import ModalComponent from 'ghost-admin/components/modals/base';
+import ghostPaths from 'ghost-admin/utils/ghost-paths';
 
 const {computed} = Ember;
 

--- a/app/components/modals/invite-new-user.js
+++ b/app/components/modals/invite-new-user.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
-import ModalComponent from 'ghost/components/modals/base';
-import ValidationEngine from 'ghost/mixins/validation-engine';
+import ModalComponent from 'ghost-admin/components/modals/base';
+import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 
 const {
     RSVP: {Promise},

--- a/app/components/modals/leave-editor.js
+++ b/app/components/modals/leave-editor.js
@@ -1,4 +1,4 @@
-import ModalComponent from 'ghost/components/modals/base';
+import ModalComponent from 'ghost-admin/components/modals/base';
 import {invokeAction} from 'ember-invoke-action';
 
 export default ModalComponent.extend({

--- a/app/components/modals/markdown-help.js
+++ b/app/components/modals/markdown-help.js
@@ -1,4 +1,4 @@
-import ModalComponent from 'ghost/components/modals/base';
+import ModalComponent from 'ghost-admin/components/modals/base';
 
 export default ModalComponent.extend({
 });

--- a/app/components/modals/new-subscriber.js
+++ b/app/components/modals/new-subscriber.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import ModalComponent from 'ghost/components/modals/base';
+import ModalComponent from 'ghost-admin/components/modals/base';
 
 export default ModalComponent.extend({
     actions: {

--- a/app/components/modals/re-authenticate.js
+++ b/app/components/modals/re-authenticate.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
-import ModalComponent from 'ghost/components/modals/base';
-import ValidationEngine from 'ghost/mixins/validation-engine';
+import ModalComponent from 'ghost-admin/components/modals/base';
+import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 
 const {
     $,

--- a/app/components/modals/transfer-owner.js
+++ b/app/components/modals/transfer-owner.js
@@ -1,4 +1,4 @@
-import ModalComponent from 'ghost/components/modals/base';
+import ModalComponent from 'ghost-admin/components/modals/base';
 import {invokeAction} from 'ember-invoke-action';
 
 export default ModalComponent.extend({

--- a/app/components/modals/upload-image.js
+++ b/app/components/modals/upload-image.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
-import ModalComponent from 'ghost/components/modals/base';
-import cajaSanitizers from 'ghost/utils/caja-sanitizers';
+import ModalComponent from 'ghost-admin/components/modals/base';
+import cajaSanitizers from 'ghost-admin/utils/caja-sanitizers';
 
 const {
     computed,

--- a/app/controllers/editor/edit.js
+++ b/app/controllers/editor/edit.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import EditorControllerMixin from 'ghost/mixins/editor-base-controller';
+import EditorControllerMixin from 'ghost-admin/mixins/editor-base-controller';
 
 const {Controller} = Ember;
 

--- a/app/controllers/editor/new.js
+++ b/app/controllers/editor/new.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import EditorControllerMixin from 'ghost/mixins/editor-base-controller';
+import EditorControllerMixin from 'ghost-admin/mixins/editor-base-controller';
 
 const {Controller} = Ember;
 

--- a/app/controllers/post-settings-menu.js
+++ b/app/controllers/post-settings-menu.js
@@ -1,8 +1,8 @@
 import Ember from 'ember';
-import {parseDateString} from 'ghost/utils/date-formatting';
-import SettingsMenuMixin from 'ghost/mixins/settings-menu-controller';
-import boundOneWay from 'ghost/utils/bound-one-way';
-import isNumber from 'ghost/utils/isNumber';
+import {parseDateString} from 'ghost-admin/utils/date-formatting';
+import SettingsMenuMixin from 'ghost-admin/mixins/settings-menu-controller';
+import boundOneWay from 'ghost-admin/utils/bound-one-way';
+import isNumber from 'ghost-admin/utils/isNumber';
 
 const {
     $,

--- a/app/controllers/reset.js
+++ b/app/controllers/reset.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import ValidationEngine from 'ghost/mixins/validation-engine';
+import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 
 const {
     Controller,

--- a/app/controllers/settings/code-injection.js
+++ b/app/controllers/settings/code-injection.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import SettingsSaveMixin from 'ghost/mixins/settings-save';
+import SettingsSaveMixin from 'ghost-admin/mixins/settings-save';
 
 const {
     Controller,

--- a/app/controllers/settings/general.js
+++ b/app/controllers/settings/general.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
-import SettingsSaveMixin from 'ghost/mixins/settings-save';
-import randomPassword from 'ghost/utils/random-password';
+import SettingsSaveMixin from 'ghost-admin/mixins/settings-save';
+import randomPassword from 'ghost-admin/utils/random-password';
 
 const {
     Controller,

--- a/app/controllers/settings/navigation.js
+++ b/app/controllers/settings/navigation.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
-import SettingsSaveMixin from 'ghost/mixins/settings-save';
-import NavigationItem from 'ghost/models/navigation-item';
+import SettingsSaveMixin from 'ghost-admin/mixins/settings-save';
+import NavigationItem from 'ghost-admin/models/navigation-item';
 
 const {
     Controller,

--- a/app/controllers/setup/two.js
+++ b/app/controllers/setup/two.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import ValidationEngine from 'ghost/mixins/validation-engine';
+import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 
 const {
     Controller,

--- a/app/controllers/signin.js
+++ b/app/controllers/signin.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import ValidationEngine from 'ghost/mixins/validation-engine';
+import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 
 const {
     $,

--- a/app/controllers/signup.js
+++ b/app/controllers/signup.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import ValidationEngine from 'ghost/mixins/validation-engine';
+import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 
 const {
     Controller,

--- a/app/controllers/subscribers.js
+++ b/app/controllers/subscribers.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import Table from 'ember-light-table';
-import PaginationMixin from 'ghost/mixins/pagination';
-import ghostPaths from 'ghost/utils/ghost-paths';
+import PaginationMixin from 'ghost-admin/mixins/pagination';
+import ghostPaths from 'ghost-admin/utils/ghost-paths';
 
 const {
     $,

--- a/app/controllers/team/user.js
+++ b/app/controllers/team/user.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
-import isNumber from 'ghost/utils/isNumber';
-import boundOneWay from 'ghost/utils/bound-one-way';
+import isNumber from 'ghost-admin/utils/isNumber';
+import boundOneWay from 'ghost-admin/utils/bound-one-way';
 import { invoke } from 'ember-invoke-action';
 
 const {

--- a/app/helpers/gh-count-words.js
+++ b/app/helpers/gh-count-words.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import counter from 'ghost/utils/word-count';
+import counter from 'ghost-admin/utils/word-count';
 
 const {Helper} = Ember;
 

--- a/app/helpers/gh-format-html.js
+++ b/app/helpers/gh-format-html.js
@@ -1,6 +1,6 @@
 /* global html_sanitize*/
 import Ember from 'ember';
-import cajaSanitizers from 'ghost/utils/caja-sanitizers';
+import cajaSanitizers from 'ghost-admin/utils/caja-sanitizers';
 
 const {Helper} = Ember;
 

--- a/app/helpers/gh-format-markdown.js
+++ b/app/helpers/gh-format-markdown.js
@@ -1,6 +1,6 @@
 /* global Showdown, html_sanitize*/
 import Ember from 'ember';
-import cajaSanitizers from 'ghost/utils/caja-sanitizers';
+import cajaSanitizers from 'ghost-admin/utils/caja-sanitizers';
 
 const {Helper} = Ember;
 

--- a/app/helpers/gh-path.js
+++ b/app/helpers/gh-path.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import ghostPaths from 'ghost/utils/ghost-paths';
+import ghostPaths from 'ghost-admin/utils/ghost-paths';
 
 // Handlebars Helper {{gh-path}}
 // Usage: Assume 'http://www.myghostblog.org/myblog/'

--- a/app/mixins/ed-editor-shortcuts.js
+++ b/app/mixins/ed-editor-shortcuts.js
@@ -1,6 +1,6 @@
 /* global moment, Showdown */
 import Ember from 'ember';
-import titleize from 'ghost/utils/titleize';
+import titleize from 'ghost-admin/utils/titleize';
 
 const {Mixin} = Ember;
 

--- a/app/mixins/editor-base-controller.js
+++ b/app/mixins/editor-base-controller.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
-import PostModel from 'ghost/models/post';
-import boundOneWay from 'ghost/utils/bound-one-way';
+import PostModel from 'ghost-admin/models/post';
+import boundOneWay from 'ghost-admin/utils/bound-one-way';
 
 const {
     Mixin,

--- a/app/mixins/editor-base-route.js
+++ b/app/mixins/editor-base-route.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
-import ShortcutsRoute from 'ghost/mixins/shortcuts-route';
-import styleBody from 'ghost/mixins/style-body';
-import ctrlOrCmd from 'ghost/utils/ctrl-or-cmd';
+import ShortcutsRoute from 'ghost-admin/mixins/shortcuts-route';
+import styleBody from 'ghost-admin/mixins/style-body';
+import ctrlOrCmd from 'ghost-admin/utils/ctrl-or-cmd';
 
 const {$, Mixin, RSVP, run} = Ember;
 

--- a/app/mixins/pagination.js
+++ b/app/mixins/pagination.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import getRequestErrorMessage from 'ghost/utils/ajax';
+import getRequestErrorMessage from 'ghost-admin/utils/ajax';
 
 const {
     Mixin,

--- a/app/mixins/shortcuts-route.js
+++ b/app/mixins/shortcuts-route.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import ShortcutsMixin from 'ghost/mixins/shortcuts';
+import ShortcutsMixin from 'ghost-admin/mixins/shortcuts';
 
 const {Mixin} = Ember;
 

--- a/app/mixins/validation-engine.js
+++ b/app/mixins/validation-engine.js
@@ -1,22 +1,22 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 import Model from 'ember-data/model';
-import getRequestErrorMessage from 'ghost/utils/ajax';
+import getRequestErrorMessage from 'ghost-admin/utils/ajax';
 
-import InviteUserValidator from 'ghost/validators/invite-user';
-import NavItemValidator from 'ghost/validators/nav-item';
-import PostValidator from 'ghost/validators/post';
-import ResetValidator from 'ghost/validators/reset';
-import SettingValidator from 'ghost/validators/setting';
-import SetupValidator from 'ghost/validators/setup';
-import SigninValidator from 'ghost/validators/signin';
-import SignupValidator from 'ghost/validators/signup';
-import SlackIntegrationValidator from 'ghost/validators/slack-integration';
-import SubscriberValidator from 'ghost/validators/subscriber';
-import TagSettingsValidator from 'ghost/validators/tag-settings';
-import UserValidator from 'ghost/validators/user';
+import InviteUserValidator from 'ghost-admin/validators/invite-user';
+import NavItemValidator from 'ghost-admin/validators/nav-item';
+import PostValidator from 'ghost-admin/validators/post';
+import ResetValidator from 'ghost-admin/validators/reset';
+import SettingValidator from 'ghost-admin/validators/setting';
+import SetupValidator from 'ghost-admin/validators/setup';
+import SigninValidator from 'ghost-admin/validators/signin';
+import SignupValidator from 'ghost-admin/validators/signup';
+import SlackIntegrationValidator from 'ghost-admin/validators/slack-integration';
+import SubscriberValidator from 'ghost-admin/validators/subscriber';
+import TagSettingsValidator from 'ghost-admin/validators/tag-settings';
+import UserValidator from 'ghost-admin/validators/user';
 
-import ValidatorExtensions from 'ghost/utils/validator-extensions';
+import ValidatorExtensions from 'ghost-admin/utils/validator-extensions';
 
 const {Mixin, RSVP, isArray} = Ember;
 const {Errors} = DS;

--- a/app/models/navigation-item.js
+++ b/app/models/navigation-item.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import ValidationEngine from 'ghost/mixins/validation-engine';
+import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 
 const {
     computed,

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 import { belongsTo, hasMany } from 'ember-data/relationships';
-import ValidationEngine from 'ghost/mixins/validation-engine';
+import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 
 const {
     computed,

--- a/app/models/setting.js
+++ b/app/models/setting.js
@@ -1,7 +1,7 @@
 /* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
-import ValidationEngine from 'ghost/mixins/validation-engine';
+import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 
 export default Model.extend(ValidationEngine, {
     validationType: 'setting',

--- a/app/models/slack-integration.js
+++ b/app/models/slack-integration.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import ValidationEngine from 'ghost/mixins/validation-engine';
+import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 
 const {
     computed,

--- a/app/models/subscriber.js
+++ b/app/models/subscriber.js
@@ -1,7 +1,7 @@
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 import {belongsTo} from 'ember-data/relationships';
-import ValidationEngine from 'ghost/mixins/validation-engine';
+import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 
 export default Model.extend(ValidationEngine, {
     validationType: 'subscriber',

--- a/app/models/tag.js
+++ b/app/models/tag.js
@@ -1,7 +1,7 @@
 /* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
-import ValidationEngine from 'ghost/mixins/validation-engine';
+import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 
 export default Model.extend(ValidationEngine, {
     validationType: 'tag',

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 import { hasMany } from 'ember-data/relationships';
-import ValidationEngine from 'ghost/mixins/validation-engine';
+import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 
 const {
     computed,

--- a/app/router.js
+++ b/app/router.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
-import ghostPaths from 'ghost/utils/ghost-paths';
-import documentTitle from 'ghost/utils/document-title';
+import ghostPaths from 'ghost-admin/utils/ghost-paths';
+import documentTitle from 'ghost-admin/utils/document-title';
 import config from './config/environment';
 
 const {

--- a/app/routes/about.js
+++ b/app/routes/about.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
-import AuthenticatedRoute from 'ghost/routes/authenticated';
-import styleBody from 'ghost/mixins/style-body';
+import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
+import styleBody from 'ghost-admin/mixins/style-body';
 
 const {
     inject: {service}

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
 import AuthConfiguration from 'ember-simple-auth/configuration';
 import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
-import ShortcutsRoute from 'ghost/mixins/shortcuts-route';
-import ctrlOrCmd from 'ghost/utils/ctrl-or-cmd';
-import windowProxy from 'ghost/utils/window-proxy';
+import ShortcutsRoute from 'ghost-admin/mixins/shortcuts-route';
+import ctrlOrCmd from 'ghost-admin/utils/ctrl-or-cmd';
+import windowProxy from 'ghost-admin/utils/window-proxy';
 
 const {
     Route,

--- a/app/routes/editor/edit.js
+++ b/app/routes/editor/edit.js
@@ -1,9 +1,9 @@
 /* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
-import AuthenticatedRoute from 'ghost/routes/authenticated';
-import base from 'ghost/mixins/editor-base-route';
-import NotFoundHandler from 'ghost/mixins/404-handler';
-import isNumber from 'ghost/utils/isNumber';
-import isFinite from 'ghost/utils/isFinite';
+import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
+import base from 'ghost-admin/mixins/editor-base-route';
+import NotFoundHandler from 'ghost-admin/mixins/404-handler';
+import isNumber from 'ghost-admin/utils/isNumber';
+import isFinite from 'ghost-admin/utils/isFinite';
 
 export default AuthenticatedRoute.extend(base, NotFoundHandler, {
     titleToken: 'Editor',

--- a/app/routes/editor/new.js
+++ b/app/routes/editor/new.js
@@ -1,5 +1,5 @@
-import AuthenticatedRoute from 'ghost/routes/authenticated';
-import base from 'ghost/mixins/editor-base-route';
+import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
+import base from 'ghost-admin/mixins/editor-base-route';
 
 export default AuthenticatedRoute.extend(base, {
     titleToken: 'Editor',

--- a/app/routes/posts.js
+++ b/app/routes/posts.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
-import AuthenticatedRoute from 'ghost/routes/authenticated';
-import ShortcutsRoute from 'ghost/mixins/shortcuts-route';
-import PaginationMixin from 'ghost/mixins/pagination';
+import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
+import ShortcutsRoute from 'ghost-admin/mixins/shortcuts-route';
+import PaginationMixin from 'ghost-admin/mixins/pagination';
 
 export default AuthenticatedRoute.extend(ShortcutsRoute, PaginationMixin, {
     titleToken: 'Content',

--- a/app/routes/posts/index.js
+++ b/app/routes/posts/index.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
-import MobileIndexRoute from 'ghost/routes/mobile-index-route';
+import MobileIndexRoute from 'ghost-admin/routes/mobile-index-route';
 
 const {
     computed,

--- a/app/routes/posts/post.js
+++ b/app/routes/posts/post.js
@@ -1,8 +1,8 @@
-import AuthenticatedRoute from 'ghost/routes/authenticated';
-import ShortcutsRoute from 'ghost/mixins/shortcuts-route';
-import NotFoundHandler from 'ghost/mixins/404-handler';
-import isNumber from 'ghost/utils/isNumber';
-import isFinite from 'ghost/utils/isFinite';
+import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
+import ShortcutsRoute from 'ghost-admin/mixins/shortcuts-route';
+import NotFoundHandler from 'ghost-admin/mixins/404-handler';
+import isNumber from 'ghost-admin/utils/isNumber';
+import isFinite from 'ghost-admin/utils/isFinite';
 
 export default AuthenticatedRoute.extend(ShortcutsRoute, NotFoundHandler, {
     model(params) {

--- a/app/routes/reset.js
+++ b/app/routes/reset.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import Configuration from 'ember-simple-auth/configuration';
-import styleBody from 'ghost/mixins/style-body';
+import styleBody from 'ghost-admin/mixins/style-body';
 
 const {
     Route,

--- a/app/routes/settings/apps.js
+++ b/app/routes/settings/apps.js
@@ -1,6 +1,6 @@
-import AuthenticatedRoute from 'ghost/routes/authenticated';
-import CurrentUserSettings from 'ghost/mixins/current-user-settings';
-import styleBody from 'ghost/mixins/style-body';
+import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
+import CurrentUserSettings from 'ghost-admin/mixins/current-user-settings';
+import styleBody from 'ghost-admin/mixins/style-body';
 
 export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
     titleToken: 'Settings - Apps',

--- a/app/routes/settings/apps/slack.js
+++ b/app/routes/settings/apps/slack.js
@@ -1,6 +1,6 @@
-import AuthenticatedRoute from 'ghost/routes/authenticated';
-import CurrentUserSettings from 'ghost/mixins/current-user-settings';
-import styleBody from 'ghost/mixins/style-body';
+import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
+import CurrentUserSettings from 'ghost-admin/mixins/current-user-settings';
+import styleBody from 'ghost-admin/mixins/style-body';
 
 export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
     titleToken: 'Settings - Apps - Slack',

--- a/app/routes/settings/code-injection.js
+++ b/app/routes/settings/code-injection.js
@@ -1,6 +1,6 @@
-import AuthenticatedRoute from 'ghost/routes/authenticated';
-import CurrentUserSettings from 'ghost/mixins/current-user-settings';
-import styleBody from 'ghost/mixins/style-body';
+import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
+import CurrentUserSettings from 'ghost-admin/mixins/current-user-settings';
+import styleBody from 'ghost-admin/mixins/style-body';
 
 export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
     titleToken: 'Settings - Code Injection',

--- a/app/routes/settings/general.js
+++ b/app/routes/settings/general.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
-import AuthenticatedRoute from 'ghost/routes/authenticated';
-import CurrentUserSettings from 'ghost/mixins/current-user-settings';
-import styleBody from 'ghost/mixins/style-body';
+import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
+import CurrentUserSettings from 'ghost-admin/mixins/current-user-settings';
+import styleBody from 'ghost-admin/mixins/style-body';
 
 const {
     RSVP,

--- a/app/routes/settings/labs.js
+++ b/app/routes/settings/labs.js
@@ -1,6 +1,6 @@
-import AuthenticatedRoute from 'ghost/routes/authenticated';
-import styleBody from 'ghost/mixins/style-body';
-import CurrentUserSettings from 'ghost/mixins/current-user-settings';
+import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
+import styleBody from 'ghost-admin/mixins/style-body';
+import CurrentUserSettings from 'ghost-admin/mixins/current-user-settings';
 
 export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
     titleToken: 'Settings - Labs',

--- a/app/routes/settings/navigation.js
+++ b/app/routes/settings/navigation.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
-import AuthenticatedRoute from 'ghost/routes/authenticated';
-import CurrentUserSettings from 'ghost/mixins/current-user-settings';
-import styleBody from 'ghost/mixins/style-body';
+import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
+import CurrentUserSettings from 'ghost-admin/mixins/current-user-settings';
+import styleBody from 'ghost-admin/mixins/style-body';
 
 const {$} = Ember;
 

--- a/app/routes/settings/tags.js
+++ b/app/routes/settings/tags.js
@@ -1,9 +1,9 @@
 /* global key */
 import Ember from 'ember';
-import AuthenticatedRoute from 'ghost/routes/authenticated';
-import CurrentUserSettings from 'ghost/mixins/current-user-settings';
-import ShortcutsRoute from 'ghost/mixins/shortcuts-route';
-import PaginationMixin from 'ghost/mixins/pagination';
+import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
+import CurrentUserSettings from 'ghost-admin/mixins/current-user-settings';
+import ShortcutsRoute from 'ghost-admin/mixins/shortcuts-route';
+import PaginationMixin from 'ghost-admin/mixins/pagination';
 
 export default AuthenticatedRoute.extend(CurrentUserSettings, PaginationMixin, ShortcutsRoute, {
     titleToken: 'Settings - Tags',

--- a/app/routes/settings/tags/index.js
+++ b/app/routes/settings/tags/index.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import AuthenticatedRoute from 'ghost/routes/authenticated';
+import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 
 const {
     inject: {service}

--- a/app/routes/settings/tags/new.js
+++ b/app/routes/settings/tags/new.js
@@ -1,4 +1,4 @@
-import AuthenticatedRoute from 'ghost/routes/authenticated';
+import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 
 export default AuthenticatedRoute.extend({
 

--- a/app/routes/settings/tags/tag.js
+++ b/app/routes/settings/tags/tag.js
@@ -1,6 +1,6 @@
 /* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
-import AuthenticatedRoute from 'ghost/routes/authenticated';
-import NotFoundHandler from 'ghost/mixins/404-handler';
+import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
+import NotFoundHandler from 'ghost-admin/mixins/404-handler';
 
 export default AuthenticatedRoute.extend(NotFoundHandler, {
 

--- a/app/routes/setup.js
+++ b/app/routes/setup.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import Configuration from 'ember-simple-auth/configuration';
-import styleBody from 'ghost/mixins/style-body';
+import styleBody from 'ghost-admin/mixins/style-body';
 
 const {
     Route,

--- a/app/routes/signin.js
+++ b/app/routes/signin.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import styleBody from 'ghost/mixins/style-body';
+import styleBody from 'ghost-admin/mixins/style-body';
 import Configuration from 'ember-simple-auth/configuration';
 import DS from 'ember-data';
 

--- a/app/routes/signout.js
+++ b/app/routes/signout.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
-import AuthenticatedRoute from 'ghost/routes/authenticated';
-import styleBody from 'ghost/mixins/style-body';
+import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
+import styleBody from 'ghost-admin/mixins/style-body';
 
 const {
     canInvoke,

--- a/app/routes/signup.js
+++ b/app/routes/signup.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 import Configuration from 'ember-simple-auth/configuration';
-import styleBody from 'ghost/mixins/style-body';
+import styleBody from 'ghost-admin/mixins/style-body';
 
 const {
     Route,

--- a/app/routes/subscribers.js
+++ b/app/routes/subscribers.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import AuthenticatedRoute from 'ghost/routes/authenticated';
+import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 
 const {
     RSVP,

--- a/app/routes/team/index.js
+++ b/app/routes/team/index.js
@@ -1,7 +1,7 @@
-import AuthenticatedRoute from 'ghost/routes/authenticated';
-import CurrentUserSettings from 'ghost/mixins/current-user-settings';
-import PaginationMixin from 'ghost/mixins/pagination';
-import styleBody from 'ghost/mixins/style-body';
+import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
+import CurrentUserSettings from 'ghost-admin/mixins/current-user-settings';
+import PaginationMixin from 'ghost-admin/mixins/pagination';
+import styleBody from 'ghost-admin/mixins/style-body';
 
 export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, PaginationMixin, {
     titleToken: 'Team',

--- a/app/routes/team/user.js
+++ b/app/routes/team/user.js
@@ -1,8 +1,8 @@
 /* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
-import AuthenticatedRoute from 'ghost/routes/authenticated';
-import CurrentUserSettings from 'ghost/mixins/current-user-settings';
-import styleBody from 'ghost/mixins/style-body';
-import NotFoundHandler from 'ghost/mixins/404-handler';
+import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
+import CurrentUserSettings from 'ghost-admin/mixins/current-user-settings';
+import styleBody from 'ghost-admin/mixins/style-body';
+import NotFoundHandler from 'ghost-admin/mixins/404-handler';
 
 export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, NotFoundHandler, {
     titleToken: 'Team - User',

--- a/app/serializers/post.js
+++ b/app/serializers/post.js
@@ -1,6 +1,6 @@
 /* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 import Ember from 'ember';
-import ApplicationSerializer from 'ghost/serializers/application';
+import ApplicationSerializer from 'ghost-admin/serializers/application';
 import EmbeddedRecordsMixin from 'ember-data/serializers/embedded-records-mixin';
 
 export default ApplicationSerializer.extend(EmbeddedRecordsMixin, {

--- a/app/serializers/setting.js
+++ b/app/serializers/setting.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import ApplicationSerializer from 'ghost/serializers/application';
+import ApplicationSerializer from 'ghost-admin/serializers/application';
 
 export default ApplicationSerializer.extend({
     serializeIntoHash(hash, type, record, options) {

--- a/app/serializers/tag.js
+++ b/app/serializers/tag.js
@@ -1,6 +1,6 @@
 /* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 import Ember from 'ember';
-import ApplicationSerializer from 'ghost/serializers/application';
+import ApplicationSerializer from 'ghost-admin/serializers/application';
 
 export default ApplicationSerializer.extend({
     serializeIntoHash(hash, type, record, options) {

--- a/app/serializers/user.js
+++ b/app/serializers/user.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import ApplicationSerializer from 'ghost/serializers/application';
+import ApplicationSerializer from 'ghost-admin/serializers/application';
 import EmbeddedRecordsMixin from 'ember-data/serializers/embedded-records-mixin';
 
 export default ApplicationSerializer.extend(EmbeddedRecordsMixin, {

--- a/app/services/ajax.js
+++ b/app/services/ajax.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import AjaxService from 'ember-ajax/services/ajax';
 import {AjaxError} from 'ember-ajax/errors';
-import config from 'ghost/config/environment';
+import config from 'ghost-admin/config/environment';
 
 const {inject, computed} = Ember;
 

--- a/app/services/dropdown.js
+++ b/app/services/dropdown.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 // This is used by the dropdown initializer (and subsequently popovers) to manage closing & toggling
-import BodyEventListener from 'ghost/mixins/body-event-listener';
+import BodyEventListener from 'ghost-admin/mixins/body-event-listener';
 
 const {Service, Evented} = Ember;
 

--- a/app/services/ghost-paths.js
+++ b/app/services/ghost-paths.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import ghostPaths from 'ghost/utils/ghost-paths';
+import ghostPaths from 'ghost-admin/utils/ghost-paths';
 
 const {Service, _ProxyMixin} = Ember;
 

--- a/app/session-stores/application.js
+++ b/app/session-stores/application.js
@@ -1,5 +1,5 @@
 import AdaptiveStore from 'ember-simple-auth/session-stores/adaptive';
-import ghostPaths from 'ghost/utils/ghost-paths';
+import ghostPaths from 'ghost-admin/utils/ghost-paths';
 
 const paths = ghostPaths();
 const keyName = `ghost${(paths.subdir.indexOf('/') === 0 ? `-${paths.subdir.substr(1)}` : ``) }:session`;

--- a/app/transforms/navigation-settings.js
+++ b/app/transforms/navigation-settings.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import Transform from 'ember-data/transform';
-import NavigationItem from 'ghost/models/navigation-item';
+import NavigationItem from 'ghost-admin/models/navigation-item';
 
 const {isArray} = Ember;
 const emberA = Ember.A;

--- a/app/transforms/slack-settings.js
+++ b/app/transforms/slack-settings.js
@@ -1,7 +1,7 @@
 /* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 import Ember from 'ember';
 import Transform from 'ember-data/transform';
-import SlackObject from 'ghost/models/slack-integration';
+import SlackObject from 'ghost-admin/models/slack-integration';
 
 const {isArray} = Ember;
 const emberA = Ember.A;

--- a/app/utils/editor-shortcuts.js
+++ b/app/utils/editor-shortcuts.js
@@ -1,7 +1,7 @@
 // # Editor shortcuts
 // Loaded by gh-editor component
 // This map is used to ensure the right action is called by each shortcut
-import ctrlOrCmd from 'ghost/utils/ctrl-or-cmd';
+import ctrlOrCmd from 'ghost-admin/utils/ctrl-or-cmd';
 
 let shortcuts = {};
 

--- a/app/validators/setup.js
+++ b/app/validators/setup.js
@@ -1,4 +1,4 @@
-import NewUserValidator from 'ghost/validators/new-user';
+import NewUserValidator from 'ghost-admin/validators/new-user';
 
 export default NewUserValidator.create({
     properties: ['name', 'email', 'password', 'blogTitle'],

--- a/app/validators/signup.js
+++ b/app/validators/signup.js
@@ -1,3 +1,3 @@
-import NewUserValidator from 'ghost/validators/new-user';
+import NewUserValidator from 'ghost-admin/validators/new-user';
 
 export default NewUserValidator.create();

--- a/config/environment.js
+++ b/config/environment.js
@@ -3,7 +3,7 @@
 
 module.exports = function (environment) {
     var ENV = {
-        modulePrefix: 'ghost',
+        modulePrefix: 'ghost-admin',
         environment: environment,
         baseURL: '/',
         locationType: 'trailing-history',

--- a/package.json
+++ b/package.json
@@ -1,10 +1,18 @@
 {
-  "name": "ghost",
+  "name": "ghost-admin",
   "version": "0.8.0",
-  "description": "Small description for ghost goes here",
+  "description": "Ember.js admin client for Ghost",
+  "author": "Ghost Foundation",
+  "homepage": "http://ghost.org",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/TryGhost/Ghost-Admin.git"
+  },
+  "bugs": "https://github.com/TryGhost/Ghost/issues",
+  "contributors": "https://github.com/TryGhost/Ghost-Admin/graphs/contributors",
+  "license": "MIT",
   "private": true,
   "directories": {
-    "doc": "doc",
     "test": "tests"
   },
   "scripts": {
@@ -12,12 +20,9 @@
     "build": "ember build",
     "test": "ember test"
   },
-  "repository": "",
   "engines": {
     "node": ">= 0.10.0"
   },
-  "author": "",
-  "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "2.4.2",
     "csscomb": "3.1.8",

--- a/tests/acceptance/authentication-test.js
+++ b/tests/acceptance/authentication-test.js
@@ -9,10 +9,10 @@ import { expect } from 'chai';
 import Ember from 'ember';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
-import { authenticateSession, currentSession, invalidateSession } from 'ghost/tests/helpers/ember-simple-auth';
+import { authenticateSession, currentSession, invalidateSession } from 'ghost-admin/tests/helpers/ember-simple-auth';
 import Mirage from 'ember-cli-mirage';
-import windowProxy from 'ghost/utils/window-proxy';
-import ghostPaths from 'ghost/utils/ghost-paths';
+import windowProxy from 'ghost-admin/utils/window-proxy';
+import ghostPaths from 'ghost-admin/utils/ghost-paths';
 
 const Ghost = ghostPaths();
 

--- a/tests/acceptance/editor-test.js
+++ b/tests/acceptance/editor-test.js
@@ -8,7 +8,7 @@ import {
 import { expect } from 'chai';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
-import { invalidateSession, authenticateSession } from 'ghost/tests/helpers/ember-simple-auth';
+import { invalidateSession, authenticateSession } from 'ghost-admin/tests/helpers/ember-simple-auth';
 import Mirage from 'ember-cli-mirage';
 
 describe('Acceptance: Editor', function() {

--- a/tests/acceptance/posts/post-test.js
+++ b/tests/acceptance/posts/post-test.js
@@ -9,8 +9,8 @@ import {
 import { expect } from 'chai';
 import startApp from '../../helpers/start-app';
 import destroyApp from '../../helpers/destroy-app';
-import { invalidateSession, authenticateSession } from 'ghost/tests/helpers/ember-simple-auth';
-import { errorOverride, errorReset } from 'ghost/tests/helpers/adapter-error';
+import { invalidateSession, authenticateSession } from 'ghost-admin/tests/helpers/ember-simple-auth';
+import { errorOverride, errorReset } from 'ghost-admin/tests/helpers/adapter-error';
 import Mirage from 'ember-cli-mirage';
 
 describe('Acceptance: Posts - Post', function() {

--- a/tests/acceptance/settings/apps-test.js
+++ b/tests/acceptance/settings/apps-test.js
@@ -9,7 +9,7 @@ import { expect } from 'chai';
 import Ember from 'ember';
 import startApp from '../../helpers/start-app';
 import destroyApp from '../../helpers/destroy-app';
-import { invalidateSession, authenticateSession } from 'ghost/tests/helpers/ember-simple-auth';
+import { invalidateSession, authenticateSession } from 'ghost-admin/tests/helpers/ember-simple-auth';
 
 const {run} = Ember;
 

--- a/tests/acceptance/settings/code-injection-test.js
+++ b/tests/acceptance/settings/code-injection-test.js
@@ -8,7 +8,7 @@ import {
 import { expect } from 'chai';
 import startApp from '../../helpers/start-app';
 import destroyApp from '../../helpers/destroy-app';
-import { invalidateSession, authenticateSession } from 'ghost/tests/helpers/ember-simple-auth';
+import { invalidateSession, authenticateSession } from 'ghost-admin/tests/helpers/ember-simple-auth';
 
 describe('Acceptance: Settings - Code-Injection', function() {
     let application;

--- a/tests/acceptance/settings/general-test.js
+++ b/tests/acceptance/settings/general-test.js
@@ -9,7 +9,7 @@ import { expect } from 'chai';
 import Ember from 'ember';
 import startApp from '../../helpers/start-app';
 import destroyApp from '../../helpers/destroy-app';
-import { invalidateSession, authenticateSession } from 'ghost/tests/helpers/ember-simple-auth';
+import { invalidateSession, authenticateSession } from 'ghost-admin/tests/helpers/ember-simple-auth';
 
 const {run} = Ember;
 

--- a/tests/acceptance/settings/labs-test.js
+++ b/tests/acceptance/settings/labs-test.js
@@ -8,7 +8,7 @@ import {
 import { expect } from 'chai';
 import startApp from '../../helpers/start-app';
 import destroyApp from '../../helpers/destroy-app';
-import { invalidateSession, authenticateSession } from 'ghost/tests/helpers/ember-simple-auth';
+import { invalidateSession, authenticateSession } from 'ghost-admin/tests/helpers/ember-simple-auth';
 
 describe('Acceptance: Settings - Labs', function() {
     let application;

--- a/tests/acceptance/settings/navigation-test.js
+++ b/tests/acceptance/settings/navigation-test.js
@@ -9,7 +9,7 @@ import {
 import { expect } from 'chai';
 import startApp from '../../helpers/start-app';
 import destroyApp from '../../helpers/destroy-app';
-import { invalidateSession, authenticateSession } from 'ghost/tests/helpers/ember-simple-auth';
+import { invalidateSession, authenticateSession } from 'ghost-admin/tests/helpers/ember-simple-auth';
 
 describe('Acceptance: Settings - Navigation', function () {
     let application;

--- a/tests/acceptance/settings/slack-test.js
+++ b/tests/acceptance/settings/slack-test.js
@@ -10,7 +10,7 @@ import Ember from 'ember';
 import startApp from '../../helpers/start-app';
 import destroyApp from '../../helpers/destroy-app';
 import Mirage from 'ember-cli-mirage';
-import { invalidateSession, authenticateSession } from 'ghost/tests/helpers/ember-simple-auth';
+import { invalidateSession, authenticateSession } from 'ghost-admin/tests/helpers/ember-simple-auth';
 
 const {run} = Ember;
 

--- a/tests/acceptance/settings/tags-test.js
+++ b/tests/acceptance/settings/tags-test.js
@@ -10,8 +10,8 @@ import { expect } from 'chai';
 import Ember from 'ember';
 import startApp from '../../helpers/start-app';
 import destroyApp from '../../helpers/destroy-app';
-import { invalidateSession, authenticateSession } from 'ghost/tests/helpers/ember-simple-auth';
-import { errorOverride, errorReset } from 'ghost/tests/helpers/adapter-error';
+import { invalidateSession, authenticateSession } from 'ghost-admin/tests/helpers/ember-simple-auth';
+import { errorOverride, errorReset } from 'ghost-admin/tests/helpers/adapter-error';
 import Mirage from 'ember-cli-mirage';
 
 const {run} = Ember;

--- a/tests/acceptance/setup-test.js
+++ b/tests/acceptance/setup-test.js
@@ -7,9 +7,9 @@ import {
 } from 'mocha';
 import { expect } from 'chai';
 import Ember from 'ember';
-import startApp from 'ghost/tests/helpers/start-app';
-import destroyApp from 'ghost/tests/helpers/destroy-app';
-import { invalidateSession, authenticateSession } from 'ghost/tests/helpers/ember-simple-auth';
+import startApp from 'ghost-admin/tests/helpers/start-app';
+import destroyApp from 'ghost-admin/tests/helpers/destroy-app';
+import { invalidateSession, authenticateSession } from 'ghost-admin/tests/helpers/ember-simple-auth';
 import Mirage from 'ember-cli-mirage';
 
 describe('Acceptance: Setup', function () {

--- a/tests/acceptance/signin-test.js
+++ b/tests/acceptance/signin-test.js
@@ -8,7 +8,7 @@ import {
 import { expect } from 'chai';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
-import { invalidateSession, authenticateSession } from 'ghost/tests/helpers/ember-simple-auth';
+import { invalidateSession, authenticateSession } from 'ghost-admin/tests/helpers/ember-simple-auth';
 import Mirage from 'ember-cli-mirage';
 
 describe('Acceptance: Signin', function() {

--- a/tests/acceptance/subscribers-test.js
+++ b/tests/acceptance/subscribers-test.js
@@ -8,7 +8,7 @@ import {
 import { expect } from 'chai';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
-import { invalidateSession, authenticateSession } from 'ghost/tests/helpers/ember-simple-auth';
+import { invalidateSession, authenticateSession } from 'ghost-admin/tests/helpers/ember-simple-auth';
 
 describe('Acceptance: Subscribers', function() {
     let application;

--- a/tests/acceptance/team-test.js
+++ b/tests/acceptance/team-test.js
@@ -9,8 +9,8 @@ import { expect } from 'chai';
 import Ember from 'ember';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
-import { invalidateSession, authenticateSession } from 'ghost/tests/helpers/ember-simple-auth';
-import { errorOverride, errorReset } from 'ghost/tests/helpers/adapter-error';
+import { invalidateSession, authenticateSession } from 'ghost-admin/tests/helpers/ember-simple-auth';
+import { errorOverride, errorReset } from 'ghost-admin/tests/helpers/adapter-error';
 import Mirage from 'ember-cli-mirage';
 
 describe('Acceptance: Team', function () {

--- a/tests/integration/components/gh-navigation-test.js
+++ b/tests/integration/components/gh-navigation-test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { describeComponent, it } from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
-import NavItem from 'ghost/models/navigation-item';
+import NavItem from 'ghost-admin/models/navigation-item';
 
 const {run} = Ember;
 

--- a/tests/integration/components/gh-navitem-test.js
+++ b/tests/integration/components/gh-navitem-test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { describeComponent, it } from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
-import NavItem from 'ghost/models/navigation-item';
+import NavItem from 'ghost-admin/models/navigation-item';
 
 const {run} = Ember;
 

--- a/tests/integration/services/ajax-test.js
+++ b/tests/integration/services/ajax-test.js
@@ -5,8 +5,8 @@ import {
 } from 'ember-mocha';
 import Pretender from 'pretender';
 import {AjaxError, UnauthorizedError} from 'ember-ajax/errors';
-import {RequestEntityTooLargeError, UnsupportedMediaTypeError} from 'ghost/services/ajax';
-import config from 'ghost/config/environment';
+import {RequestEntityTooLargeError, UnsupportedMediaTypeError} from 'ghost-admin/services/ajax';
+import config from 'ghost-admin/config/environment';
 
 function stubAjaxEndpoint(server, response = {}, code = 200) {
     server.get('/test/', function () {

--- a/tests/integration/services/feature-test.js
+++ b/tests/integration/services/feature-test.js
@@ -4,9 +4,9 @@ import {
 } from 'ember-mocha';
 import Pretender from 'pretender';
 import wait from 'ember-test-helpers/wait';
-import FeatureService, {feature} from 'ghost/services/feature';
+import FeatureService, {feature} from 'ghost-admin/services/feature';
 import Ember from 'ember';
-import { errorOverride, errorReset } from 'ghost/tests/helpers/adapter-error';
+import { errorOverride, errorReset } from 'ghost-admin/tests/helpers/adapter-error';
 
 const {RSVP, merge, run} = Ember;
 const EmberError = Ember.Error;

--- a/tests/integration/services/store-test.js
+++ b/tests/integration/services/store-test.js
@@ -4,7 +4,7 @@ import {
     it
 } from 'ember-mocha';
 import Pretender from 'pretender';
-import config from 'ghost/config/environment';
+import config from 'ghost-admin/config/environment';
 
 describeModule(
     'service:store',

--- a/tests/unit/controllers/settings/navigation-test.js
+++ b/tests/unit/controllers/settings/navigation-test.js
@@ -2,7 +2,7 @@
 import { expect, assert } from 'chai';
 import { describeModule, it } from 'ember-mocha';
 import Ember from 'ember';
-import NavItem from 'ghost/models/navigation-item';
+import NavItem from 'ghost-admin/models/navigation-item';
 
 const {run} = Ember;
 

--- a/tests/unit/helpers/gh-format-timeago-test.js
+++ b/tests/unit/helpers/gh-format-timeago-test.js
@@ -6,7 +6,7 @@ import {
 } from 'mocha';
 import {
     timeAgo
-} from 'ghost/helpers/gh-format-timeago';
+} from 'ghost-admin/helpers/gh-format-timeago';
 import sinon from 'sinon';
 
 describe('Unit: Helper: gh-format-timeago', function () {

--- a/tests/unit/helpers/gh-user-can-admin-test.js
+++ b/tests/unit/helpers/gh-user-can-admin-test.js
@@ -2,7 +2,7 @@ import {
     describeModule,
     it
 } from 'ember-mocha';
-import { ghUserCanAdmin } from 'ghost/helpers/gh-user-can-admin';
+import { ghUserCanAdmin } from 'ghost-admin/helpers/gh-user-can-admin';
 
 describe('Unit: Helper: gh-user-can-admin', function () {
     // Mock up roles and test for truthy

--- a/tests/unit/helpers/highlighted-text-test.js
+++ b/tests/unit/helpers/highlighted-text-test.js
@@ -6,7 +6,7 @@ import {
 } from 'mocha';
 import {
   highlightedText
-} from 'ghost/helpers/highlighted-text';
+} from 'ghost-admin/helpers/highlighted-text';
 
 describe('Unit: Helper: highlighted-text', function() {
 

--- a/tests/unit/helpers/is-equal-test.js
+++ b/tests/unit/helpers/is-equal-test.js
@@ -6,7 +6,7 @@ import {
 } from 'mocha';
 import {
     isEqual
-} from 'ghost/helpers/is-equal';
+} from 'ghost-admin/helpers/is-equal';
 
 describe('Unit: Helper: is-equal', function () {
     // Replace this with your real tests.

--- a/tests/unit/helpers/is-not-test.js
+++ b/tests/unit/helpers/is-not-test.js
@@ -6,7 +6,7 @@ import {
 } from 'mocha';
 import {
     isNot
-} from 'ghost/helpers/is-not';
+} from 'ghost-admin/helpers/is-not';
 
 describe('Unit: Helper: is-not', function () {
     // Replace this with your real tests.

--- a/tests/unit/mixins/infinite-scroll-test.js
+++ b/tests/unit/mixins/infinite-scroll-test.js
@@ -5,7 +5,7 @@ import {
     it
 } from 'mocha';
 import Ember from 'ember';
-import InfiniteScrollMixin from 'ghost/mixins/infinite-scroll';
+import InfiniteScrollMixin from 'ghost-admin/mixins/infinite-scroll';
 
 describe('Unit: Mixin: infinite-scroll', function () {
     // Replace this with your real tests.

--- a/tests/unit/mixins/validation-engine-test.js
+++ b/tests/unit/mixins/validation-engine-test.js
@@ -5,7 +5,7 @@ import {
     it
 } from 'mocha';
 import Ember from 'ember';
-import ValidationEngineMixin from 'ghost/mixins/validation-engine';
+import ValidationEngineMixin from 'ghost-admin/mixins/validation-engine';
 
 describe('ValidationEngineMixin', function () {
     // Replace this with your real tests.

--- a/tests/unit/transforms/navigation-settings-test.js
+++ b/tests/unit/transforms/navigation-settings-test.js
@@ -2,7 +2,7 @@
 import { expect } from 'chai';
 import { describeModule, it } from 'ember-mocha';
 import Ember from 'ember';
-import NavigationItem from 'ghost/models/navigation-item';
+import NavigationItem from 'ghost-admin/models/navigation-item';
 
 const emberA = Ember.A;
 

--- a/tests/unit/transforms/slack-settings-test.js
+++ b/tests/unit/transforms/slack-settings-test.js
@@ -2,7 +2,7 @@
 import { expect } from 'chai';
 import { describeModule, it } from 'ember-mocha';
 import Ember from 'ember';
-import SlackIntegration from 'ghost/models/slack-integration';
+import SlackIntegration from 'ghost-admin/models/slack-integration';
 
 const emberA = Ember.A;
 

--- a/tests/unit/utils/date-formatting-test.js
+++ b/tests/unit/utils/date-formatting-test.js
@@ -1,4 +1,4 @@
-import {formatDate, parseDateString} from 'ghost/utils/date-formatting';
+import {formatDate, parseDateString} from 'ghost-admin/utils/date-formatting';
 
 describe('Unit: Util: date-formatting', function () {
     it('parses a string into a moment');

--- a/tests/unit/utils/ghost-paths-test.js
+++ b/tests/unit/utils/ghost-paths-test.js
@@ -1,4 +1,4 @@
-import ghostPaths from 'ghost/utils/ghost-paths';
+import ghostPaths from 'ghost-admin/utils/ghost-paths';
 
 describe('Unit: Util: ghost-paths', function () {
     describe('join', function () {

--- a/tests/unit/validators/nav-item-test.js
+++ b/tests/unit/validators/nav-item-test.js
@@ -4,8 +4,8 @@ import {
     describe,
     it
 } from 'mocha';
-import validator from 'ghost/validators/nav-item';
-import NavItem from 'ghost/models/navigation-item';
+import validator from 'ghost-admin/validators/nav-item';
+import NavItem from 'ghost-admin/models/navigation-item';
 
 const testInvalidUrl = function (url) {
     let navItem = NavItem.create({url});

--- a/tests/unit/validators/slack-integration-test.js
+++ b/tests/unit/validators/slack-integration-test.js
@@ -4,8 +4,8 @@ import {
     describe,
     it
 } from 'mocha';
-import validator from 'ghost/validators/slack-integration';
-import SlackObject from 'ghost/models/slack-integration';
+import validator from 'ghost-admin/validators/slack-integration';
+import SlackObject from 'ghost-admin/models/slack-integration';
 
 const testInvalidUrl = function (url) {
     let slackObject = SlackObject.create({url});

--- a/tests/unit/validators/subscriber-test.js
+++ b/tests/unit/validators/subscriber-test.js
@@ -5,7 +5,7 @@ import {
     it
 } from 'mocha';
 import Ember from 'ember';
-import ValidationEngine from 'ghost/mixins/validation-engine';
+import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 
 const {run} = Ember;
 

--- a/tests/unit/validators/tag-settings-test.js
+++ b/tests/unit/validators/tag-settings-test.js
@@ -6,8 +6,8 @@ import {
 } from 'mocha';
 import sinon from 'sinon';
 import Ember from 'ember';
-// import validator from 'ghost/validators/tag-settings';
-import ValidationEngine from 'ghost/mixins/validation-engine';
+// import validator from 'ghost-admin/validators/tag-settings';
+import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 
 const {run} = Ember;
 


### PR DESCRIPTION
no issue
- updates `package.json` details to better reflect the separation from the `Ghost` package
- update ember config and all import statements to reflect the new `ghost-admin` module name in `package.json`