### PR TITLE
✨ validate file uploads against "accept" mime-type before uploading

### DIFF
--- a/app/components/gh-file-upload.js
+++ b/app/components/gh-file-upload.js
@@ -3,6 +3,7 @@ import Component from 'ember-component';
 export default Component.extend({
     _file: null,
 
+    acceptEncoding: null,
     uploadButtonText: 'Text',
     uploadButtonDisabled: true,
 

--- a/app/components/gh-image-uploader.js
+++ b/app/components/gh-image-uploader.js
@@ -10,7 +10,8 @@ import ghostPaths from 'ghost-admin/utils/ghost-paths';
 import {
     isRequestEntityTooLargeError,
     isUnsupportedMediaTypeError,
-    isVersionMismatchError
+    isVersionMismatchError,
+    UnsupportedMediaTypeError
 } from 'ghost-admin/services/ajax';
 
 export default Component.extend({
@@ -22,6 +23,8 @@ export default Component.extend({
     text: '',
     altText: '',
     saveButton: true,
+    accept: 'image/gif,image/jpg,image/jpeg,image/png,image/svg+xml',
+    validate: null,
 
     dragClass: null,
     failureMessage: null,
@@ -200,12 +203,42 @@ export default Component.extend({
         });
     },
 
+    _validate(file) {
+        if (this.get('validate')) {
+            return invokeAction(this, 'validate', file);
+        } else {
+            return this._defaultValidator(file);
+        }
+    },
+
+    _defaultValidator(file) {
+        let accept = this.get('accept');
+
+        if (!isBlank(accept) && file && accept.indexOf(file.type) === -1) {
+            return new UnsupportedMediaTypeError();
+        }
+
+        return true;
+    },
+
     actions: {
         fileSelected(fileList) {
-            this.set('file', fileList[0]);
-            run.schedule('actions', this, function () {
-                this.generateRequest();
-            });
+            // can't use array destructuring here as FileList is not a strict
+            // array and fails in Safari
+            // jscs:disable requireArrayDestructuring
+            let file = fileList[0];
+            // jscs:enable requireArrayDestructuring
+            let validationResult = this._validate(file);
+
+            this.set('file', file);
+
+            if (validationResult === true) {
+                run.schedule('actions', this, function () {
+                    this.generateRequest();
+                });
+            } else {
+                this._uploadFailed(validationResult);
+            }
         },
 
         onInput(url) {

--- a/app/controllers/settings/labs.js
+++ b/app/controllers/settings/labs.js
@@ -1,13 +1,17 @@
 import $ from 'jquery';
 import Controller from 'ember-controller';
 import injectService from 'ember-service/inject';
+import {isBlank} from 'ember-utils';
 import {isEmberArray} from 'ember-array/utils';
+import {UnsupportedMediaTypeError} from 'ghost-admin/services/ajax';
 
 export default Controller.extend({
     uploadButtonText: 'Import',
     importErrors: '',
     submitting: false,
     showDeleteAllModal: false,
+
+    importMimeType: 'application/json',
 
     ghostPaths: injectService(),
     notifications: injectService(),
@@ -20,9 +24,15 @@ export default Controller.extend({
             let notifications = this.get('notifications');
             let currentUserId = this.get('session.user.id');
             let dbUrl = this.get('ghostPaths.url').api('db');
+            let accept = this.get('importMimeType');
 
             this.set('uploadButtonText', 'Importing');
             this.set('importErrors', '');
+
+            if (!isBlank(accept) && file && accept.indexOf(file.type) === -1) {
+                this.set('importErrors', [new UnsupportedMediaTypeError()]);
+                return;
+            }
 
             formData.append('importfile', file);
 

--- a/app/templates/components/gh-file-upload.hbs
+++ b/app/templates/components/gh-file-upload.hbs
@@ -1,4 +1,4 @@
-<input data-url="upload" class="gh-input btn-block" type="file" name="importfile" accept="{{options.acceptEncoding}}">
+<input data-url="upload" class="gh-input btn-block" type="file" name="importfile" accept="{{acceptEncoding}}">
 <button type="submit" class="btn btn-green btn-block" id="startupload" disabled={{uploadButtonDisabled}} {{action "upload"}}>
     {{uploadButtonText}}
 </button>

--- a/app/templates/components/gh-file-uploader.hbs
+++ b/app/templates/components/gh-file-uploader.hbs
@@ -13,7 +13,7 @@
     {{/if}}
 {{else}}
     <div class="upload-form">
-        {{#gh-file-input multiple=false alt=labelText action=(action 'fileSelected') accept="text/csv"}}
+        {{#gh-file-input multiple=false alt=labelText action=(action 'fileSelected') accept=accept}}
             <div class="description">{{labelText}}</div>
         {{/gh-file-input}}
     </div>

--- a/app/templates/components/gh-image-uploader.hbs
+++ b/app/templates/components/gh-image-uploader.hbs
@@ -15,7 +15,7 @@
     {{#if showUploadForm}}
         {{!-- file selection/drag-n-drop  --}}
         <div class="upload-form">
-            {{#gh-file-input multiple=false alt=description action=(action 'fileSelected') accept="image/gif,image/jpg,image/jpeg,image/png,image/svg+xml"}}
+            {{#gh-file-input multiple=false alt=description action=(action 'fileSelected') accept=accept}}
                 <div class="description">{{description}}</div>
             {{/gh-file-input}}
         </div>

--- a/app/templates/settings/labs.hbs
+++ b/app/templates/settings/labs.hbs
@@ -19,7 +19,7 @@
                 <div class="form-group">
                     <label>Import</label>
                     {{partial "import-errors"}}
-                    {{gh-file-upload id="importfile" classNames="flex" uploadButtonText=uploadButtonText onUpload="onUpload"}}
+                    {{gh-file-upload id="importfile" classNames="flex" uploadButtonText=uploadButtonText onUpload="onUpload" acceptEncoding=importMimeType}}
                     <p>Import from another Ghost installation. If you import a user, this will replace the current user & log you out.</p>
                 </div>
             </fieldset>

--- a/tests/acceptance/subscribers-test.js
+++ b/tests/acceptance/subscribers-test.js
@@ -246,7 +246,7 @@ describe('Acceptance: Subscribers', function() {
             });
 
             click('.btn:contains("Import CSV")');
-            fileUpload('.fullscreen-modal input[type="file"]');
+            fileUpload('.fullscreen-modal input[type="file"]', ['test'], {type: 'text/csv'});
 
             andThen(function () {
                 // modal title changes

--- a/tests/acceptance/version-mismatch-test.js
+++ b/tests/acceptance/version-mismatch-test.js
@@ -104,7 +104,7 @@ describe('Acceptance: Version Mismatch', function() {
 
             visit('/subscribers');
             click('.btn:contains("Import CSV")');
-            fileUpload('.fullscreen-modal input[type="file"]');
+            fileUpload('.fullscreen-modal input[type="file"]', ['test'], {type: 'text/csv'});
 
             andThen(() => {
                 // alert is shown

--- a/tests/integration/components/gh-image-uploader-test.js
+++ b/tests/integration/components/gh-image-uploader-test.js
@@ -12,6 +12,7 @@ import {createFile, fileUpload} from '../../helpers/file-upload';
 import $ from 'jquery';
 import run from 'ember-runloop';
 import Service from 'ember-service';
+import {UnsupportedMediaTypeError} from 'ghost-admin/services/ajax';
 
 const keyCodes = {
     enter: 13
@@ -144,7 +145,7 @@ describeComponent(
                 stubSuccessfulUpload(server);
 
                 this.render(hbs`{{gh-image-uploader image=image update=(action update)}}`);
-                fileUpload(this.$('input[type="file"]'));
+                fileUpload(this.$('input[type="file"]'), ['test'], {type: 'image/png'});
 
                 wait().then(() => {
                     expect(server.handledRequests.length).to.equal(1);
@@ -160,7 +161,7 @@ describeComponent(
                 this.get('sessionService').set('isAuthenticated', true);
 
                 this.render(hbs`{{gh-image-uploader image=image update=(action update)}}`);
-                fileUpload(this.$('input[type="file"]'));
+                fileUpload(this.$('input[type="file"]'), ['test'], {type: 'image/png'});
 
                 wait().then(() => {
                     let [request] = server.handledRequests;
@@ -176,7 +177,7 @@ describeComponent(
                 stubSuccessfulUpload(server);
 
                 this.render(hbs`{{gh-image-uploader image=image update=(action update)}}`);
-                fileUpload(this.$('input[type="file"]'));
+                fileUpload(this.$('input[type="file"]'), ['test'], {type: 'image/png'});
 
                 wait().then(() => {
                     expect(update.calledOnce).to.be.true;
@@ -192,7 +193,7 @@ describeComponent(
                 stubFailedUpload(server, 500);
 
                 this.render(hbs`{{gh-image-uploader image=image update=(action update)}}`);
-                fileUpload(this.$('input[type="file"]'));
+                fileUpload(this.$('input[type="file"]'), ['test'], {type: 'image/png'});
 
                 wait().then(() => {
                     expect(update.calledOnce).to.be.false;
@@ -207,7 +208,7 @@ describeComponent(
                 stubSuccessfulUpload(server);
 
                 this.render(hbs`{{gh-image-uploader image=image uploadStarted=(action uploadStarted) update=(action update)}}`);
-                fileUpload(this.$('input[type="file"]'));
+                fileUpload(this.$('input[type="file"]'), ['test'], {type: 'image/png'});
 
                 wait().then(() => {
                     expect(uploadStarted.calledOnce).to.be.true;
@@ -222,7 +223,7 @@ describeComponent(
                 stubSuccessfulUpload(server);
 
                 this.render(hbs`{{gh-image-uploader image=image uploadFinished=(action uploadFinished) update=(action update)}}`);
-                fileUpload(this.$('input[type="file"]'));
+                fileUpload(this.$('input[type="file"]'), ['test'], {type: 'image/png'});
 
                 wait().then(() => {
                     expect(uploadFinished.calledOnce).to.be.true;
@@ -237,7 +238,7 @@ describeComponent(
                 stubFailedUpload(server);
 
                 this.render(hbs`{{gh-image-uploader image=image uploadFinished=(action uploadFinished) update=(action update)}}`);
-                fileUpload(this.$('input[type="file"]'));
+                fileUpload(this.$('input[type="file"]'), ['test'], {type: 'image/png'});
 
                 wait().then(() => {
                     expect(uploadFinished.calledOnce).to.be.true;
@@ -248,7 +249,7 @@ describeComponent(
             it('displays invalid file type error', function (done) {
                 stubFailedUpload(server, 415, 'UnsupportedMediaTypeError');
                 this.render(hbs`{{gh-image-uploader image=image update=(action update)}}`);
-                fileUpload(this.$('input[type="file"]'));
+                fileUpload(this.$('input[type="file"]'), ['test'], {type: 'image/png'});
 
                 wait().then(() => {
                     expect(this.$('.failed').length, 'error message is displayed').to.equal(1);
@@ -262,7 +263,7 @@ describeComponent(
             it('displays file too large for server error', function (done) {
                 stubFailedUpload(server, 413, 'RequestEntityTooLargeError');
                 this.render(hbs`{{gh-image-uploader image=image update=(action update)}}`);
-                fileUpload(this.$('input[type="file"]'));
+                fileUpload(this.$('input[type="file"]'), ['test'], {type: 'image/png'});
 
                 wait().then(() => {
                     expect(this.$('.failed').length, 'error message is displayed').to.equal(1);
@@ -276,7 +277,7 @@ describeComponent(
                     return [413, {}, ''];
                 });
                 this.render(hbs`{{gh-image-uploader image=image update=(action update)}}`);
-                fileUpload(this.$('input[type="file"]'));
+                fileUpload(this.$('input[type="file"]'), ['test'], {type: 'image/png'});
 
                 wait().then(() => {
                     expect(this.$('.failed').length, 'error message is displayed').to.equal(1);
@@ -288,7 +289,7 @@ describeComponent(
             it('displays other server-side error with message', function (done) {
                 stubFailedUpload(server, 400, 'UnknownError');
                 this.render(hbs`{{gh-image-uploader image=image update=(action update)}}`);
-                fileUpload(this.$('input[type="file"]'));
+                fileUpload(this.$('input[type="file"]'), ['test'], {type: 'image/png'});
 
                 wait().then(() => {
                     expect(this.$('.failed').length, 'error message is displayed').to.equal(1);
@@ -302,7 +303,7 @@ describeComponent(
                     return [500, {'Content-Type': 'application/json'}, ''];
                 });
                 this.render(hbs`{{gh-image-uploader image=image update=(action update)}}`);
-                fileUpload(this.$('input[type="file"]'));
+                fileUpload(this.$('input[type="file"]'), ['test'], {type: 'image/png'});
 
                 wait().then(() => {
                     expect(this.$('.failed').length, 'error message is displayed').to.equal(1);
@@ -318,7 +319,7 @@ describeComponent(
                 stubFailedUpload(server, 400, 'VersionMismatchError');
 
                 this.render(hbs`{{gh-image-uploader image=image update=(action update)}}`);
-                fileUpload(this.$('input[type="file"]'));
+                fileUpload(this.$('input[type="file"]'), ['test'], {type: 'image/png'});
 
                 wait().then(() => {
                     expect(showAPIError.calledOnce).to.be.true;
@@ -332,7 +333,7 @@ describeComponent(
 
                 stubFailedUpload(server, 400, 'UnknownError');
                 this.render(hbs`{{gh-image-uploader image=image update=(action update)}}`);
-                fileUpload(this.$('input[type="file"]'));
+                fileUpload(this.$('input[type="file"]'), ['test'], {type: 'image/png'});
 
                 wait().then(() => {
                     expect(showAPIError.called).to.be.false;
@@ -343,7 +344,7 @@ describeComponent(
             it('can be reset after a failed upload', function (done) {
                 stubFailedUpload(server, 400, 'UnknownError');
                 this.render(hbs`{{gh-image-uploader image=image update=(action update)}}`);
-                fileUpload(this.$('input[type="file"]'));
+                fileUpload(this.$('input[type="file"]'), ['test'], {type: 'image/png'});
 
                 wait().then(() => {
                     run(() => {
@@ -364,7 +365,7 @@ describeComponent(
                 stubSuccessfulUpload(server, 150);
 
                 this.render(hbs`{{gh-image-uploader image=image uploadFinished=(action done) update=(action update)}}`);
-                fileUpload(this.$('input[type="file"]'));
+                fileUpload(this.$('input[type="file"]'), ['test'], {type: 'image/png'});
 
                 // after 75ms we should have had one progress event
                 run.later(this, function () {
@@ -402,7 +403,7 @@ describeComponent(
                 let uploadSuccess = sinon.spy();
                 let drop = $.Event('drop', {
                     dataTransfer: {
-                        files: [createFile()]
+                        files: [createFile(['test'], {type: 'image/png'})]
                     }
                 });
 
@@ -418,6 +419,80 @@ describeComponent(
                 wait().then(() => {
                     expect(uploadSuccess.calledOnce).to.be.true;
                     expect(uploadSuccess.firstCall.args[0]).to.equal('/content/images/test.png');
+                    done();
+                });
+            });
+
+            it('validates "accept" mime type by default', function (done) {
+                let uploadSuccess = sinon.spy();
+                let uploadFailed = sinon.spy();
+
+                this.set('uploadSuccess', uploadSuccess);
+                this.set('uploadFailed', uploadFailed);
+
+                stubSuccessfulUpload(server);
+
+                this.render(hbs`{{gh-image-uploader
+                    uploadSuccess=(action uploadSuccess)
+                    uploadFailed=(action uploadFailed)}}`);
+
+                fileUpload(this.$('input[type="file"]'), ['test'], {type: 'application/plain'});
+
+                wait().then(() => {
+                    expect(uploadSuccess.called).to.be.false;
+                    expect(uploadFailed.calledOnce).to.be.true;
+                    expect(this.$('.failed').length, 'error message is displayed').to.equal(1);
+                    expect(this.$('.failed').text()).to.match(/The image type you uploaded is not supported/);
+                    done();
+                });
+            });
+
+            it('uploads if validate action supplied and returns true', function (done) {
+                let validate = sinon.stub().returns(true);
+                let uploadSuccess = sinon.spy();
+
+                this.set('validate', validate);
+                this.set('uploadSuccess', uploadSuccess);
+
+                stubSuccessfulUpload(server);
+
+                this.render(hbs`{{gh-image-uploader
+                    uploadSuccess=(action uploadSuccess)
+                    validate=(action validate)}}`);
+
+                fileUpload(this.$('input[type="file"]'), ['test'], {type: 'application/plain'});
+
+                wait().then(() => {
+                    expect(validate.calledOnce).to.be.true;
+                    expect(uploadSuccess.calledOnce).to.be.true;
+                    done();
+                });
+            });
+
+            it('skips upload and displays error if validate action supplied and doesn\'t return true', function (done) {
+                let validate = sinon.stub().returns(new UnsupportedMediaTypeError());
+                let uploadSuccess = sinon.spy();
+                let uploadFailed = sinon.spy();
+
+                this.set('validate', validate);
+                this.set('uploadSuccess', uploadSuccess);
+                this.set('uploadFailed', uploadFailed);
+
+                stubSuccessfulUpload(server);
+
+                this.render(hbs`{{gh-image-uploader
+                    uploadSuccess=(action uploadSuccess)
+                    uploadFailed=(action uploadFailed)
+                    validate=(action validate)}}`);
+
+                fileUpload(this.$('input[type="file"]'), ['test'], {type: 'image/png'});
+
+                wait().then(() => {
+                    expect(validate.calledOnce).to.be.true;
+                    expect(uploadSuccess.called).to.be.false;
+                    expect(uploadFailed.calledOnce).to.be.true;
+                    expect(this.$('.failed').length, 'error message is displayed').to.equal(1);
+                    expect(this.$('.failed').text()).to.match(/The image type you uploaded is not supported/);
                     done();
                 });
             });


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/7144
- allow `gh-file-uploader`'s `accept` attr to be specified
- allows a `validate` action to be passed into `gh-image-uploader` and `gh-file-uploader` components that runs after a file is selected and before the upload starts
- adds a default `validate` action to `gh-image-uploader` and `gh-file-uploader` that triggers the normal `UnsupportedFileType` error when the selected file's mime-type does not match the `accept` attribute