### PR TITLE
Fix url field focus

### DIFF
--- a/app/components/gh-navitem-url-input.js
+++ b/app/components/gh-navitem-url-input.js
@@ -131,12 +131,14 @@ export default TextField.extend(InvokeActionMixin, {
                 url = url.replace(baseUrlParts.pathname.slice(0, -1), '');
             }
 
-            if (!url.match(/^\//)) {
-                url = `/${url}`;
-            }
+            if (url !== '') {
+                if (!url.match(/^\//)) {
+                    url = `/${url}`;
+                }
 
-            if (!url.match(/\/$/) && !url.match(/[\.#\?]/)) {
-                url = `${url}/`;
+                if (!url.match(/\/$/) && !url.match(/[\.#\?]/)) {
+                    url = `${url}/`;
+                }
             }
         }
 


### PR DESCRIPTION
Closes TryGhost/Ghost#7140

* Even if the url was blank, it was always appending a `/` at the end
which would cause isBlank to return false. Added logic that if the url
was blank, don’t try to then add the trailing slash.