### PR TITLE
Fix subscriber height being too tall for viewport

### DIFF
--- a/app/styles/layouts/subscribers.css
+++ b/app/styles/layouts/subscribers.css
@@ -4,7 +4,6 @@
 .view-subscribers .view-container {
     display: flex;
     flex-direction: row;
-    min-height: 100%;
 }
 
 


### PR DESCRIPTION
Closes TryGhost/Ghost#7163

* With flex-column, setting height to 100% will make the child the same
as the full height of the flex container, not fill up the remaining
space, so it was bleeding down below the viewport