### PR TITLE
internal-tags style followup

### DIFF
--- a/app/styles/layouts/content.css
+++ b/app/styles/layouts/content.css
@@ -64,6 +64,11 @@
     line-height: 18px;
 }
 
+.content-list .entry-meta .internal-tags-list {
+    margin-top: 5px;
+    line-height: 22px;
+}
+
 .content-list .avatar {
     position: relative;
     float: left;

--- a/app/templates/posts.hbs
+++ b/app/templates/posts.hbs
@@ -33,9 +33,11 @@
                                     {{/if}}
                                 </span>
                                 {{#if feature.internalTags}}
-                                    {{#each post.internalTags as |tag|}}
-                                        <span class="label label-default">{{tag.name}}</span>
-                                    {{/each}}
+                                    <div class="internal-tags-list">
+                                        {{#each post.internalTags as |tag|}}
+                                            <span class="label label-default">{{tag.name}}</span>
+                                        {{/each}}
+                                    </div>
                                 {{/if}}
                             </section>
                         {{/link-to}}

--- a/app/templates/settings/labs.hbs
+++ b/app/templates/settings/labs.hbs
@@ -54,7 +54,7 @@
                         Subscribers - Collect email addresses from your readers, more info in <a href="http://support.ghost.org/subscribers-beta/">the docs</a>
                     {{/gh-feature-flag}}
                     {{#gh-feature-flag "internalTags"}}
-                        Internal Tags - tags which don't show up in your theme. more info in <a href="http://support.ghost.org/internal-tags-beta/">the docs</a>.
+                        Internal Tags - tags which don't show up in your theme, more info in <a href="http://support.ghost.org/internal-tags-beta/">the docs</a>.
                     {{/gh-feature-flag}}
                 </div>
             </fieldset>


### PR DESCRIPTION
no issue
- improves internal-tags display on content page
- fix typo in settings/labs


Here is the screenshot of the new look:

<img width="458" alt="screen shot 2016-06-13 at 9 40 07 am" src="https://cloud.githubusercontent.com/assets/5167581/16013516/f49a2a6a-314a-11e6-9554-8ae1e3a54a93.png">