### PR TITLE
Use node 0.12 for lint testing (temporary)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ node_js:
 
 matrix:
   include:
-    - node_js: "0.10"
+    - node_js: "0.12"
       env: TEST_SUITE=lint
 
 cache:


### PR DESCRIPTION
To be used until https://github.com/jscs-dev/node-jscs/issues/2279 is resolved