### PR TITLE
Add User Role to Invited Users

### DIFF
--- a/app/styles/layouts/users.css
+++ b/app/styles/layouts/users.css
@@ -116,8 +116,9 @@ a.user-list-item {
     font-size: 12px;
 }
 
-.user-list-item-aside .user-list-action:not(:first-of-type) {
-    margin-left: 20px;
+.user-list-item-aside .user-list-action {
+    float: left;
+    margin-right: 20px;
 }
 
 .user-list-item-aside .role-label {

--- a/app/templates/team/index.hbs
+++ b/app/templates/team/index.hbs
@@ -52,6 +52,9 @@
                                         <a class="user-list-action" href="#" {{action "resend" target=component}}>
                                             Resend
                                         </a>
+                                        {{#each user.roles as |role|}}
+                                            <span class="role-label {{role.lowerCaseName}}">{{role.name}}</span>
+                                        {{/each}}
                                     {{/if}}
                                 </aside>
                             </div>


### PR DESCRIPTION
Closes TryGhost/Ghost#7130

* Adds the user role to the invited users template
* Adjusts some css to keep the role on the right side

<img width="1125" alt="screen shot 2016-08-02 at 4 10 26 pm" src="https://cloud.githubusercontent.com/assets/4715098/17348546/ac9c5a28-58cb-11e6-9c5c-d22ded8f8bc8.png">
