### PR TITLE
Switch to new native system font stack

### DIFF
--- a/app/styles/components/dropdowns.css
+++ b/app/styles/components/dropdowns.css
@@ -26,7 +26,6 @@
     list-style: none;
     text-align: left;
     text-transform: none;
-    letter-spacing: 0;
     font-size: 1.4rem;
     font-weight: normal;
 }

--- a/app/styles/components/settings-menu.css
+++ b/app/styles/components/settings-menu.css
@@ -176,5 +176,5 @@
     transform: translate3d(-350px, 0px, 0px);
 }
 .mobile-menu-expanded .content-cover {
-    transform: translate3d(235px, 0px, 0px);
+    transform: translate3d(205px, 0px, 0px);
 }

--- a/app/styles/layouts/auth.css
+++ b/app/styles/layouts/auth.css
@@ -39,7 +39,6 @@
     border-left: #dae1e3 1px solid;
     border-radius: 0;
     text-transform: none;
-    letter-spacing: 0;
     font-size: 1.1rem;
     line-height: 1.2rem;
 }

--- a/app/styles/layouts/editor.css
+++ b/app/styles/layouts/editor.css
@@ -16,7 +16,6 @@
     border: 0;
     background: transparent;
     color: var(--darkgrey);
-    letter-spacing: -1px;
     font-size: 2.6rem;
     font-weight: bold;
 }

--- a/app/styles/layouts/flow.css
+++ b/app/styles/layouts/flow.css
@@ -171,7 +171,6 @@
 }
 
 .gh-flow-content h1 {
-    letter-spacing: -1px;
     font-size: 4.2rem;
     font-weight: 100;
 }

--- a/app/styles/layouts/main.css
+++ b/app/styles/layouts/main.css
@@ -49,7 +49,7 @@ body > .ember-view:not(.liquid-target-container) {
 .gh-nav {
     position: relative;
     z-index: 800;
-    flex: 0 0 235px;
+    flex: 0 0 205px;
     display: flex;
     flex-direction: column;
     min-width: 0; /* TODO: This is a bullshit Firefox hack */
@@ -93,10 +93,9 @@ body > .ember-view:not(.liquid-target-container) {
 
 .gh-nav-menu-details-blog {
     overflow: hidden;
-    margin-bottom: 1px;
     text-overflow: ellipsis;
     white-space: nowrap;
-    font-size: 1.5rem;
+    font-size: 1.4rem;
     line-height: 1.3em;
     font-weight: 600;
 }
@@ -163,8 +162,8 @@ body > .ember-view:not(.liquid-target-container) {
     text-transform: uppercase;
     text-overflow: ellipsis;
     white-space: nowrap;
-    letter-spacing: 1px;
-    font-size: 1.2rem;
+    letter-spacing: 0.05em;
+    font-size: 1.1rem;
     line-height: 1.1em;
 }
 
@@ -174,17 +173,20 @@ body > .ember-view:not(.liquid-target-container) {
     padding: 5px 10px 5px 15px;
     border-radius: 0 4px 4px 0;
     color: var(--darkgrey);
+    opacity: 0.9;
     transition: none;
 }
 
 .gh-nav-list .active {
     background: color(var(--blue) lightness(+10%));
     color: #fff;
+    opacity: 1;
 }
 
 .gh-nav-list a:not(.active):hover {
     background: color(var(--blue) alpha(-85%));
     color: var(--darkgrey);
+    opacity: 1;
 }
 
 .gh-nav-list i {
@@ -307,7 +309,7 @@ body > .ember-view:not(.liquid-target-container) {
     }
 
     .gh-nav-list-h {
-        font-size: 1.4rem;
+        font-size: 1.2rem;
     }
 
     .gh-nav-list i {
@@ -370,7 +372,7 @@ body > .ember-view:not(.liquid-target-container) {
 
 .gh-nav.open .gh-autonav-toggle {
     transition: transform 0.15s;
-    transform: translate3d(-235px,0,0);
+    transform: translate3d(-205px,0,0);
 }
 
 @media (min-width: 801px) {
@@ -380,11 +382,11 @@ body > .ember-view:not(.liquid-target-container) {
         top: 0;
         left: 0;
         z-index: 1000;
-        width: 235px;
+        width: 205px;
         height: 100%;
         transition: transform 0.20s;
         /* translate3d for GPU accelerated animation - http://bit.ly/1EY1Xhx */
-        transform: translate3d(-220px,0,0);
+        transform: translate3d(-180px,0,0);
     }
 
     /* THE FUTURE: Super sexy background blur for Webkit - http://cl.ly/b1rG */

--- a/app/styles/layouts/users.css
+++ b/app/styles/layouts/users.css
@@ -146,7 +146,6 @@ a.user-list-item {
     background: #eee;
     color: rgba(0, 0, 0, 0.5);
     text-transform: uppercase;
-    letter-spacing: 0.1em;
     font-size: 9px;
     line-height: 1;
     font-weight: 400;

--- a/app/styles/patterns/buttons.css
+++ b/app/styles/patterns/buttons.css
@@ -15,7 +15,6 @@
     text-transform: uppercase;
     text-shadow: none;
     white-space: nowrap;
-    letter-spacing: 1px;
     font-size: 1.1rem;
     line-height: 1.428571429;
     font-weight: 300;
@@ -164,7 +163,6 @@ fieldset[disabled] .btn {
 .btn-minor {
     padding: 8px 15px;
     text-transform: none;
-    letter-spacing: 0;
     font-size: 1.2rem;
 }
 

--- a/app/styles/patterns/global.css
+++ b/app/styles/patterns/global.css
@@ -65,7 +65,7 @@ html {
     width: 100%;
     /* Prevent elastic scrolling on the whole page */
     height: 100%;
-    font: 62.5%/1.65 "Open Sans", sans-serif;
+    font: 62.5%/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Open Sans","Helvetica Neue",sans-serif;
 
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }


### PR DESCRIPTION
Based on an increasingly popular trend and modern web typography capabilities, switch out Google Fonts for default native system fonts, tailored in a stack to suit every device. Also makes some very minor visual adjustments to suit.

Nixes all references to Google Fonts, and provides a faster rendering experience and fewer http requests. 💃 

Reference material:
- https://www.smashingmagazine.com/2015/11/using-system-ui-fonts-practical-guide/
- https://medium.design/system-shock-6b1dc6d6596f#.rhqx5fmyz

Dependencies:
- https://github.com/TryGhost/Ghost-Admin/pull/211
- https://github.com/TryGhost/Ghost/pull/7219
- https://github.com/TryGhost/Ghost-Desktop/pull/190