### PR TITLE
Fix auth header caching in ajax service

### DIFF
--- a/app/services/ajax.js
+++ b/app/services/ajax.js
@@ -53,7 +53,7 @@ export default AjaxService.extend({
         }
 
         return headers;
-    }),
+    }).volatile(),
 
     handleResponse(status, headers, payload) {
         if (this.isRequestEntityTooLargeError(status, headers, payload)) {


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/6884
- mark the `headers` method in the ajax service as "volatile" - it's dependent key was causing the auth headers to be cached on first use which would then cause 401 errors once the token had been refreshed externally

It would also be possible to add `session.authenticated.access_token` as a dependent key but the code-path and usage are minimal so I believe `.volatile()` is preferable as it means that it's not tied directly to the authorizer implementation.