### PR TITLE
Recommend Node v4 & use as default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 
 language: node_js
 node_js:
-  - "0.10"
+  - "4"
 
 env:
   global:
@@ -11,7 +11,7 @@ env:
 
 matrix:
   include:
-    - node_js: "0.10"
+    - node_js: "4"
       env: TEST_SUITE=lint
 
 branches:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "ember test"
   },
   "engines": {
-    "node": ">= 0.10.0"
+    "node": "~0.10.0 || ~0.12.0 || ^4.2.0"
   },
   "devDependencies": {
     "bluebird": "3.4.1",


### PR DESCRIPTION
Now that we're going to recommend v4, this means making it the default test environment.

Whilst I was looking around, I also updated the package.json file so the `engines` match Ghost's exactly. Not sure if there was a reason why they were different?

refs TryGhost/Ghost#7098

- Use Node v4 as our default build environment
- Change engines in package.json to match Ghost core