### PR TITLE
Add `grunt clean` task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,6 +19,25 @@ module.exports = function(grunt) {
     require('matchdep').filterDev(['grunt-*', '!grunt-cli']).forEach(grunt.loadNpmTasks);
 
     grunt.initConfig({
+        clean: {
+            built: {
+                src: [
+                    'dist/**',
+                    'public/assets/img/contributors/**',
+                    'app/templates/-contributors.hbs'
+                ]
+            },
+            dependencies: {
+                src: [
+                    'bower_components/**',
+                    'node_modules/**'
+                ]
+            },
+            tmp: {
+                src: ['tmp/**']
+            }
+        },
+
         jshint: {
             options: {
                 jshintrc: true,

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "fs-extra": "0.30.0",
     "glob": "^7.0.5",
     "grunt": "1.0.1",
+    "grunt-contrib-clean": "1.0.0",
     "grunt-contrib-jshint": "1.0.0",
     "grunt-jscs": "3.0.1",
     "grunt-shell": "1.3.0",


### PR DESCRIPTION
refs #6977
- adds `grunt-contrib-clean` dependency
- adds `grunt clean` task that cleans the same client folders (plus `tmp`) as core's `grunt clean` ready to be used via subgrunt