### PR TITLE
Revert to ember-wormhole@0.3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "ember-sortable": "1.8.1",
     "ember-suave": "3.0.1",
     "ember-watson": "0.8.2",
-    "ember-wormhole": "0.4.0",
+    "ember-wormhole": "0.3.6",
     "emberx-file-input": "1.0.0",
     "fs-extra": "0.30.0",
     "glob": "^7.0.5",

--- a/tests/integration/components/gh-search-input-test.js
+++ b/tests/integration/components/gh-search-input-test.js
@@ -6,6 +6,7 @@ import {
 } from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
 import run from 'ember-runloop';
+import wait from 'ember-test-helpers/wait';
 
 describeComponent(
     'gh-search-input',
@@ -19,6 +20,20 @@ describeComponent(
             this.render(hbs`{{gh-search-input}}`);
 
             expect(this.$('.ember-power-select-search input')).to.have.length(1);
+        });
+
+        it('opens the dropdown on text entry', function (done) {
+            this.render(hbs`{{gh-search-input}}`);
+
+            // enter text to trigger search
+            run(() => {
+                this.$('input[type="search"]').val('test').trigger('input');
+            });
+
+            wait().then(() => {
+                expect(this.$('.ember-basic-dropdown-content').length).to.equal(1);
+                done();
+            });
         });
     }
 );


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/7073
- reverts `ember-wormhole` to 0.3.6
- adds working test that was broken under `ember-wormhole` 0.4.0