### PR TITLE
Post meta error style fixes

### DIFF
--- a/app/controllers/post-settings-menu.js
+++ b/app/controllers/post-settings-menu.js
@@ -376,45 +376,49 @@ export default Controller.extend(SettingsMenuMixin, {
         },
 
         setMetaTitle(metaTitle) {
-            let property = 'metaTitle';
+            // Grab the model and current stored meta title
             let model = this.get('model');
-            let currentTitle = model.get(property) || '';
+            let currentTitle = model.get('metaTitle');
 
-            // Only update if the title has changed
+            // If the title entered matches the stored meta title, do nothing
             if (currentTitle === metaTitle) {
                 return;
             }
 
-            model.set(property, metaTitle);
+            // If the title entered is different, set it as the new meta title
+            model.set('metaTitle', metaTitle);
 
-            // If this is a new post.  Don't save the model.  Defer the save
-            // to the user pressing the save button
-            if (model.get('isNew')) {
-                return;
-            }
+            // Make sure the meta title is valid and if so, save it into the model
+            return model.validate({property: 'metaTitle'}).then(() => {
+                if (model.get('isNew')) {
+                    return;
+                }
 
-            model.save();
+                return model.save();
+            });
         },
 
         setMetaDescription(metaDescription) {
-            let property = 'metaDescription';
+            // Grab the model and current stored meta description
             let model = this.get('model');
-            let currentDescription = model.get(property) || '';
+            let currentDescription = model.get('metaDescription');
 
-            // Only update if the description has changed
+            // If the title entered matches the stored meta title, do nothing
             if (currentDescription === metaDescription) {
                 return;
             }
 
-            model.set(property, metaDescription);
+            // If the title entered is different, set it as the new meta title
+            model.set('metaDescription', metaDescription);
 
-            // If this is a new post.  Don't save the model.  Defer the save
-            // to the user pressing the save button
-            if (model.get('isNew')) {
-                return;
-            }
+            // Make sure the meta title is valid and if so, save it into the model
+            return model.validate({property: 'metaDescription'}).then(() => {
+                if (model.get('isNew')) {
+                    return;
+                }
 
-            model.save();
+                return model.save();
+            });
         },
 
         setCoverImage(image) {

--- a/app/templates/post-settings-menu.hbs
+++ b/app/templates/post-settings-menu.hbs
@@ -119,14 +119,14 @@
 
         <div class="settings-menu-content">
             <form {{action "discardEnter" on="submit"}}>
-            {{#gh-form-group errors=model.errors property="metaTitle"}}
+            {{#gh-form-group errors=model.errors hasValidated=model.hasValidated property="metaTitle"}}
                 <label for="meta-title">Meta Title</label>
                 {{gh-input metaTitleScratch class="post-setting-meta-title" id="meta-title" name="post-setting-meta-title" focusOut=(action "setMetaTitle" metaTitleScratch) stopEnterKeyDownPropagation="true" update=(action (mut metaTitleScratch))}}
                 <p>Recommended: <b>70</b> characters. You’ve used {{gh-count-down-characters metaTitleScratch 70}}</p>
                 {{gh-error-message errors=model.errors property="metaTitle"}}
             {{/gh-form-group}}
 
-            {{#gh-form-group errors=model.errors property="metaDescription"}}
+            {{#gh-form-group errors=model.errors hasValidated=model.hasValidated property="metaDescription"}}
                 <label for="meta-description">Meta Description</label>
                 {{gh-textarea metaDescriptionScratch class="post-setting-meta-description" id="meta-description" name="post-setting-meta-description" focusOut=(action "setMetaDescription" metaDescriptionScratch) stopEnterKeyDownPropagation="true" update=(action (mut metaDescriptionScratch))}}
                 <p>Recommended: <b>156</b> characters. You’ve used {{gh-count-down-characters metaDescriptionScratch 156}}</p>


### PR DESCRIPTION
Closes TryGhost/Ghost#7138

* Fixes red error styling not showing up for meta title and meta
description on posts