### PR TITLE
🐛  Fix position of arrow in Apps UI

### DIFF
--- a/app/styles/layouts/apps.css
+++ b/app/styles/layouts/apps.css
@@ -85,6 +85,7 @@
 .apps-configured > i {
     position: absolute;
     top: 2px;
+    right: 0;
     font-size: 1.1rem;
 }
 


### PR DESCRIPTION
closes  TryGhost/Ghost#7222

Adds `right: 0` to `.apps-configured > i`, so the arrow doesn't overlap with the letters.

![image](https://cloud.githubusercontent.com/assets/8037602/17777403/be84ac62-6560-11e6-8a53-5c04690cab04.png)

![image](https://cloud.githubusercontent.com/assets/8037602/17777420/c9369a30-6560-11e6-9989-a8a786846f21.png)
