### PR TITLE
revert: package.json to 0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost-admin",
-  "version": "0.10.0",
+  "version": "0.9.0",
   "description": "Ember.js admin client for Ghost",
   "author": "Ghost Foundation",
   "homepage": "http://ghost.org",


### PR DESCRIPTION
no issue

I've bumped the `package.json` version to `0.10.0` too early.
See https://github.com/TryGhost/Ghost-Admin/commit/a427aab11c9dd458a593094f6d1ee46c9203fed6

With this PR it gets reverted to `0.9.0`.