### PR TITLE
💄 move grouped mirage config into separate files

### DIFF
--- a/app/mirage/config.js
+++ b/app/mirage/config.js
@@ -1,138 +1,13 @@
-/* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
-import Ember from 'ember';
-import Mirage from 'ember-cli-mirage';
+import mockAuthentication from './config/authentication';
+import mockPosts from './config/posts';
+import mockRoles from './config/roles';
+import mockSettings from './config/settings';
+import mockSlugs from './config/slugs';
+import mockSubscribers from './config/subscribers';
+import mockTags from './config/tags';
+import mockUsers from './config/users';
 
-const {
-    $,
-    isBlank,
-    String: {dasherize}
-} = Ember;
-
-/* jshint unused:false */
-function maintenanceResponse() {
-    return new Mirage.Response(503, {}, {
-        errors: [{
-            errorType: 'Maintenance'
-        }]
-    });
-}
-
-function versionMismatchResponse() {
-    return new Mirage.Response(400, {}, {
-        errors: [{
-            errorType: 'VersionMismatchError'
-        }]
-    });
-}
-/* jshint unused:true */
-
-function paginatedResponse(modelName, allModels, request) {
-    let page = +request.queryParams.page || 1;
-    let limit = request.queryParams.limit || 15;
-    let pages, models, next, prev;
-
-    allModels = allModels || [];
-
-    if (limit === 'all') {
-        models = allModels;
-        pages = 1;
-    } else {
-        limit = +limit;
-
-        let start = (page - 1) * limit;
-        let end = start + limit;
-
-        models = allModels.slice(start, end);
-        pages = Math.ceil(allModels.length / limit);
-
-        if (start > 0) {
-            prev = page - 1;
-        }
-
-        if (end < allModels.length) {
-            next = page + 1;
-        }
-    }
-
-    return {
-        meta: {
-            pagination: {
-                page,
-                limit,
-                pages,
-                total: allModels.length,
-                next: next || null,
-                prev: prev || null
-            }
-        },
-        [modelName]: models
-    };
-}
-
-function mockSubscribers(server) {
-    server.get('/subscribers/', function (db, request) {
-        let response = paginatedResponse('subscribers', db.subscribers, request);
-        return response;
-    });
-
-    server.post('/subscribers/', function (db, request) {
-        let [attrs] = JSON.parse(request.requestBody).subscribers;
-        let [subscriber] = db.subscribers.where({email: attrs.email});
-
-        if (subscriber) {
-            return new Mirage.Response(422, {}, {
-                errors: [{
-                    errorType: 'ValidationError',
-                    message: 'Email already exists.',
-                    property: 'email'
-                }]
-            });
-        } else {
-            attrs.created_at = new Date();
-            attrs.created_by = 0;
-
-            subscriber = db.subscribers.insert(attrs);
-
-            return {
-                subscriber
-            };
-        }
-    });
-
-    server.put('/subscribers/:id/', function (db, request) {
-        let {id} = request.params;
-        let [attrs] = JSON.parse(request.requestBody).subscribers;
-        let subscriber = db.subscribers.update(id, attrs);
-
-        return {
-            subscriber
-        };
-    });
-
-    server.del('/subscribers/:id/', function (db, request) {
-        db.subscribers.remove(request.params.id);
-
-        return new Mirage.Response(204, {}, {});
-    });
-
-    server.post('/subscribers/csv/', function (/*db, request*/) {
-        // NB: we get a raw FormData object with no way to inspect it in Chrome
-        // until version 50 adds the additional read methods
-        // https://developer.mozilla.org/en-US/docs/Web/API/FormData#Browser_compatibility
-
-        server.createList('subscriber', 50);
-
-        return {
-            meta: {
-                stats: {
-                    imported: 50,
-                    duplicates: 3,
-                    invalid: 2
-                }
-            }
-        };
-    });
-}
+// import {versionMismatchResponse} from 'utils';
 
 export default function () {
     // this.urlPrefix = '';    // make this `http://localhost:8080`, for example, if your API is on a different server
@@ -141,6 +16,7 @@ export default function () {
 
     // Mock endpoints here to override real API requests during development
     // this.put('/posts/:id/', versionMismatchResponse);
+    // mockSubscribers(this);
 
     // keep this line, it allows all other API requests to hit the real server
     this.passthrough();
@@ -157,157 +33,18 @@ export function testConfig() {
     // this.timing = 400;      // delay for each request, automatically set to 0 during testing
     // this.logging = true;
 
-    /* Authentication ------------------------------------------------------- */
-
-    this.post('/authentication/token', function () {
-        return {
-            access_token: '5JhTdKI7PpoZv4ROsFoERc6wCHALKFH5jxozwOOAErmUzWrFNARuH1q01TYTKeZkPW7FmV5MJ2fU00pg9sm4jtH3Z1LjCf8D6nNqLYCfFb2YEKyuvG7zHj4jZqSYVodN2YTCkcHv6k8oJ54QXzNTLIDMlCevkOebm5OjxGiJpafMxncm043q9u1QhdU9eee3zouGRMVVp8zkKVoo5zlGMi3zvS2XDpx7xsfk8hKHpUgd7EDDQxmMueifWv7hv6n',
-            expires_in: 3600,
-            refresh_token: 'XP13eDjwV5mxOcrq1jkIY9idhdvN3R1Br5vxYpYIub2P5Hdc8pdWMOGmwFyoUshiEB62JWHTl8H1kACJR18Z8aMXbnk5orG28br2kmVgtVZKqOSoiiWrQoeKTqrRV0t7ua8uY5HdDUaKpnYKyOdpagsSPn3WEj8op4vHctGL3svOWOjZhq6F2XeVPMR7YsbiwBE8fjT3VhTB3KRlBtWZd1rE0Qo2EtSplWyjGKv1liAEiL0ndQoLeeSOCH4rTP7',
-            token_type: 'Bearer'
-        };
-    });
-
-    this.post('/authentication/passwordreset', function (db, request) {
-        // jscs:disable requireObjectDestructuring
-        let {passwordreset} = $.deparam(request.requestBody);
-        let email = passwordreset[0].email;
-        // jscs:enable requireObjectDestructuring
-
-        if (email === 'unknown@example.com') {
-            return new Mirage.Response(404, {}, {
-                errors: [
-                    {
-                        message: 'There is no user with that email address.',
-                        errorType: 'NotFoundError'
-                    }
-                ]
-            });
-        } else {
-            return {
-                passwordreset: [
-                    {message: 'Check your email for further instructions.'}
-                ]
-            };
-        }
-    });
-
-    /* Download Count ------------------------------------------------------- */
-
-    let downloadCount = 0;
-    this.get('https://count.ghost.org/', function () {
-        downloadCount++;
-        return {
-            count: downloadCount
-        };
-    });
+    mockAuthentication(this);
+    mockPosts(this);
+    mockRoles(this);
+    mockSettings(this);
+    mockSlugs(this);
+    mockSubscribers(this);
+    mockTags(this);
+    mockUsers(this);
 
     /* Notifications -------------------------------------------------------- */
 
     this.get('/notifications/', 'notifications');
-
-    /* Posts ---------------------------------------------------------------- */
-
-    this.post('/posts/', function (db, request) {
-        let [attrs] = JSON.parse(request.requestBody).posts;
-        let post;
-
-        if (isBlank(attrs.slug) && !isBlank(attrs.title)) {
-            attrs.slug = attrs.title.dasherize();
-        }
-
-        // NOTE: this does not use the post factory to fill in blank fields
-        post = db.posts.insert(attrs);
-
-        return {
-            posts: [post]
-        };
-    });
-
-    this.get('/posts/', function (db, request) {
-        // TODO: handle status/staticPages/author params
-        let response = paginatedResponse('posts', db.posts, request);
-        return response;
-    });
-
-    this.get('/posts/:id/', function (db, request) {
-        let {id} = request.params;
-        let post = db.posts.find(id);
-
-        if (!post) {
-            return new Mirage.Response(404, {}, {
-                errors: [{
-                    errorType: 'NotFoundError',
-                    message: 'Post not found.'
-                }]
-            });
-        } else {
-            return {posts: [post]};
-        }
-    });
-
-    this.put('/posts/:id/', function (db, request) {
-        let {id} = request.params;
-        let [attrs] = JSON.parse(request.requestBody).posts;
-        delete attrs.id;
-
-        let post = db.posts.update(id, attrs);
-
-        return {
-            posts: [post]
-        };
-    });
-
-    this.del('/posts/:id/', function (db, request) {
-        db.posts.remove(request.params.id);
-
-        return new Mirage.Response(204, {}, {});
-    });
-
-    /* Roles ---------------------------------------------------------------- */
-
-    this.get('/roles/', function (db, request) {
-        if (request.queryParams.permissions === 'assign') {
-            let roles = db.roles.find([1,2,3]);
-            return {roles};
-        }
-
-        return {
-            roles: db.roles
-        };
-    });
-
-    /* Settings ------------------------------------------------------------- */
-
-    this.get('/settings/', function (db, request) {
-        let filters = request.queryParams.type.split(',');
-        let settings = [];
-
-        filters.forEach((filter) => {
-            settings.pushObjects(db.settings.where({type: filter}));
-        });
-
-        return {
-            settings,
-            meta: {
-                filters: {
-                    type: request.queryParams.type
-                }
-            }
-        };
-    });
-
-    this.put('/settings/', function (db, request) {
-        let newSettings = JSON.parse(request.requestBody).settings;
-
-        db.settings.remove();
-        db.settings.insert(newSettings);
-
-        return {
-            meta: {},
-            settings: db.settings
-        };
-    });
 
     /* Apps - Slack Test Notification --------------------------------------------------------- */
 
@@ -325,178 +62,15 @@ export function testConfig() {
         };
     });
 
-    /* Slugs ---------------------------------------------------------------- */
-
-    this.get('/slugs/post/:slug/', function (db, request) {
-        return {
-            slugs: [
-                {slug: dasherize(decodeURIComponent(request.params.slug))}
-            ]
-        };
-    });
-
-    this.get('/slugs/user/:slug/', function (db, request) {
-        return {
-            slugs: [
-                {slug: dasherize(decodeURIComponent(request.params.slug))}
-            ]
-        };
-    });
-
-    /* Setup ---------------------------------------------------------------- */
-
-    this.post('/authentication/setup', function (db, request) {
-        let [attrs] = $.deparam(request.requestBody).setup;
-        let [role] = db.roles.where({name: 'Owner'});
-        let user;
-
-        // create owner role unless already exists
-        if (!role) {
-            role = db.roles.insert({name: 'Owner'});
-        }
-        attrs.roles = [role];
-
-        if (!isBlank(attrs.email)) {
-            attrs.slug = attrs.email.split('@')[0].dasherize();
-        }
-
-        // NOTE: this does not use the user factory to fill in blank fields
-        user = db.users.insert(attrs);
-
-        delete user.roles;
-
-        return {
-            users: [user]
-        };
-    });
-
-    this.get('/authentication/setup/', function () {
-        return {
-            setup: [
-                {status: true}
-            ]
-        };
-    });
-
-    /* Subscribers ---------------------------------------------------------- */
-
-    mockSubscribers(this);
-
-    /* Tags ----------------------------------------------------------------- */
-
-    this.post('/tags/', function (db, request) {
-        let [attrs] = JSON.parse(request.requestBody).tags;
-        let tag;
-
-        if (isBlank(attrs.slug) && !isBlank(attrs.name)) {
-            attrs.slug = attrs.name.dasherize();
-        }
-
-        // NOTE: this does not use the tag factory to fill in blank fields
-        tag = db.tags.insert(attrs);
-
-        return {
-            tag
-        };
-    });
-
-    this.get('/tags/', function (db, request) {
-        let response = paginatedResponse('tags', db.tags, request);
-        // TODO: remove post_count unless requested?
-        return response;
-    });
-
-    this.get('/tags/slug/:slug/', function (db, request) {
-        let [tag] = db.tags.where({slug: request.params.slug});
-
-        // TODO: remove post_count unless requested?
-
-        return {
-            tag
-        };
-    });
-
-    this.put('/tags/:id/', function (db, request) {
-        let {id} = request.params;
-        let [attrs] = JSON.parse(request.requestBody).tags;
-        let record = db.tags.update(id, attrs);
-
-        return {
-            tag: record
-        };
-    });
-
-    this.del('/tags/:id/', function (db, request) {
-        db.tags.remove(request.params.id);
-
-        return new Mirage.Response(204, {}, {});
-    });
-
-    /* Users ---------------------------------------------------------------- */
-
-    this.post('/users/', function (db, request) {
-        let [attrs] = JSON.parse(request.requestBody).users;
-        let user;
-
-        if (!isBlank(attrs.email)) {
-            attrs.slug = attrs.email.split('@')[0].dasherize();
-        }
-
-        // NOTE: this does not use the user factory to fill in blank fields
-        user = db.users.insert(attrs);
-
-        return {
-            users: [user]
-        };
-    });
-
-    // /users/me = Always return the user with ID=1
-    this.get('/users/me', function (db) {
-        return {
-            users: [db.users.find(1)]
-        };
-    });
-
-    this.get('/users/', 'users');
-
-    this.get('/users/slug/:slug/', function (db, request) {
-        let user = db.users.where({slug: request.params.slug});
-
-        return {
-            users: user
-        };
-    });
-
-    this.del('/users/:id/', function (db, request) {
-        db.users.remove(request.params.id);
-
-        return new Mirage.Response(204, {}, {});
-    });
-
-    this.get('/users/:id', function (db, request) {
-        return {
-            users: [db.users.find(request.params.id)]
-        };
-    });
-
-    this.put('/users/:id/', function (db, request) {
-        let {id} = request.params;
-
-        if (id === 'password') {
-            return {
-                password: [{message: 'Password changed successfully.'}]
-            };
-        } else {
-            let [attrs] = JSON.parse(request.requestBody).users;
-            let record = db.users.update(id, attrs);
-
-            return {
-                user: record
-            };
-        }
-    });
-
     /* External sites ------------------------------------------------------- */
+
+    let downloadCount = 0;
+    this.get('https://count.ghost.org/', function () {
+        downloadCount++;
+        return {
+            count: downloadCount
+        };
+    });
 
     this.get('http://www.gravatar.com/avatar/:md5', function () {
         return '';

--- a/app/mirage/config/authentication.js
+++ b/app/mirage/config/authentication.js
@@ -1,0 +1,74 @@
+/* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
+import Mirage from 'ember-cli-mirage';
+import $ from 'jquery';
+import {isBlank} from 'ember-utils';
+
+export default function mockAuthentication(server) {
+    server.post('/authentication/token', function () {
+        return {
+            access_token: '5JhTdKI7PpoZv4ROsFoERc6wCHALKFH5jxozwOOAErmUzWrFNARuH1q01TYTKeZkPW7FmV5MJ2fU00pg9sm4jtH3Z1LjCf8D6nNqLYCfFb2YEKyuvG7zHj4jZqSYVodN2YTCkcHv6k8oJ54QXzNTLIDMlCevkOebm5OjxGiJpafMxncm043q9u1QhdU9eee3zouGRMVVp8zkKVoo5zlGMi3zvS2XDpx7xsfk8hKHpUgd7EDDQxmMueifWv7hv6n',
+            expires_in: 3600,
+            refresh_token: 'XP13eDjwV5mxOcrq1jkIY9idhdvN3R1Br5vxYpYIub2P5Hdc8pdWMOGmwFyoUshiEB62JWHTl8H1kACJR18Z8aMXbnk5orG28br2kmVgtVZKqOSoiiWrQoeKTqrRV0t7ua8uY5HdDUaKpnYKyOdpagsSPn3WEj8op4vHctGL3svOWOjZhq6F2XeVPMR7YsbiwBE8fjT3VhTB3KRlBtWZd1rE0Qo2EtSplWyjGKv1liAEiL0ndQoLeeSOCH4rTP7',
+            token_type: 'Bearer'
+        };
+    });
+
+    server.post('/authentication/passwordreset', function (db, request) {
+        // jscs:disable requireObjectDestructuring
+        let {passwordreset} = $.deparam(request.requestBody);
+        let email = passwordreset[0].email;
+        // jscs:enable requireObjectDestructuring
+
+        if (email === 'unknown@example.com') {
+            return new Mirage.Response(404, {}, {
+                errors: [
+                    {
+                        message: 'There is no user with that email address.',
+                        errorType: 'NotFoundError'
+                    }
+                ]
+            });
+        } else {
+            return {
+                passwordreset: [
+                    {message: 'Check your email for further instructions.'}
+                ]
+            };
+        }
+    });
+
+    /* Setup ---------------------------------------------------------------- */
+
+    server.post('/authentication/setup', function (db, request) {
+        let [attrs] = $.deparam(request.requestBody).setup;
+        let [role] = db.roles.where({name: 'Owner'});
+        let user;
+
+        // create owner role unless already exists
+        if (!role) {
+            role = db.roles.insert({name: 'Owner'});
+        }
+        attrs.roles = [role];
+
+        if (!isBlank(attrs.email)) {
+            attrs.slug = attrs.email.split('@')[0].dasherize();
+        }
+
+        // NOTE: this does not use the user factory to fill in blank fields
+        user = db.users.insert(attrs);
+
+        delete user.roles;
+
+        return {
+            users: [user]
+        };
+    });
+
+    server.get('/authentication/setup/', function () {
+        return {
+            setup: [
+                {status: true}
+            ]
+        };
+    });
+}

--- a/app/mirage/config/posts.js
+++ b/app/mirage/config/posts.js
@@ -1,0 +1,61 @@
+import Mirage from 'ember-cli-mirage';
+import {isBlank} from 'ember-utils';
+import {paginatedResponse} from '../utils';
+
+export default function mockPosts(server) {
+    server.post('/posts/', function (db, request) {
+        let [attrs] = JSON.parse(request.requestBody).posts;
+        let post;
+
+        if (isBlank(attrs.slug) && !isBlank(attrs.title)) {
+            attrs.slug = attrs.title.dasherize();
+        }
+
+        // NOTE: this does not use the post factory to fill in blank fields
+        post = db.posts.insert(attrs);
+
+        return {
+            posts: [post]
+        };
+    });
+
+    server.get('/posts/', function (db, request) {
+        // TODO: handle status/staticPages/author params
+        let response = paginatedResponse('posts', db.posts, request);
+        return response;
+    });
+
+    server.get('/posts/:id/', function (db, request) {
+        let {id} = request.params;
+        let post = db.posts.find(id);
+
+        if (!post) {
+            return new Mirage.Response(404, {}, {
+                errors: [{
+                    errorType: 'NotFoundError',
+                    message: 'Post not found.'
+                }]
+            });
+        } else {
+            return {posts: [post]};
+        }
+    });
+
+    server.put('/posts/:id/', function (db, request) {
+        let {id} = request.params;
+        let [attrs] = JSON.parse(request.requestBody).posts;
+        delete attrs.id;
+
+        let post = db.posts.update(id, attrs);
+
+        return {
+            posts: [post]
+        };
+    });
+
+    server.del('/posts/:id/', function (db, request) {
+        db.posts.remove(request.params.id);
+
+        return new Mirage.Response(204, {}, {});
+    });
+}

--- a/app/mirage/config/roles.js
+++ b/app/mirage/config/roles.js
@@ -1,0 +1,12 @@
+export default function mockRoles(server) {
+    server.get('/roles/', function (db, request) {
+        if (request.queryParams.permissions === 'assign') {
+            let roles = db.roles.find([1,2,3]);
+            return {roles};
+        }
+
+        return {
+            roles: db.roles
+        };
+    });
+}

--- a/app/mirage/config/settings.js
+++ b/app/mirage/config/settings.js
@@ -1,0 +1,31 @@
+export default function mockSettings(server) {
+    server.get('/settings/', function (db, request) {
+        let filters = request.queryParams.type.split(',');
+        let settings = [];
+
+        filters.forEach((filter) => {
+            settings.pushObjects(db.settings.where({type: filter}));
+        });
+
+        return {
+            settings,
+            meta: {
+                filters: {
+                    type: request.queryParams.type
+                }
+            }
+        };
+    });
+
+    server.put('/settings/', function (db, request) {
+        let newSettings = JSON.parse(request.requestBody).settings;
+
+        db.settings.remove();
+        db.settings.insert(newSettings);
+
+        return {
+            meta: {},
+            settings: db.settings
+        };
+    });
+}

--- a/app/mirage/config/slugs.js
+++ b/app/mirage/config/slugs.js
@@ -1,0 +1,23 @@
+import Ember from 'ember';
+
+const {
+    String: {dasherize}
+} = Ember;
+
+export default function mockSlugs(server) {
+    server.get('/slugs/post/:slug/', function (db, request) {
+        return {
+            slugs: [
+                {slug: dasherize(decodeURIComponent(request.params.slug))}
+            ]
+        };
+    });
+
+    server.get('/slugs/user/:slug/', function (db, request) {
+        return {
+            slugs: [
+                {slug: dasherize(decodeURIComponent(request.params.slug))}
+            ]
+        };
+    });
+}

--- a/app/mirage/config/subscribers.js
+++ b/app/mirage/config/subscribers.js
@@ -1,0 +1,68 @@
+/* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
+import Mirage from 'ember-cli-mirage';
+import {paginatedResponse} from '../utils';
+
+export default function mockSubscribers(server) {
+    server.get('/subscribers/', function (db, request) {
+        let response = paginatedResponse('subscribers', db.subscribers, request);
+        return response;
+    });
+
+    server.post('/subscribers/', function (db, request) {
+        let [attrs] = JSON.parse(request.requestBody).subscribers;
+        let [subscriber] = db.subscribers.where({email: attrs.email});
+
+        if (subscriber) {
+            return new Mirage.Response(422, {}, {
+                errors: [{
+                    errorType: 'ValidationError',
+                    message: 'Email already exists.',
+                    property: 'email'
+                }]
+            });
+        } else {
+            attrs.created_at = new Date();
+            attrs.created_by = 0;
+
+            subscriber = db.subscribers.insert(attrs);
+
+            return {
+                subscriber
+            };
+        }
+    });
+
+    server.put('/subscribers/:id/', function (db, request) {
+        let {id} = request.params;
+        let [attrs] = JSON.parse(request.requestBody).subscribers;
+        let subscriber = db.subscribers.update(id, attrs);
+
+        return {
+            subscriber
+        };
+    });
+
+    server.del('/subscribers/:id/', function (db, request) {
+        db.subscribers.remove(request.params.id);
+
+        return new Mirage.Response(204, {}, {});
+    });
+
+    server.post('/subscribers/csv/', function (/*db, request*/) {
+        // NB: we get a raw FormData object with no way to inspect it in Chrome
+        // until version 50 adds the additional read methods
+        // https://developer.mozilla.org/en-US/docs/Web/API/FormData#Browser_compatibility
+
+        server.createList('subscriber', 50);
+
+        return {
+            meta: {
+                stats: {
+                    imported: 50,
+                    duplicates: 3,
+                    invalid: 2
+                }
+            }
+        };
+    });
+}

