### PR TITLE
recognise => recognize and add a period at the end

### DIFF
--- a/app/templates/team/user.hbs
+++ b/app/templates/team/user.hbs
@@ -83,7 +83,7 @@
                     {{#if user.errors.name}}
                         {{gh-error-message errors=user.errors property="name"}}
                     {{else}}
-                        <p>Use your real name so people can recognise you</p>
+                        <p>Use your real name so people can recognize you.</p>
                     {{/if}}
                 {{/gh-form-group}}
 


### PR DESCRIPTION
While going through the admin, I noticed that there was a spelling mistake. Also, a sentence started with a capital, but didn't end with a period. :p

https://www.google.ca/webhp#q=define:recognize