### PR TITLE
⬇️ 🐛  Downgrade to ember-one-way-controls 0.9.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "ember-light-table": "0.1.9",
     "ember-load-initializers": "0.5.1",
     "ember-myth": "0.1.1",
-    "ember-one-way-controls": "1.0.0",
+    "ember-one-way-controls": "0.9.2",
     "ember-power-select": "0.10.11",
     "ember-resolver": "2.0.3",
     "ember-route-action-helper": "1.0.0",


### PR DESCRIPTION
closes Tryghost/Ghost#7245

Downgrades to `ember-one-way-controls` v0.9.2, as v1.0.1 had a bug when starting to type in the middle of the text inside of the input field.

![psm](https://cloud.githubusercontent.com/assets/8037602/17882031/43f7ec68-690a-11e6-8b37-e8738a856e16.gif)
