### PR TITLE
Only build parts of jquery-ui that we need

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -85,7 +85,15 @@ module.exports = function (defaults) {
     app.import('bower_components/showdown-ghost/src/extensions/highlight.js');
     app.import('bower_components/keymaster/keymaster.js');
     app.import('bower_components/devicejs/lib/device.js');
-    app.import('bower_components/jquery-ui/jquery-ui.js');
+
+    // jquery-ui partial build
+    app.import('bower_components/jquery-ui/ui/core.js');
+    app.import('bower_components/jquery-ui/ui/widget.js');
+    app.import('bower_components/jquery-ui/ui/mouse.js');
+    app.import('bower_components/jquery-ui/ui/draggable.js');
+    app.import('bower_components/jquery-ui/ui/droppable.js');
+    app.import('bower_components/jquery-ui/ui/sortable.js');
+
     app.import('bower_components/jquery-file-upload/js/jquery.fileupload.js');
     app.import('bower_components/blueimp-load-image/js/load-image.all.min.js');
     app.import('bower_components/jquery-file-upload/js/jquery.fileupload-process.js');


### PR DESCRIPTION
refs TryGhost/Ghost#6149
- switches from a full import of jquery-ui to a partial build.

Filesize diff

| version | ghost.js | ghost.min.js | vendor.js | vendor.min.js |
|--------|-------:|-------:|--------:|--------:|
| master | 1,651,512 (1.6 M) | 855,384 (835 K) | 7,634,320 (7.2 M) | 1,950,683 (1.9 M) |
| with this PR | 1,651,512 (1.6 M)  | 855,384 (835 K) | 7,282,583 (6.9 M) | 1,773,896 (1.7M)
