### PR TITLE
Labs Subscribers option clearer & with docs link

### DIFF
--- a/app/templates/settings/labs.hbs
+++ b/app/templates/settings/labs.hbs
@@ -51,7 +51,7 @@
                         Public API - For full instructions, read the <a href="http://support.ghost.org/public-api-beta/">developer guide</a>.
                     {{/gh-feature-flag}}
                     {{#gh-feature-flag "subscribers"}}
-                        Subscribers - Allow visitors to subscribe to e-mail updates of your new posts
+                        Subscribers - Collect email addresses from your readers, more info in <a href="http://support.ghost.org/subscribers-beta/">the docs</a>
                     {{/gh-feature-flag}}
                 </div>
             </fieldset>


### PR DESCRIPTION
My first PR to Ghost-Admin 🎉 

Just updated the label next to the Subscribers checkbox in labs:

![](http://puu.sh/pnsM6.png)

no issue

- changes wording to not indicate that we already send emails
- adds link to documentation