### PR TITLE
Remove test-loader asset from test html file

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -51,7 +51,6 @@
     <script src="{{rootURL}}assets/test-support.js"></script>
     <script src="{{rootURL}}assets/ghost.js"></script>
     <script src="{{rootURL}}assets/tests.js"></script>
-    <script src="{{rootURL}}assets/test-loader.js"></script>
 
     {{content-for "body-footer"}}
     {{content-for "test-body-footer"}}


### PR DESCRIPTION
no issue

- with ember-cli 2.7 came the npm version of ember-cli-test-loader, making this line in `tests/index.html` throw 404 errors on tests