### PR TITLE
Added upgrade notification component to About page.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ logs
 results
 
 npm-debug.log
+.nvmrc
 .bowerrc
 .idea/*
 *.iml

--- a/app/components/gh-upgrade-notification.js
+++ b/app/components/gh-upgrade-notification.js
@@ -1,0 +1,13 @@
+import Component from 'ember-component';
+import {alias} from 'ember-computed';
+import injectService from 'ember-service/inject';
+
+export default Component.extend({
+    tagName: 'section',
+
+    classNames: ['gh-upgrade-notification'],
+
+    upgradeNotification: injectService('upgrade-notification'),
+
+    message: alias('upgradeNotification.content')
+});

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -26,6 +26,7 @@ export default Route.extend(ApplicationRouteMixin, ShortcutsRoute, {
     feature: injectService(),
     dropdown: injectService(),
     notifications: injectService(),
+    upgradeNotification: injectService(),
 
     afterModel(model, transition) {
         this._super(...arguments);
@@ -114,7 +115,11 @@ export default Route.extend(ApplicationRouteMixin, ShortcutsRoute, {
                     if (!user.get('isAuthor') && !user.get('isEditor')) {
                         this.store.findAll('notification', {reload: true}).then((serverNotifications) => {
                             serverNotifications.forEach((notification) => {
-                                this.get('notifications').handleNotification(notification, isDelayed);
+                                if (notification.get('type') === 'upgrade') {
+                                    this.get('upgradeNotification').set('content', notification.get('message'));
+                                } else {
+                                    this.get('notifications').handleNotification(notification, isDelayed);
+                                }
                             });
                         });
                     }

--- a/app/services/upgrade-notification.js
+++ b/app/services/upgrade-notification.js
@@ -1,0 +1,5 @@
+import Service from 'ember-service';
+
+export default Service.extend({
+    content: ''
+});

--- a/app/styles/layouts/about.css
+++ b/app/styles/layouts/about.css
@@ -114,6 +114,18 @@
     opacity: 1;
 }
 
+/* Upgrade
+/* ---------------------------------------------------------- */
+.gh-upgrade-notification {
+    color: var(--red);
+    font-size: 20px;
+}
+
+.gh-upgrade-notification a {
+    color: var(--red);
+    text-decoration: underline;
+}
+
 /* Copyright Info
 /* ---------------------------------------------------------- */
 

--- a/app/templates/about.hbs
+++ b/app/templates/about.hbs
@@ -5,9 +5,9 @@
     <section class="view-content">
         <header class="gh-about-header">
             <img class="gh-logo" src="{{gh-path 'admin' '/img/ghost-logo.png'}}" alt="Ghost" />
-            {{!-- TODO: fix about notifications --}}
-            {{gh-notifications location="about-upgrade" notify="updateNotificationChange"}}
         </header>
+
+        {{gh-upgrade-notification}}
 
         <section class="gh-env-details">
             <ul class="gh-env-list">

--- a/app/templates/components/gh-upgrade-notification.hbs
+++ b/app/templates/components/gh-upgrade-notification.hbs
@@ -1,0 +1,3 @@
+{{#if message}}
+    <span>{{gh-format-html message}}</span>
+{{/if}}

--- a/tests/unit/components/gh-upgrade-notification-test.js
+++ b/tests/unit/components/gh-upgrade-notification-test.js
@@ -1,0 +1,36 @@
+/* jshint expr:true */
+import {expect} from 'chai';
+import {
+    describeComponent,
+    it
+    }
+from 'ember-mocha';
+
+describeComponent(
+    'gh-upgrade-notification',
+    'GhUpgradeNotificationComponent',
+    {
+        needs: ['helper:gh-format-html']
+    },
+    function() {
+        beforeEach(function() {
+            let upgradeMessage = {'content': 'Ghost 10.02.91 is available! Hot Damn. <a href="http://support.ghost.org/how-to-upgrade/" target="_blank">Click here</a> to upgrade.'};
+            this.subject().set('upgradeNotification', upgradeMessage);
+        });
+
+        it('renders', function() {
+            // creates the component instance
+            let component = this.subject();
+            expect(component._state).to.equal('preRender');
+
+            // renders the component on the page
+            this.render();
+            expect(component._state).to.equal('inDOM');
+
+            expect(this.$().prop('tagName')).to.equal('SECTION');
+            expect(this.$().hasClass('gh-upgrade-notification')).to.be.true;
+            // caja tools sanitize target='_blank' attribute
+            expect(this.$().html()).to.contain('Hot Damn. <a href="http://support.ghost.org/how-to-upgrade/">Click here</a>');
+        });
+    }
+);


### PR DESCRIPTION
Closes "Move the "update available" notification to the about page." part of #5071

Currently when a new upgrade is available, a banner displayed on top of the header, on all pages, which doesn't go away until the blog is upgraded. This message was moved to About page. The message won't go away till the blog is upgraded but it's far less annoying.

- New release notifications are shown only in About page instead of as a banner on the top
- Added `gh-upgrade-notification` component and `upgrade-notification` service 
- `app/routes/application.js` looks for notifications of type "upgrade" and invokes `upgrade-notification` service to render the message in `about.hbs`. 
- Added `gh-upgrade-notification` CSS classes to render message in red.
- Picked some fixes https://github.com/TryGhost/Ghost/pull/5670/files