### PR TITLE
Fixes curser changing to pointer on hover

### DIFF
--- a/app/styles/components/notifications.css
+++ b/app/styles/components/notifications.css
@@ -118,6 +118,10 @@
     line-height: 1.3em;
 }
 
+.gh-notification-schedule:hover {
+    cursor: default;
+}
+
 /* Alerts
 /* ---------------------------------------------------------- */
 


### PR DESCRIPTION
closes TryGhost/Ghost#7100

Adds `:hover` pseudo-class to `gh-notification-schedule` that sets the curser to default to avoid having it as a pointer on hover.