### PR TITLE
lock walk-sync version

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "moment-timezone": "0.5.5",
     "password-generator": "2.0.2",
     "top-gh-contribs": "2.0.4",
-    "walk-sync": "^0.3.0"
+    "walk-sync": "0.3.0"
   },
   "ember-addon": {
     "paths": [


### PR DESCRIPTION
Greenkeeper added it a `^` to walk-sync for some reason... 🤔