### PR TITLE
Fix for handling intermittent internet connectivity

### DIFF
--- a/app/authenticators/oauth2.js
+++ b/app/authenticators/oauth2.js
@@ -1,10 +1,21 @@
 import computed from 'ember-computed';
 import injectService from 'ember-service/inject';
 import Authenticator from 'ember-simple-auth/authenticators/oauth2-password-grant';
+import run from 'ember-runloop';
 
 export default Authenticator.extend({
+    session: injectService(),
     config: injectService(),
     ghostPaths: injectService(),
+
+    init() {
+        this._super(...arguments);
+
+        let handler = run.bind(this, () => {
+            this.onOnline();
+        });
+        window.addEventListener('online', handler);
+    },
 
     serverTokenEndpoint: computed('ghostPaths.apiRoot', function () {
         return `${this.get('ghostPaths.apiRoot')}/authentication/token`;
@@ -20,5 +31,21 @@ export default Authenticator.extend({
         data.client_secret = this.get('config.clientSecret');
         /* jscs:enable requireCamelCaseOrUpperCaseIdentifiers */
         return this._super(url, data);
+    },
+
+    /**
+     * Invoked when "navigator.online" event is trigerred.
+     * This is a helper function to handle intermittent internet connectivity. Token is refreshed
+     * when browser status becomes "online".
+     */
+    onOnline() {
+        if (this.get('session.isAuthenticated')) {
+            let autoRefresh = this.get('refreshAccessTokens');
+            if (autoRefresh) {
+                let expiresIn = this.get('session.data.authenticated.expires_in');
+                let token = this.get('session.data.authenticated.refresh_token');
+                return this._refreshAccessToken(expiresIn, token);
+            }
+        }
     }
 });


### PR DESCRIPTION
closes [#6868](https://github.com/TryGhost/Ghost/issues/6868) 

This improvement targets Ghost Admin users on unreliable internet connections. 

## The Problem
With intermittent internet connectivity, refreshing a token is a hit or miss. The library we use to handle OAuth authentication doesn't provide mechanisms to retry refreshing a token when a request to server fails. Also, currently there are [no provisions to catch/handle errors](https://github.com/simplabs/ember-simple-auth/issues/980) when Authenticator fails to connect to the server. 

## The Fix
The solution implemented in the PR is based on ideas presented [here](https://github.com/simplabs/ember-simple-auth/issues/980) and takes advantage of [navigator.online](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorOnLine/onLine) event. Most [modern browsers support](http://caniuse.com/#feat=online-status) this feature. If we need a better and more comprehensive support, perhaps we could use [Offline](https://github.com/hubspot/offline).

After user logs in, an event handler is registered for `navigator.online` event. The handler is defined in a subclass of `oauth2-password-grant`. After the user logs in, the handler is invoked any time the  browser becomes online. It calls `_refreshAccessTokens()` in the Authenticator to extend token's life time. 

Handler is only invoked if session is still active. If user goes offline and the session expires, user has to login again.
 
Token is refreshed when internet connectivity is established provided the session is still active

- Added navigator.online handler which listens for browser's online status.
- _refreshAccessTokens() is explicitly called when browser becomes online

## Testing
Testing this is a little tricky. Turn off WiFi/Ethernet connection while your session is still active. Refresh token should renew.  