--- a/app/mirage/config/tags.js
+++ b/app/mirage/config/tags.js
@@ -1,0 +1,53 @@
+import Mirage from 'ember-cli-mirage';
+import {isBlank} from 'ember-utils';
+import {paginatedResponse} from '../utils';
+
+export default function mockTags(server) {
+    server.post('/tags/', function (db, request) {
+        let [attrs] = JSON.parse(request.requestBody).tags;
+        let tag;
+
+        if (isBlank(attrs.slug) && !isBlank(attrs.name)) {
+            attrs.slug = attrs.name.dasherize();
+        }
+
+        // NOTE: this does not use the tag factory to fill in blank fields
+        tag = db.tags.insert(attrs);
+
+        return {
+            tag
+        };
+    });
+
+    server.get('/tags/', function (db, request) {
+        let response = paginatedResponse('tags', db.tags, request);
+        // TODO: remove post_count unless requested?
+        return response;
+    });
+
+    server.get('/tags/slug/:slug/', function (db, request) {
+        let [tag] = db.tags.where({slug: request.params.slug});
+
+        // TODO: remove post_count unless requested?
+
+        return {
+            tag
+        };
+    });
+
+    server.put('/tags/:id/', function (db, request) {
+        let {id} = request.params;
+        let [attrs] = JSON.parse(request.requestBody).tags;
+        let record = db.tags.update(id, attrs);
+
+        return {
+            tag: record
+        };
+    });
+
+    server.del('/tags/:id/', function (db, request) {
+        db.tags.remove(request.params.id);
+
+        return new Mirage.Response(204, {}, {});
+    });
+}

