### PR TITLE
✨ detailed theme validation errors

### DIFF
--- a/app/components/modals/upload-theme.js
+++ b/app/components/modals/upload-theme.js
@@ -2,7 +2,10 @@ import ModalComponent from 'ghost-admin/components/modals/base';
 import computed, {mapBy, or} from 'ember-computed';
 import {invokeAction} from 'ember-invoke-action';
 import ghostPaths from 'ghost-admin/utils/ghost-paths';
-import {UnsupportedMediaTypeError} from 'ghost-admin/services/ajax';
+import {
+    UnsupportedMediaTypeError,
+    isThemeValidationError
+} from 'ghost-admin/services/ajax';
 import {isBlank} from 'ember-utils';
 import run from 'ember-runloop';
 import injectService from 'ember-service/inject';
@@ -91,6 +94,12 @@ export default ModalComponent.extend({
             invokeAction(this, 'model.uploadSuccess', this.get('theme'));
         },
 
+        uploadFailed(error) {
+            if (isThemeValidationError(error)) {
+                this.set('validationErrors', error.errors[0].errorDetails);
+            }
+        },
+
         confirm() {
             // noop - we don't want the enter key doing anything
         },
@@ -104,6 +113,10 @@ export default ModalComponent.extend({
             if (!this.get('closeDisabled')) {
                 this._super(...arguments);
             }
+        },
+
+        reset() {
+            this.set('validationErrors', null);
         }
     }
 });

--- a/app/services/ajax.js
+++ b/app/services/ajax.js
@@ -88,6 +88,24 @@ export function isMaintenanceError(errorOrStatus) {
     }
 }
 
+/* Theme validation error */
+
+export function ThemeValidationError(errors) {
+    AjaxError.call(this, errors, 'Theme is not compatible or contains errors.');
+}
+
+ThemeValidationError.prototype = Object.create(AjaxError.prototype);
+
+export function isThemeValidationError(errorOrStatus, payload) {
+    if (isAjaxError(errorOrStatus)) {
+        return errorOrStatus instanceof ThemeValidationError;
+    } else if (errorOrStatus && get(errorOrStatus, 'isAdapterError')) {
+        return get(errorOrStatus, 'errors.firstObject.errorType') === 'ThemeValidationError';
+    } else {
+        return get(payload || {}, 'errors.firstObject.errorType') === 'ThemeValidationError';
+    }
+}
+
 /* end: custom error types */
 
 export default AjaxService.extend({
@@ -119,6 +137,8 @@ export default AjaxService.extend({
             return new UnsupportedMediaTypeError(payload.errors);
         } else if (this.isMaintenanceError(status, headers, payload)) {
             return new MaintenanceError(payload.errors);
+        } else if (this.isThemeValidationError(status, headers, payload)) {
+            return new ThemeValidationError(payload.errors);
         }
 
         return this._super(...arguments);
@@ -160,5 +180,9 @@ export default AjaxService.extend({
 
     isMaintenanceError(status, headers, payload) {
         return isMaintenanceError(status, payload);
+    },
+
+    isThemeValidationError(status, headers, payload) {
+        return isThemeValidationError(status, payload);
     }
 });

--- a/app/styles/layouts/settings.css
+++ b/app/styles/layouts/settings.css
@@ -251,3 +251,22 @@ a.theme-list-action {
         margin-right: 20px;
     }
 }
+
+.theme-validation-errors {
+    padding-left: 0;
+}
+
+.theme-validation-errors p {
+    margin-bottom: 0;
+}
+
+.theme-validation-errors > li {
+    margin-bottom: 1.2em;
+    list-style: none;
+    font-size: 15px;
+}
+
+.theme-validation-errors > li > ul {
+    margin-top: 0.2em;
+    font-size: 13px;
+}

--- a/app/templates/components/modals/upload-theme.hbs
+++ b/app/templates/components/modals/upload-theme.hbs
@@ -2,6 +2,8 @@
     <h1>
         {{#if theme}}
             Upload successful!
+        {{else if validationErrors}}
+            Invalid theme
         {{else}}
             Upload a theme
         {{/if}}
@@ -19,6 +21,24 @@
         <p>
             "{{fileThemeName}}" will overwrite an existing theme of the same name. Are you sure?
         </p>
+    {{else if validationErrors}}
+        <ul class="theme-validation-errors">
+            {{#each validationErrors as |error|}}
+                <li>
+                    {{#if error.details}}
+                        {{{error.details}}}
+                    {{else}}
+                        {{{error.rule}}}
+                    {{/if}}
+
+                    <ul>
+                        {{#each error.failures as |failure|}}
+                            <li><code>{{failure.ref}}</code>{{#if failure.message}}: {{failure.message}}{{/if}}</li>
+                        {{/each}}
+                    </ul>
+                </li>
+            {{/each}}
+        </ul>
     {{else}}
         {{gh-file-uploader
             url=uploadUrl
@@ -29,6 +49,7 @@
             uploadStarted=(action "uploadStarted")
             uploadFinished=(action "uploadFinished")
             uploadSuccess=(action "uploadSuccess")
+            uploadFailed=(action "uploadFailed")
             listenTo="themeUploader"}}
     {{/if}}
 </div>
@@ -40,6 +61,11 @@
     {{#if displayOverwriteWarning}}
         <button {{action "confirmOverwrite"}} class="btn btn-red">
             Overwrite
+        </button>
+    {{/if}}
+    {{#if validationErrors}}
+        <button {{action "reset"}} class="btn btn-green">
+            Try Again
         </button>
     {{/if}}
     {{#if canActivateTheme}}


### PR DESCRIPTION
no issue

Display the detailed validation errors that we get back from gscan so that users know how to fix their theme

- add `ThemeValidationError` to custom ajax error types
- intercept failed theme uploads from the uploader component and switch to an "invalid theme" state if we have a theme validation error, otherwise display an error in the upload component as usual

TODO:
- [x] styling
- [x] tests

<img width="606" alt="screen shot 2016-08-24 at 18 59 18" src="https://cloud.githubusercontent.com/assets/415/17941851/f6e7d932-6a2c-11e6-817a-0e3242f860f5.png">

