### PR TITLE
Refactor signin/signup/setup/reset routes to use correct route mixin

### DIFF
--- a/app/routes/reset.js
+++ b/app/routes/reset.js
@@ -1,20 +1,20 @@
 import Route from 'ember-route';
 import injectService from 'ember-service/inject';
-import Configuration from 'ember-simple-auth/configuration';
+import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
 import styleBody from 'ghost-admin/mixins/style-body';
 
-export default Route.extend(styleBody, {
+export default Route.extend(styleBody, UnauthenticatedRouteMixin, {
     classNames: ['ghost-reset'],
 
     notifications: injectService(),
     session: injectService(),
 
     beforeModel() {
-        this._super(...arguments);
         if (this.get('session.isAuthenticated')) {
             this.get('notifications').showAlert('You can\'t reset your password while you\'re signed in.', {type: 'warn', delayed: true, key: 'password.reset.signed-in'});
-            this.transitionTo(Configuration.routeAfterAuthentication);
         }
+
+        this._super(...arguments);
     },
 
     setupController(controller, params) {

--- a/app/routes/signup.js
+++ b/app/routes/signup.js
@@ -9,13 +9,13 @@ import {
 } from 'ghost-admin/services/ajax';
 
 import DS from 'ember-data';
-import Configuration from 'ember-simple-auth/configuration';
+import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
 import styleBody from 'ghost-admin/mixins/style-body';
 
 const {Promise} = RSVP;
 const {Errors} = DS;
 
-export default Route.extend(styleBody, {
+export default Route.extend(styleBody, UnauthenticatedRouteMixin, {
     classNames: ['ghost-signup'],
 
     ghostPaths: injectService(),
@@ -24,12 +24,11 @@ export default Route.extend(styleBody, {
     ajax: injectService(),
 
     beforeModel() {
-        this._super(...arguments);
-
         if (this.get('session.isAuthenticated')) {
             this.get('notifications').showAlert('You need to sign out to register as a new user.', {type: 'warn', delayed: true, key: 'signup.create.already-authenticated'});
-            this.transitionTo(Configuration.routeIfAlreadyAuthenticated);
         }
+
+        this._super(...arguments);
     },
 
     model(params) {


### PR DESCRIPTION
no issue
- aligns those routes more with the ember-simple-auth method of doing things
