### PR TITLE
update bower deps and start switch from bower to npm

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,6 @@
     "Faker": "3.1.0",
     "fastclick": "1.0.6",
     "google-caja": "6005.0.0",
-    "jquery-deparam": "0.5.1",
     "jquery-file-upload": "9.12.3",
     "jquery-ui": "1.11.4",
     "jqueryui-touch-punch": "furf/jquery-ui-touch-punch#4bc009145202d9c7483ba85f3a236a8f3470354d",

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "ghost",
   "dependencies": {
-    "blueimp-md5": "2.3.0",
     "devicejs": "0.2.7",
     "ember": "2.6.1",
     "ember-cli-shims": "0.1.3",
@@ -16,10 +15,7 @@
     "jquery.simulate.drag-sortable": "0.1.0",
     "keymaster": "1.6.3",
     "lodash": "3.7.0",
-    "moment": "2.13.0",
-    "moment-timezone": "0.5.4",
     "normalize.css": "3.0.3",
-    "password-generator": "2.0.2",
     "pretender": "1.1.0",
     "rangyinputs": "1.2.0",
     "selectize": "~0.12.1",

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "codemirror": "5.15.2",
     "devicejs": "0.2.7",
     "ember": "2.6.1",
-    "ember-cli-shims": "0.1.1",
+    "ember-cli-shims": "0.1.3",
     "ember-cli-test-loader": "0.2.2",
     "ember-mocha": "0.8.11",
     "Faker": "3.1.0",

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "blueimp-md5": "2.3.0",
     "codemirror": "5.15.2",
     "devicejs": "0.2.7",
-    "ember": "2.6.0",
+    "ember": "2.6.1",
     "ember-cli-shims": "0.1.1",
     "ember-cli-test-loader": "0.2.2",
     "ember-mocha": "0.8.11",

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,6 @@
   "name": "ghost",
   "dependencies": {
     "blueimp-md5": "2.3.0",
-    "codemirror": "5.15.2",
     "devicejs": "0.2.7",
     "ember": "2.6.1",
     "ember-cli-shims": "0.1.3",

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -41,6 +41,19 @@ module.exports = function (defaults) {
         },
         hinting: false,
         fingerprint: disabled,
+        nodeAssets: {
+            codemirror: {
+                import: [
+                    'lib/codemirror.js',
+                    'lib/codemirror.css',
+                    'theme/xq-light.css',
+                    'mode/htmlmixed/htmlmixed.js',
+                    'mode/xml/xml.js',
+                    'mode/css/css.js',
+                    'mode/javascript/javascript.js',
+                ]
+            }
+        },
         'ember-cli-selectize': {
             theme: false
         }
@@ -65,11 +78,6 @@ module.exports = function (defaults) {
     app.import('bower_components/jquery-file-upload/js/jquery.fileupload-image.js');
     app.import('bower_components/google-caja/html-css-sanitizer-bundle.js');
     app.import('bower_components/jqueryui-touch-punch/jquery.ui.touch-punch.js');
-    app.import('bower_components/codemirror/lib/codemirror.js');
-    app.import('bower_components/codemirror/mode/htmlmixed/htmlmixed.js');
-    app.import('bower_components/codemirror/mode/xml/xml.js');
-    app.import('bower_components/codemirror/mode/css/css.js');
-    app.import('bower_components/codemirror/mode/javascript/javascript.js');
     app.import('bower_components/password-generator/lib/password-generator.js');
     app.import('bower_components/blueimp-md5/js/md5.js');
 
@@ -77,10 +85,6 @@ module.exports = function (defaults) {
         app.import(app.bowerDirectory + '/jquery.simulate.drag-sortable/jquery.simulate.drag-sortable.js', {type: 'test'});
         app.import(app.bowerDirectory + '/jquery-deparam/jquery-deparam.js', {type: 'test'});
     }
-
-    // 'dem Styles
-    app.import('bower_components/codemirror/lib/codemirror.css');
-    app.import('bower_components/codemirror/theme/xq-light.css');
 
     return app.toTree();
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -42,6 +42,9 @@ module.exports = function (defaults) {
         hinting: false,
         fingerprint: disabled,
         nodeAssets: {
+            'blueimp-md5': {
+                import: ['js/md5.js']
+            },
             codemirror: {
                 import: [
                     'lib/codemirror.js',
@@ -56,6 +59,15 @@ module.exports = function (defaults) {
             'jquery-deparam': {
                 enabled: EmberApp.env() === 'test',
                 import: ['jquery-deparam.js']
+            },
+            moment: {
+                import: ['moment.js']
+            },
+            'moment-timezone': {
+                import: ['builds/moment-timezone-with-data.js']
+            },
+            'password-generator': {
+                import: ['lib/password-generator.js']
             }
         },
         'ember-cli-selectize': {
@@ -71,8 +83,6 @@ module.exports = function (defaults) {
     app.import('bower_components/showdown-ghost/src/extensions/ghostimagepreview.js');
     app.import('bower_components/showdown-ghost/src/extensions/footnotes.js');
     app.import('bower_components/showdown-ghost/src/extensions/highlight.js');
-    app.import('bower_components/moment/moment.js');
-    app.import('bower_components/moment-timezone/builds/moment-timezone-with-data.js');
     app.import('bower_components/keymaster/keymaster.js');
     app.import('bower_components/devicejs/lib/device.js');
     app.import('bower_components/jquery-ui/jquery-ui.js');
@@ -82,8 +92,6 @@ module.exports = function (defaults) {
     app.import('bower_components/jquery-file-upload/js/jquery.fileupload-image.js');
     app.import('bower_components/google-caja/html-css-sanitizer-bundle.js');
     app.import('bower_components/jqueryui-touch-punch/jquery.ui.touch-punch.js');
-    app.import('bower_components/password-generator/lib/password-generator.js');
-    app.import('bower_components/blueimp-md5/js/md5.js');
 
     if (app.env === 'test') {
         app.import(app.bowerDirectory + '/jquery.simulate.drag-sortable/jquery.simulate.drag-sortable.js', {type: 'test'});

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -52,6 +52,10 @@ module.exports = function (defaults) {
                     'mode/css/css.js',
                     'mode/javascript/javascript.js',
                 ]
+            },
+            'jquery-deparam': {
+                enabled: EmberApp.env() === 'test',
+                import: ['jquery-deparam.js']
             }
         },
         'ember-cli-selectize': {
@@ -83,7 +87,6 @@ module.exports = function (defaults) {
 
     if (app.env === 'test') {
         app.import(app.bowerDirectory + '/jquery.simulate.drag-sortable/jquery.simulate.drag-sortable.js', {type: 'test'});
-        app.import(app.bowerDirectory + '/jquery-deparam/jquery-deparam.js', {type: 'test'});
     }
 
     return app.toTree();

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "ember-cli-jshint": "1.0.4",
     "ember-cli-mirage": "0.1.13",
     "ember-cli-mocha": "0.10.4",
+    "ember-cli-node-assets": "0.1.3",
     "ember-cli-pretender": "0.6.0",
     "ember-cli-release": "0.2.8",
     "ember-cli-selectize": "0.5.5",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "grunt-contrib-jshint": "1.0.0",
     "grunt-jscs": "3.0.1",
     "grunt-shell": "1.3.0",
+    "jquery-deparam": "0.5.2",
     "liquid-fire": "0.23.1",
     "liquid-tether": "1.1.1",
     "loader.js": "4.0.10",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "bluebird": "3.4.1",
+    "blueimp-md5": "2.3.0",
     "bower": "1.7.9",
     "broccoli-asset-rev": "2.4.3",
     "chalk": "1.1.3",
@@ -80,6 +81,8 @@
     "lodash": "4.13.1",
     "matchdep": "1.0.1",
     "moment": "2.13.0",
+    "moment-timezone": "0.5.4",
+    "password-generator": "2.0.2",
     "top-gh-contribs": "2.0.4",
     "walk-sync": "^0.2.6"
   },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "bower": "1.7.9",
     "broccoli-asset-rev": "2.4.3",
     "chalk": "1.1.3",
+    "codemirror": "5.16.0",
     "csscomb": "3.1.8",
     "ember-ajax": "2.4.1",
     "ember-cli": "2.6.2",


### PR DESCRIPTION
no issue
- `ember-cli-node-assets@0.1.3`
  - allows npm module assets to be loaded in a similar way to bower assets
  - switching to npm deps means we get automated greenkeeper updates
- `codemirror@5.16.0` && bower->npm
- `ember@2.6.1`
- `jquery-deparam@0.5.2` && bower->npm
- `moment` bower->npm
- `moment-timezone` bower->npm
- `password-generator` bower->npm
- `blueimp-md5` bower->npm

This still leaves some bower dependencies, reasons for this include:
- the dependency only provides a bower component
- the dependency is pulled in through bower via another dependency (notably the `ember*`, `pretender`, `lodash`, and `Faker` deps)
- the dependency will be removed soon (`jquery-ui`, `jquery-file-upload`)
- the switch didn't work
  - `validator.js` see #34
  - `device.js` uses incompatible module code in it's npm build
  - `keymster.js` fails due to missing `.toUpperCase()`