### PR TITLE
Fix font rendering in ie/edge

### DIFF
--- a/app/styles/patterns/global.css
+++ b/app/styles/patterns/global.css
@@ -65,7 +65,9 @@ html {
     width: 100%;
     /* Prevent elastic scrolling on the whole page */
     height: 100%;
-    font: 62.5%/1.65 var(--font-family);
+    font-family: var(--font-family);
+    font-size: 62.5%;
+    line-height: 1.65;
 
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }


### PR DESCRIPTION
This splits out the font properties into individual rules to work around IE/Edge not following css font rule spec.