### PR TITLE
Remove ember-cli-release dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "ember-cli-mocha": "0.10.4",
     "ember-cli-node-assets": "0.1.4",
     "ember-cli-pretender": "0.6.0",
-    "ember-cli-release": "0.2.8",
     "ember-cli-selectize": "0.5.5",
     "ember-cli-sri": "2.1.0",
     "ember-cli-test-loader": "1.1.0",


### PR DESCRIPTION
We could potentially use this to release new versions of Ghost-Admin; however, I feel like since that process is such a simple one for our use case, and Ghost-Admin doesn't really get released on its own, that this addon is a bit overkill. And given that there's no release config I didn't think it was being used.

This fixes one of the deprecation errors that occur at build-time.