### PR TITLE
✅ add final theme management acceptance tests

### DIFF
--- a/app/mirage/config/settings.js
+++ b/app/mirage/config/settings.js
@@ -18,17 +18,14 @@ export default function mockSettings(server) {
     });
 
     server.put('/settings/', function (db, request) {
-        console.log('/settings/', request.requestBody);
         let newSettings = JSON.parse(request.requestBody).settings;
 
-        db.settings.remove();
-        db.settings.insert(newSettings);
+        newSettings.forEach((newSetting) => {
+            db.settings.update({key: newSetting.key}, newSetting);
+        });
 
         let [activeTheme] = db.settings.where({key: 'activeTheme'});
         let [availableThemes] = db.settings.where({key: 'availableThemes'});
-
-        console.log('activeTheme', activeTheme);
-        console.log('availableThemes', availableThemes);
 
         availableThemes.value.forEach((theme) => {
             if (theme.name === activeTheme.value) {
@@ -38,7 +35,8 @@ export default function mockSettings(server) {
             }
         });
 
-        db.settings.update(availableThemes.id, availableThemes);
+        db.settings.remove({key: 'availableThemes'});
+        db.settings.insert(availableThemes);
 
         return {
             meta: {},

--- a/app/mirage/config/themes.js
+++ b/app/mirage/config/themes.js
@@ -1,3 +1,5 @@
+import Mirage from 'ember-cli-mirage';
+
 let themeCount = 1;
 
 export default function mockThemes(server) {
@@ -23,5 +25,18 @@ export default function mockThemes(server) {
         return {
             themes: [theme]
         };
+    });
+
+    server.del('/themes/:theme/', function (db, request) {
+        let [availableThemes] = db.settings.where({key: 'availableThemes'});
+
+        availableThemes.value = availableThemes.value.filter((theme) => {
+            return theme.name !== request.params.theme;
+        });
+
+        db.settings.remove({key: 'availableThemes'});
+        db.settings.insert(availableThemes);
+
+        return new Mirage.Response(204, {}, null);
     });
 }


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost-Admin/pull/210
- adds missing acceptance tests for theme deletion
- adds theme deletion endpoint to mirage config
- fixes mirage settings update endpoint (was previously removing config that the client didn't send and also losing the `type` key for all entries preventing the `GET` request from working properly)