### PR TITLE
Invite user modal fixes

### DIFF
--- a/app/components/modals/invite-new-user.js
+++ b/app/components/modals/invite-new-user.js
@@ -46,6 +46,13 @@ export default ModalComponent.extend(ValidationEngine, {
         this.set('hasValidated', emberA());
     },
 
+    didInsertElement() {
+        let emailInput = this;
+        run.later(() => {
+            emailInput.$('#new-user-email').focus();
+        }, 500);
+    },
+
     validate() {
         let email = this.get('email');
 

--- a/app/templates/components/modals/invite-new-user.hbs
+++ b/app/templates/components/modals/invite-new-user.hbs
@@ -26,7 +26,7 @@
 
         <div class="form-group for-select">
             <label for="new-user-role">Role</label>
-            <span class="gh-select" tabindex="0">
+            <span class="gh-select" tabindex="-1">
                 {{gh-select-native id="new-user-role"
                     content=roles
                     optionValuePath="id"

--- a/tests/integration/components/modals/invite-new-user-test.js
+++ b/tests/integration/components/modals/invite-new-user-test.js
@@ -1,0 +1,37 @@
+/* jshint expr:true */
+import { expect } from 'chai';
+import {
+    describeComponent,
+    it
+} from 'ember-mocha';
+import hbs from 'htmlbars-inline-precompile';
+import startApp from 'ghost-admin/tests/helpers/start-app';
+import run from 'ember-runloop';
+import $ from 'jquery';
+
+describeComponent(
+    'modals/invite-new-user',
+    'Integration: Component: modals/invite-new-user',
+    {
+        integration: true
+    },
+    function() {
+        let application;
+
+        beforeEach(function () {
+            application = startApp();
+        });
+
+        it('renders', function() {
+            this.render(hbs`{{modals/invite-new-user}}`);
+            expect(this.$()).to.have.length(1);
+        });
+
+        it('input has focus', function() {
+            this.render(hbs`{{modals/invite-new-user}}`);
+            run.later(this, function () {
+                expect($(this).is(':focus')).to.be.true;
+            }, 500);
+        });
+    }
+);


### PR DESCRIPTION
Closes TryGhost/Ghost#7132
- Adds tabindex -1 to the select span to allow the tab to go straight
  from input to select
- Adds a focus to the new user input on open
  - Needs the run later otherwise it is triggering too fast and not
    getting the input
