### PR TITLE
Add UTC timezone as default in settings model

### DIFF
--- a/app/mirage/fixtures/settings.js
+++ b/app/mirage/fixtures/settings.js
@@ -210,7 +210,7 @@ export default [
         updated_at: '2015-09-23T13:32:49.868Z',
         updated_by: 1,
         uuid: '310c9169-9613-48b0-8bc4-d1e1c9be85b8',
-        value: 'Europe/Dublin'
+        value: 'Etc/UTC'
     },
     {
         key: 'availableThemes',

--- a/app/mirage/fixtures/timezones.js
+++ b/app/mirage/fixtures/timezones.js
@@ -1,327 +1,266 @@
 export default [
     {
         name: 'Pacific/Pago_Pago',
-        label: '(GMT -11:00) Midway Island, Samoa',
-        offset: -660
+        label: '(GMT -11:00) Midway Island, Samoa'
     },
     {
         name: 'Pacific/Honolulu',
-        label: '(GMT -10:00) Hawaii',
-        offset: -600
+        label: '(GMT -10:00) Hawaii'
     },
     {
         name: 'America/Anchorage',
-        label: '(GMT -9:00) Alaska',
-        offset: -540
+        label: '(GMT -9:00) Alaska'
     },
     {
         name: 'America/Tijuana',
-        label: '(GMT -8:00) Chihuahua, La Paz, Mazatlan',
-        offset: -480
+        label: '(GMT -8:00) Chihuahua, La Paz, Mazatlan'
     },
     {
         name: 'America/Los_Angeles',
-        label: '(GMT -8:00) Pacific Time (US & Canada); Tijuana',
-        offset: -480
+        label: '(GMT -8:00) Pacific Time (US & Canada); Tijuana'
     },
     {
         name: 'America/Phoenix',
-        label: '(GMT -7:00) Arizona',
-        offset: -420
+        label: '(GMT -7:00) Arizona'
     },
     {
         name: 'America/Denver',
-        label: '(GMT -7:00) Mountain Time (US & Canada)',
-        offset: -420
+        label: '(GMT -7:00) Mountain Time (US & Canada)'
     },
     {
         name: 'America/Costa_Rica',
-        label: '(GMT -6:00) Central America',
-        offset: -360
+        label: '(GMT -6:00) Central America'
     },
     {
         name: 'America/Chicago',
-        label: '(GMT -6:00) Central Time (US & Canada)',
-        offset: -360
+        label: '(GMT -6:00) Central Time (US & Canada)'
     },
     {
         name: 'America/Mexico_City',
-        label: '(GMT -6:00) Guadalajara, Mexico City, Monterrey',
-        offset: -360
+        label: '(GMT -6:00) Guadalajara, Mexico City, Monterrey'
     },
     {
         name: 'America/Regina',
-        label: '(GMT -6:00) Saskatchewan',
-        offset: -360
+        label: '(GMT -6:00) Saskatchewan'
     },
     {
         name: 'America/Bogota',
-        label: '(GMT -5:00) Bogota, Lima, Quito',
-        offset: -300
+        label: '(GMT -5:00) Bogota, Lima, Quito'
     },
     {
         name: 'America/New_York',
-        label: '(GMT -5:00) Eastern Time (US & Canada)',
-        offset: -300
+        label: '(GMT -5:00) Eastern Time (US & Canada)'
     },
     {
         name: 'America/Fort_Wayne',
-        label: '(GMT -5:00) Indiana (East)',
-        offset: -300
+        label: '(GMT -5:00) Indiana (East)'
     },
     {
         name: 'America/Caracas',
-        label: '(GMT -4:30) Caracas, La Paz',
-        offset: -270
+        label: '(GMT -4:00) Caracas, La Paz'
     },
     {
         name: 'America/Halifax',
-        label: '(GMT -4:00) Atlantic Time (Canada); Brasilia, Greenland',
-        offset: -240
-    },
-    {
-        name: 'America/St_Johns',
-        label: '(GMT -3:30) Newfoundland',
-        offset: -210
-    },
-    {
-        name: 'America/Argentina/Buenos_Aires',
-        label: '(GMT -3:00) Buenos Aires, Georgetown',
-        offset: -180
+        label: '(GMT -4:00) Atlantic Time (Canada); Brasilia, Greenland'
     },
     {
         name: 'America/Santiago',
-        label: '(GMT -3:00) Santiago',
-        offset: -180
+        label: '(GMT -4:00) Santiago'
+    },
+    {
+        name: 'America/St_Johns',
+        label: '(GMT -3:30) Newfoundland'
+    },
+    {
+        name: 'America/Argentina/Buenos_Aires',
+        label: '(GMT -3:00) Buenos Aires, Georgetown'
     },
     {
         name: 'America/Noronha',
-        label: '(GMT -2:00) Fernando de Noronha',
-        offset: -120
+        label: '(GMT -2:00) Fernando de Noronha'
     },
     {
         name: 'Atlantic/Azores',
-        label: '(GMT -1:00) Azores',
-        offset: -60
+        label: '(GMT -1:00) Azores'
     },
     {
         name: 'Atlantic/Cape_Verde',
-        label: '(GMT -1:00) Cape Verde Is.',
-        offset: -60
+        label: '(GMT -1:00) Cape Verde Is.'
+    },
+    {
+        name: 'Etc/UTC',
+        label: '(GMT) UTC'
     },
     {
         name: 'Africa/Casablanca',
-        label: '(GMT) Casablanca, Monrovia',
-        offset: 0
+        label: '(GMT +0:00) Casablanca, Monrovia'
     },
     {
         name: 'Europe/Dublin',
-        label: '(GMT) Greenwich Mean Time : Dublin, Edinburgh, London',
-        offset: 0
+        label: '(GMT +0:00) Dublin, Edinburgh, London'
     },
     {
         name: 'Europe/Amsterdam',
-        label: '(GMT +1:00) Amsterdam, Berlin, Rome, Stockholm, Vienna',
-        offset: 60
+        label: '(GMT +1:00) Amsterdam, Berlin, Rome, Stockholm, Vienna'
     },
     {
         name: 'Europe/Prague',
-        label: '(GMT +1:00) Belgrade, Bratislava, Budapest, Prague',
-        offset: 60
+        label: '(GMT +1:00) Belgrade, Bratislava, Budapest, Prague'
     },
     {
         name: 'Europe/Paris',
-        label: '(GMT +1:00) Brussels, Copenhagen, Madrid, Paris',
-        offset: 60
+        label: '(GMT +1:00) Brussels, Copenhagen, Madrid, Paris'
     },
     {
         name: 'Europe/Warsaw',
-        label: '(GMT +1:00) Sarajevo, Skopje, Warsaw, Zagreb',
-        offset: 60
+        label: '(GMT +1:00) Sarajevo, Skopje, Warsaw, Zagreb'
     },
     {
         name: 'Africa/Lagos',
-        label: '(GMT +1:00) West Central Africa',
-        offset: 60
+        label: '(GMT +1:00) West Central Africa'
     },
     {
         name: 'Europe/Istanbul',
-        label: '(GMT +2:00) Athens, Beirut, Bucharest, Istanbul',
-        offset: 120
+        label: '(GMT +2:00) Athens, Beirut, Bucharest, Istanbul'
     },
     {
         name: 'Africa/Cairo',
-        label: '(GMT +2:00) Cairo, Egypt',
-        offset: 120
+        label: '(GMT +2:00) Cairo, Egypt'
     },
     {
         name: 'Africa/Maputo',
-        label: '(GMT +2:00) Harare',
-        offset: 120
+        label: '(GMT +2:00) Harare'
     },
     {
         name: 'Europe/Kiev',
-        label: '(GMT +2:00) Helsinki, Kiev, Riga, Sofia, Tallinn, Vilnius',
-        offset: 120
+        label: '(GMT +2:00) Helsinki, Kiev, Riga, Sofia, Tallinn, Vilnius'
     },
     {
         name: 'Asia/Jerusalem',
-        label: '(GMT +2:00) Jerusalem',
-        offset: 120
+        label: '(GMT +2:00) Jerusalem'
     },
     {
         name: 'Africa/Johannesburg',
-        label: '(GMT +2:00) Pretoria',
-        offset: 120
+        label: '(GMT +2:00) Pretoria'
     },
     {
         name: 'Asia/Baghdad',
-        label: '(GMT +3:00) Baghdad',
-        offset: 180
+        label: '(GMT +3:00) Baghdad'
     },
     {
         name: 'Asia/Riyadh',
-        label: '(GMT +3:00) Kuwait, Nairobi, Riyadh',
-        offset: 180
-    },
-    {
-        name: 'Asia/Tehran',
-        label: '(GMT +3:30) Tehran',
-        offset: 210
-    },
-    {
-        name: 'Asia/Dubai',
-        label: '(GMT +4:00) Abu Dhabi, Muscat',
-        offset: 240
-    },
-    {
-        name: 'Asia/Baku',
-        label: '(GMT +4:00) Baku, Tbilisi, Yerevan',
-        offset: 240
+        label: '(GMT +3:00) Kuwait, Nairobi, Riyadh'
     },
     {
         name: 'Europe/Moscow',
-        label: '(GMT +4:00) Moscow, St. Petersburg, Volgograd',
-        offset: 240
+        label: '(GMT +3:00) Moscow, St. Petersburg, Volgograd'
+    },
+    {
+        name: 'Asia/Tehran',
+        label: '(GMT +3:30) Tehran'
+    },
+    {
+        name: 'Asia/Dubai',
+        label: '(GMT +4:00) Abu Dhabi, Muscat'
+    },
+    {
+        name: 'Asia/Baku',
+        label: '(GMT +4:00) Baku, Tbilisi, Yerevan'
     },
     {
         name: 'Asia/Kabul',
-        label: '(GMT +4:30) Kabul',
-        offset: 270
+        label: '(GMT +4:30) Kabul'
     },
     {
         name: 'Asia/Karachi',
-        label: '(GMT +5:00) Islamabad, Karachi, Tashkent',
-        offset: 300
-    },
-    {
-        name: 'Asia/Kolkata',
-        label: '(GMT +5:30) Chennai, Calcutta, Mumbai, New Delhi',
-        offset: 330
-    },
-    {
-        name: 'Asia/Kathmandu',
-        label: '(GMT +5:45) Katmandu',
-        offset: 345
-    },
-    {
-        name: 'Asia/Almaty',
-        label: '(GMT +6:00) Almaty, Novosibirsk',
-        offset: 360
-    },
-    {
-        name: 'Asia/Dhaka',
-        label: '(GMT +6:00) Astana, Dhaka, Sri Jayawardenepura',
-        offset: 360
+        label: '(GMT +5:00) Islamabad, Karachi, Tashkent'
     },
     {
         name: 'Asia/Yekaterinburg',
-        label: '(GMT +6:00) Yekaterinburg',
-        offset: 360
+        label: '(GMT +5:00) Yekaterinburg'
+    },
+    {
+        name: 'Asia/Kolkata',
+        label: '(GMT +5:30) Chennai, Calcutta, Mumbai, New Delhi'
+    },
+    {
+        name: 'Asia/Kathmandu',
+        label: '(GMT +5:45) Katmandu'
+    },
+    {
+        name: 'Asia/Almaty',
+        label: '(GMT +6:00) Almaty, Novosibirsk'
+    },
+    {
+        name: 'Asia/Dhaka',
+        label: '(GMT +6:00) Astana, Dhaka, Sri Jayawardenepura'
     },
     {
         name: 'Asia/Rangoon',
-        label: '(GMT +6:30) Rangoon',
-        offset: 390
+        label: '(GMT +6:30) Rangoon'
     },
     {
         name: 'Asia/Bangkok',
-        label: '(GMT +7:00) Bangkok, Hanoi, Jakarta',
-        offset: 420
-    },
-    {
-        name: 'Asia/Hong_Kong',
-        label: '(GMT +8:00) Beijing, Chongqing, Hong Kong, Urumqi',
-        offset: 480
+        label: '(GMT +7:00) Bangkok, Hanoi, Jakarta'
     },
     {
         name: 'Asia/Krasnoyarsk',
-        label: '(GMT +8:00) Krasnoyarsk',
-        offset: 480
+        label: '(GMT +7:00) Krasnoyarsk'
     },
     {
-        name: 'Asia/Singapore',
-        label: '(GMT +8:00) Kuala Lumpur, Perth, Singapore, Taipei',
-        offset: 480
+        name: 'Asia/Hong_Kong',
+        label: '(GMT +8:00) Beijing, Chongqing, Hong Kong, Urumqi'
     },
     {
         name: 'Asia/Irkutsk',
-        label: '(GMT +9:00) Irkutsk, Ulaan Bataar',
-        offset: 540
+        label: '(GMT +8:00) Irkutsk, Ulaan Bataar'
+    },
+    {
+        name: 'Asia/Singapore',
+        label: '(GMT +8:00) Kuala Lumpur, Perth, Singapore, Taipei'
     },
     {
         name: 'Asia/Tokyo',
-        label: '(GMT +9:00) Osaka, Sapporo, Tokyo',
-        offset: 540
+        label: '(GMT +9:00) Osaka, Sapporo, Tokyo'
     },
     {
         name: 'Asia/Seoul',
-        label: '(GMT +9:00) Seoul',
-        offset: 540
-    },
-    {
-        name: 'Australia/Darwin',
-        label: '(GMT +9:30) Darwin',
-        offset: 570
-    },
-    {
-        name: 'Australia/Brisbane',
-        label: '(GMT +10:00) Brisbane, Guam, Port Moresby',
-        offset: 600
+        label: '(GMT +9:00) Seoul'
     },
     {
         name: 'Asia/Yakutsk',
-        label: '(GMT +10:00) Yakutsk',
-        offset: 600
+        label: '(GMT +9:00) Yakutsk'
     },
     {
         name: 'Australia/Adelaide',
-        label: '(GMT +10:30) Adelaide',
-        offset: 630
+        label: '(GMT +9:30) Adelaide'
+    },
+    {
+        name: 'Australia/Darwin',
+        label: '(GMT +9:30) Darwin'
+    },
+    {
+        name: 'Australia/Brisbane',
+        label: '(GMT +10:00) Brisbane, Guam, Port Moresby'
     },
     {
         name: 'Australia/Sydney',
-        label: '(GMT +11:00) Canberra, Hobart, Melbourne, Sydney, Vladivostok',
-        offset: 660
-    },
-    {
-        name: 'Pacific/Fiji',
-        label: '(GMT +12:00) Fiji, Kamchatka, Marshall Is.',
-        offset: 720
-    },
-    {
-        name: 'Pacific/Kwajalein',
-        label: '(GMT +12:00) International Date Line West',
-        offset: 720
+        label: '(GMT +10:00) Canberra, Hobart, Melbourne, Sydney, Vladivostok'
     },
     {
         name: 'Asia/Magadan',
-        label: '(GMT +12:00) Magadan, Soloman Is., New Caledonia',
-        offset: 720
+        label: '(GMT +11:00) Magadan, Soloman Is., New Caledonia'
     },
     {
         name: 'Pacific/Auckland',
-        label: '(GMT +13:00) Auckland, Wellington',
-        offset: 780
+        label: '(GMT +12:00) Auckland, Wellington'
+    },
+    {
+        name: 'Pacific/Fiji',
+        label: '(GMT +12:00) Fiji, Kamchatka, Marshall Is.'
+    },
+    {
+        name: 'Pacific/Kwajalein',
+        label: '(GMT +12:00) International Date Line West'
     }
 ];

--- a/app/models/setting.js
+++ b/app/models/setting.js
@@ -16,7 +16,7 @@ export default Model.extend(ValidationEngine, {
     permalinks: attr('string'),
     activeTheme: attr('string'),
     availableThemes: attr(),
-    activeTimezone: attr('string', {defaultValue: 'Europe/Dublin'}),
+    activeTimezone: attr('string', {defaultValue: 'Etc/UTC'}),
     ghost_head: attr('string'),
     ghost_foot: attr('string'),
     facebook: attr('facebook-url-user'),

--- a/tests/acceptance/editor-test.js
+++ b/tests/acceptance/editor-test.js
@@ -225,7 +225,7 @@ describe('Acceptance: Editor', function() {
                 expect(currentURL(), 'currentURL for settings')
                     .to.equal('/settings/general');
                 expect(find('#activeTimezone option:selected').text().trim(), 'default timezone')
-                    .to.equal('(GMT) Greenwich Mean Time : Dublin, Edinburgh, London');
+                    .to.equal('(GMT) UTC');
                 // select a new timezone
                 find('#activeTimezone option[value="Pacific/Auckland"]').prop('selected', true);
             });
@@ -236,7 +236,7 @@ describe('Acceptance: Editor', function() {
 
             andThen(() => {
                 expect(find('#activeTimezone option:selected').text().trim(), 'new timezone after saving')
-                    .to.equal('(GMT +13:00) Auckland, Wellington');
+                    .to.equal('(GMT +12:00) Auckland, Wellington');
             });
 
             // and now go back to the editor
@@ -246,7 +246,7 @@ describe('Acceptance: Editor', function() {
                 expect(currentURL(), 'currentURL in editor')
                     .to.equal('/editor/2');
                 expect(find('input[name="post-setting-date"]').val(), 'date with timezone offset')
-                    .to.equal('10 May 16 @ 21:00');
+                    .to.equal('10 May 16 @ 22:00');
             });
         });
     });

--- a/tests/acceptance/settings/general-test.js
+++ b/tests/acceptance/settings/general-test.js
@@ -140,8 +140,8 @@ describe('Acceptance: Settings - General', function () {
             andThen(() => {
                 expect(currentURL(), 'currentURL').to.equal('/settings/general');
 
-                expect(find('#activeTimezone select option').length, 'available timezones').to.equal(65);
-                expect(find('#activeTimezone option:selected').text().trim()).to.equal('(GMT) Greenwich Mean Time : Dublin, Edinburgh, London');
+                expect(find('#activeTimezone select option').length, 'available timezones').to.equal(66);
+                expect(find('#activeTimezone option:selected').text().trim()).to.equal('(GMT) UTC');
                 find('#activeTimezone option[value="Africa/Cairo"]').prop('selected', true);
             });
 


### PR DESCRIPTION
no issue

- Changes the default timezone from 'Europe/Dublin' to 'Etc/UTC' in setting model
- Updates acceptance test for settings general
- adds mirage fixtures values