### PR TITLE
Fix and add tests for Ghost Desktop manual update notification

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -96,6 +96,7 @@ export default Route.extend(ApplicationRouteMixin, ShortcutsRoute, {
         signedIn() {
             this.get('notifications').clearAll();
             this.send('loadServerNotifications', true);
+            this.send('checkForOutdatedDesktopApp');
         },
 
         invalidateSession() {
@@ -119,6 +120,26 @@ export default Route.extend(ApplicationRouteMixin, ShortcutsRoute, {
                         });
                     }
                 });
+            }
+        },
+
+        checkForOutdatedDesktopApp() {
+            // Check if the user is running an older version of Ghost Desktop
+            // that needs to be manually updated
+            // (yes, the desktop team is deeply ashamed of these lines 😢)
+            let ua = navigator && navigator.userAgent ? navigator.userAgent : null;
+
+            if (ua && ua.includes && ua.includes('ghost-desktop')) {
+                let updateCheck = /ghost-desktop\/0\.((5\.0)|((4|2)\.0)|((3\.)(0|1)))/;
+                let link = '<a href="https://dev.ghost.org/ghost-desktop-manual-update" target="_blank">click here</a>';
+                let msg = `Your version of Ghost Desktop needs to be manually updated. Please ${link} to get started.`;
+
+                if (updateCheck.test(ua)) {
+                    this.get('notifications').showAlert(msg.htmlSafe(), {
+                        type: 'upgrade',
+                        key: 'desktop.manual.upgrade'
+                    });
+                }
             }
         },
 

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -7,6 +7,7 @@ import windowProxy from 'ghost-admin/utils/window-proxy';
 
 const {
     Route,
+    String: {htmlSafe},
     inject: {service},
     run
 } = Ember;
@@ -34,6 +35,7 @@ export default Route.extend(ApplicationRouteMixin, ShortcutsRoute, {
         if (this.get('session.isAuthenticated')) {
             this.set('appLoadTransition', transition);
             transition.send('loadServerNotifications');
+            transition.send('checkForOutdatedDesktopApp');
 
             // return the feature loading promise so that we block until settings
             // are loaded in order for synchronous access everywhere
@@ -96,7 +98,6 @@ export default Route.extend(ApplicationRouteMixin, ShortcutsRoute, {
         signedIn() {
             this.get('notifications').clearAll();
             this.send('loadServerNotifications', true);
-            this.send('checkForOutdatedDesktopApp');
         },
 
         invalidateSession() {
@@ -135,8 +136,8 @@ export default Route.extend(ApplicationRouteMixin, ShortcutsRoute, {
                 let msg = `Your version of Ghost Desktop needs to be manually updated. Please ${link} to get started.`;
 
                 if (updateCheck.test(ua)) {
-                    this.get('notifications').showAlert(msg.htmlSafe(), {
-                        type: 'upgrade',
+                    this.get('notifications').showAlert(htmlSafe(msg), {
+                        type: 'warn',
                         key: 'desktop.manual.upgrade'
                     });
                 }

--- a/tests/acceptance/ghost-desktop-test.js
+++ b/tests/acceptance/ghost-desktop-test.js
@@ -1,0 +1,80 @@
+/* jshint expr:true */
+import {
+    describe,
+    it,
+    beforeEach,
+    afterEach
+} from 'mocha';
+import { expect } from 'chai';
+import startApp from '../helpers/start-app';
+import destroyApp from '../helpers/destroy-app';
+import { authenticateSession } from 'ghost-admin/tests/helpers/ember-simple-auth';
+
+const originalUserAgent = window.navigator.userAgent;
+
+const _setUserAgent = function (userAgent) {
+    let userAgentProp = {get() { return userAgent; }, configurable: true};
+    Object.defineProperty(window.navigator, 'userAgent', userAgentProp);
+};
+
+const stubUserAgent = function (userAgent) {
+    if (window.navigator.userAgent !== userAgent) {
+        _setUserAgent(userAgent);
+    }
+};
+
+const restoreUserAgent = function () {
+    if (window.navigator.userAgent !== originalUserAgent) {
+        _setUserAgent(originalUserAgent);
+    }
+};
+
+describe('Acceptance: Ghost Desktop', function() {
+    let application;
+
+    beforeEach(function() {
+        application = startApp();
+    });
+
+    afterEach(function() {
+        destroyApp(application);
+    });
+
+    describe('update alerts for broken versions', function () {
+        beforeEach(function() {
+            let role = server.create('role', {name: 'Administrator'});
+            let user = server.create('user', {roles: [role]});
+
+            server.loadFixtures();
+
+            return authenticateSession(application);
+        });
+
+        afterEach(function() {
+            restoreUserAgent();
+        });
+
+        it('displays alert for broken version', function() {
+            stubUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) ghost-desktop/0.4.0 Chrome/51.0.2704.84 Electron/1.2.2 Safari/537.36');
+
+            visit('/');
+
+            andThen(function () {
+                // has an alert with matching text
+                expect(find('.gh-alert-yellow').length, 'number of warning alerts').to.equal(1);
+                expect(find('.gh-alert-yellow').text().trim(), 'alert text').to.match(/Your version of Ghost Desktop needs to be manually updated/);
+            });
+        });
+
+        it('doesn\'t display alert for working version', function () {
+            stubUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) ghost-desktop/0.5.1 Chrome/51.0.2704.84 Electron/1.2.2 Safari/537.36');
+
+            visit('/');
+
+            andThen(function () {
+                // no alerts
+                expect(find('.gh-alert').length, 'number of alerts').to.equal(0);
+            });
+        });
+    });
+});


### PR DESCRIPTION
closes #51
- move the check into the `afterModel` hook so that it's always performed on app load (previously it would only be displayed after going through the sign-in process)
- change the alert type to `warn` so that it matches our existing types (success, warn, error)
- don't rely on the `.htmlSafe()` prototype extension
- add basic tests for the upgrade alert display