### PR TITLE
deps: ember@2.6.0

### DIFF
--- a/app/utils/ghost-paths.js
+++ b/app/utils/ghost-paths.js
@@ -16,7 +16,7 @@ let makeRoute = function (root, args) {
 export default function () {
     let path = window.location.pathname;
     let subdir = path.substr(0, path.search('/ghost/'));
-    let adminRoot = `${subdir}/ghost`;
+    let adminRoot = `${subdir}/ghost/`;
     let apiRoot = `${subdir}/ghost/api/v0.1`;
 
     function assetUrl(src) {

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "blueimp-md5": "2.3.0",
     "codemirror": "5.15.2",
     "devicejs": "0.2.7",
-    "ember": "2.5.1",
+    "ember": "2.6.0",
     "ember-cli-shims": "0.1.1",
     "ember-cli-test-loader": "0.2.2",
     "ember-mocha": "0.8.11",

--- a/tests/acceptance/settings/tags-test.js
+++ b/tests/acceptance/settings/tags-test.js
@@ -111,7 +111,7 @@ describe('Acceptance: Settings - Tags', function () {
                     .to.equal(tag1.name);
 
                 // it highlights selected tag
-                expect(find(`a[href="/settings/tags/${tag1.slug}"]`).hasClass('active'), 'highlights selected tag')
+                expect(find(`a[href="/ghost/settings/tags/${tag1.slug}"]`).hasClass('active'), 'highlights selected tag')
                     .to.be.true;
 
                 // it shows selected tag form
@@ -129,7 +129,7 @@ describe('Acceptance: Settings - Tags', function () {
                 expect(currentURL(), 'url after clicking tag').to.equal(`/settings/tags/${tag2.slug}`);
 
                 // it highlights selected tag
-                expect(find(`a[href="/settings/tags/${tag2.slug}"]`).hasClass('active'), 'highlights selected tag')
+                expect(find(`a[href="/ghost/settings/tags/${tag2.slug}"]`).hasClass('active'), 'highlights selected tag')
                     .to.be.true;
 
                 // it shows selected tag form
@@ -150,7 +150,7 @@ describe('Acceptance: Settings - Tags', function () {
                 expect(currentURL(), 'url after keyboard up arrow').to.equal(`/settings/tags/${tag1.slug}`);
 
                 // it highlights selected tag
-                expect(find(`a[href="/settings/tags/${tag1.slug}"]`).hasClass('active'), 'selects previous tag')
+                expect(find(`a[href="/ghost/settings/tags/${tag1.slug}"]`).hasClass('active'), 'selects previous tag')
                     .to.be.true;
             });
 
@@ -167,7 +167,7 @@ describe('Acceptance: Settings - Tags', function () {
                 expect(currentURL(), 'url after keyboard down arrow').to.equal(`/settings/tags/${tag2.slug}`);
 
                 // it highlights selected tag
-                expect(find(`a[href="/settings/tags/${tag2.slug}"]`).hasClass('active'), 'selects next tag')
+                expect(find(`a[href="/ghost/settings/tags/${tag2.slug}"]`).hasClass('active'), 'selects next tag')
                     .to.be.true;
             });
 
@@ -213,7 +213,7 @@ describe('Acceptance: Settings - Tags', function () {
                     .to.equal(3);
                 expect(find('.settings-tags .settings-tag:last .tag-title').text(), 'new tag list item title')
                     .to.equal('New Tag');
-                expect(find('a[href="/settings/tags/new-tag"]').hasClass('active'), 'highlights new tag')
+                expect(find('a[href="/ghost/settings/tags/new-tag"]').hasClass('active'), 'highlights new tag')
                     .to.be.true;
             });
 
@@ -244,7 +244,7 @@ describe('Acceptance: Settings - Tags', function () {
                     .to.equal(2);
 
                 // selects tag in list
-                expect(find('a[href="/settings/tags/tag-1"]').hasClass('active'), 'highlights requested tag')
+                expect(find('a[href="/ghost/settings/tags/tag-1"]').hasClass('active'), 'highlights requested tag')
                     .to.be.true;
 
                 // shows requested tag in settings pane

--- a/tests/acceptance/team-test.js
+++ b/tests/acceptance/team-test.js
@@ -98,7 +98,7 @@ describe('Acceptance: Team', function () {
                     expect(document.title, 'title after clicking user').to.equal('Team - User - Test Blog');
 
                     // view title should exist and be linkable and active
-                    expect(find('.view-title a[href="/team"]').hasClass('active'), 'has linkable url back to team main page')
+                    expect(find('.view-title a[href="/ghost/team"]').hasClass('active'), 'has linkable url back to team main page')
                         .to.be.true;
                 });
 


### PR DESCRIPTION
no issue
- bugfix & cleanup release https://github.com/emberjs/ember.js/releases/tag/v2.6.0
- fix tests that were relying on not having the `rootURL` prefixed in `href`s