--- a/app/mirage/config/users.js
+++ b/app/mirage/config/users.js
@@ -1,0 +1,66 @@
+import Mirage from 'ember-cli-mirage';
+import {isBlank} from 'ember-utils';
+
+export default function mockUsers(server) {
+    server.post('/users/', function (db, request) {
+        let [attrs] = JSON.parse(request.requestBody).users;
+        let user;
+
+        if (!isBlank(attrs.email)) {
+            attrs.slug = attrs.email.split('@')[0].dasherize();
+        }
+
+        // NOTE: this does not use the user factory to fill in blank fields
+        user = db.users.insert(attrs);
+
+        return {
+            users: [user]
+        };
+    });
+
+    // /users/me = Always return the user with ID=1
+    server.get('/users/me', function (db) {
+        return {
+            users: [db.users.find(1)]
+        };
+    });
+
+    server.get('/users/', 'users');
+
+    server.get('/users/slug/:slug/', function (db, request) {
+        let user = db.users.where({slug: request.params.slug});
+
+        return {
+            users: user
+        };
+    });
+
+    server.del('/users/:id/', function (db, request) {
+        db.users.remove(request.params.id);
+
+        return new Mirage.Response(204, {}, {});
+    });
+
+    server.get('/users/:id', function (db, request) {
+        return {
+            users: [db.users.find(request.params.id)]
+        };
+    });
+
+    server.put('/users/:id/', function (db, request) {
+        let {id} = request.params;
+
+        if (id === 'password') {
+            return {
+                password: [{message: 'Password changed successfully.'}]
+            };
+        } else {
+            let [attrs] = JSON.parse(request.requestBody).users;
+            let record = db.users.update(id, attrs);
+
+            return {
+                user: record
+            };
+        }
+    });
+}

