### PR TITLE
Fix: travis exception for greenkeeper branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
       env: TEST_SUITE=lint
 
 branches:
-  exclude:
+  except:
     - /^greenkeeper-.+$/
 
 cache:


### PR DESCRIPTION
 According to the docs, travis uses `exclude` in the matrix, but `except` in branches 😞

https://docs.travis-ci.com/user/customizing-the-build/#Building-Specific-Branches

- travis terminology is inconsistent :(