### PR TITLE
🐛 fix post-settings-menu slug input

### DIFF
--- a/app/controllers/post-settings-menu.js
+++ b/app/controllers/post-settings-menu.js
@@ -23,6 +23,7 @@ export default Controller.extend(SettingsMenuMixin, {
     ghostPaths: injectService(),
     notifications: injectService(),
     session: injectService(),
+    slugGenerator: injectService(),
     timeZone: injectService(),
 
     initializeSelectedAuthor: observer('model', function () {


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/7255
- adds missing `slugGenerator` service injection