--- a/app/mirage/utils.js
+++ b/app/mirage/utils.js
@@ -1,0 +1,60 @@
+import Mirage from 'ember-cli-mirage';
+
+export function paginatedResponse(modelName, allModels, request) {
+    let page = +request.queryParams.page || 1;
+    let limit = request.queryParams.limit || 15;
+    let pages, models, next, prev;
+
+    allModels = allModels || [];
+
+    if (limit === 'all') {
+        models = allModels;
+        pages = 1;
+    } else {
+        limit = +limit;
+
+        let start = (page - 1) * limit;
+        let end = start + limit;
+
+        models = allModels.slice(start, end);
+        pages = Math.ceil(allModels.length / limit);
+
+        if (start > 0) {
+            prev = page - 1;
+        }
+
+        if (end < allModels.length) {
+            next = page + 1;
+        }
+    }
+
+    return {
+        meta: {
+            pagination: {
+                page,
+                limit,
+                pages,
+                total: allModels.length,
+                next: next || null,
+                prev: prev || null
+            }
+        },
+        [modelName]: models
+    };
+}
+
+export function maintenanceResponse() {
+    return new Mirage.Response(503, {}, {
+        errors: [{
+            errorType: 'Maintenance'
+        }]
+    });
+}
+
+export function versionMismatchResponse() {
+    return new Mirage.Response(400, {}, {
+        errors: [{
+            errorType: 'VersionMismatchError'
+        }]
+    });
+}


### PR DESCRIPTION
no issue
- moves mirage config for grouped endpoints into separate files to cleanup the `app/mirage/config.js` file
- endpoints are now mocked via a single `mockX(this)` call allowing for quick/easy mocking in the dev environment as well as the test environment without cluttering `config.js`