### PR TITLE
Add greenkeeper branch ignores to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ matrix:
   include:
     - node_js: "0.10"
       env: TEST_SUITE=lint
+      
+branches:
+  exclude:
+    - /^greenkeeper-.+$/
 
 cache:
   directories:


### PR DESCRIPTION
This prevents greenkeeper branches from being built as they will always by run in the PR.