### PR TITLE
Rename "offset" to "blogTimezone"

### DIFF
--- a/app/components/gh-datetime-input.js
+++ b/app/components/gh-datetime-input.js
@@ -23,7 +23,7 @@ export default Component.extend(TextInputMixin, {
     didReceiveAttrs() {
         let promises = {
             datetime: RSVP.resolve(this.get('datetime') || moment.utc()),
-            offset: RSVP.resolve(this.get('timeZone.offset'))
+            blogTimezone: RSVP.resolve(this.get('timeZone.blogTimezone'))
         };
 
         if (!this.get('update')) {
@@ -31,7 +31,7 @@ export default Component.extend(TextInputMixin, {
         }
 
         RSVP.hash(promises).then((hash) => {
-            this.set('datetime', formatDate(hash.datetime || moment.utc(), hash.offset));
+            this.set('datetime', formatDate(hash.datetime || moment.utc(), hash.blogTimezone));
         });
     },
 

--- a/app/controllers/post-settings-menu.js
+++ b/app/controllers/post-settings-menu.js
@@ -297,8 +297,8 @@ export default Controller.extend(SettingsMenuMixin, {
                 }
                 return;
             }
-            this.get('timeZone.offset').then((offset) => {
-                let newPublishedAt = parseDateString(userInput, offset);
+            this.get('timeZone.blogTimezone').then((blogTimezone) => {
+                let newPublishedAt = parseDateString(userInput, blogTimezone);
                 let publishedAt = moment.utc(this.get('model.publishedAt'));
                 let errMessage = '';
 

--- a/app/services/time-zone.js
+++ b/app/services/time-zone.js
@@ -19,7 +19,7 @@ export default Service.extend({
         return store.queryRecord('setting', {type: 'blog,theme,private'});
     }),
 
-    offset: computed('_settings.activeTimezone', function () {
+    blogTimezone: computed('_settings.activeTimezone', function () {
         return this.get('_settings').then((settings) => {
             return this._parseTimezones(settings);
         });

--- a/app/utils/date-formatting.js
+++ b/app/utils/date-formatting.js
@@ -24,18 +24,18 @@ function verifyTimeStamp(dateString) {
 }
 
 // Parses a string to a Moment
-function parseDateString(value, offset) {
-    // We need the offset here, otherwise the date will be parsed
+function parseDateString(value, timezone) {
+    // We need the timezone here, otherwise the date will be parsed
     // in UTC timezone
-    moment.tz.setDefault(offset);
+    moment.tz.setDefault(timezone);
 
     return value ? moment(verifyTimeStamp(value), parseDateFormats, true) : undefined;
 }
 
 // Formats a Date or Moment
-function formatDate(value, offset) {
-    // we output the date adjusted by the offset of the timezone set in the blog setting
-    return verifyTimeStamp(value ? moment(value).tz(offset).format(displayDateFormat) : '');
+function formatDate(value, timezone) {
+    // we output the date adjusted to the blog timezone selected in settings
+    return verifyTimeStamp(value ? moment(value).tz(timezone).format(displayDateFormat) : '');
 }
 
 export {

--- a/tests/integration/services/time-zone-test.js
+++ b/tests/integration/services/time-zone-test.js
@@ -38,13 +38,13 @@ describeModule(
             server.shutdown();
         });
 
-        it('should return a timezone offset', function (done) {
+        it('should return the blogs timezone', function (done) {
             let service = this.subject();
 
             settingsStub(server);
 
-            service.get('offset').then(function (offset) {
-                expect(offset).to.equal('Africa/Cairo');
+            service.get('blogTimezone').then(function (blogTimezone) {
+                expect(blogTimezone).to.equal('Africa/Cairo');
                 done();
             });
         });


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/pull/6941#issuecomment-224553575
- `blogTimezone` and `timezone` better reflect their values (a string representing a timezone in the format `Europe/Dublin`) than `offset` which suggests a fixed value

This hopefully makes things a little easier to follow for now. Once the synchronous `settings` service is ready I imagine the `timeZone` service and it's `timeZone.blogTimezone` will disappear and it'll be replaced with `settings.activeTimezone`.