### PR TITLE
Ensure validation errors are shown on post save

### DIFF
--- a/app/mixins/editor-base-controller.js
+++ b/app/mixins/editor-base-controller.js
@@ -7,6 +7,7 @@ import injectController from 'ember-controller/inject';
 import {htmlSafe} from 'ember-string';
 import observer from 'ember-metal/observer';
 import run from 'ember-runloop';
+import {isEmberArray} from 'ember-array/utils';
 
 import PostModel from 'ghost-admin/models/post';
 import boundOneWay from 'ghost-admin/utils/bound-one-way';
@@ -309,6 +310,10 @@ export default Mixin.create({
 
         if (error && isString(error)) {
             errorMessage = error;
+        } else if (error && isEmberArray(error)) {
+            // This is here because validation errors are returned as an array
+            // TODO: remove this once validations are fixed
+            errorMessage = error[0];
         } else if (error && error.errors && error.errors[0].message) {
             errorMessage = error.errors[0].message;
         } else {

--- a/tests/acceptance/editor-test.js
+++ b/tests/acceptance/editor-test.js
@@ -391,6 +391,35 @@ describe('Acceptance: Editor', function() {
             });
         });
 
+        it('handles title validation errors correctly', function () {
+            let post = server.createList('post', 1);
+
+            // post id 1 is a draft, checking for draft behaviour now
+            visit('/editor/1');
+
+            andThen(() => {
+                expect(currentURL(), 'currentURL')
+                    .to.equal('/editor/1');
+            });
+
+            // Test title validation
+            fillIn('input[id="entry-title"]', Array(160).join('a'));
+            triggerEvent('input[id="entry-title"]', 'blur');
+            click('.view-header .btn.btn-sm.js-publish-button');
+
+            andThen(() => {
+                expect(
+                    find('.gh-alert').length,
+                    'number of alerts after invalid title'
+                ).to.equal(1);
+
+                expect(
+                    find('.gh-alert').text(),
+                    'alert text after invalid title'
+                ).to.match(/Title cannot be longer than 150 characters/);
+            });
+        });
+
         it('renders first countdown notification before scheduled time', function () {
             /* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
             let clock = sinon.useFakeTimers(moment().valueOf());


### PR DESCRIPTION
closes TryGhost/Ghost#7120
- fix error handling in editor-base-controller
- adds failing test fixed by this change

Note: this is a bit of a hack, but will be ultimately fixed by the validations refactor in #109 