### PR TITLE
💄 Set max-width for theme uploader table

### DIFF
--- a/app/styles/layouts/settings.css
+++ b/app/styles/layouts/settings.css
@@ -166,6 +166,10 @@
 /* Themes
 /* ---------------------------------------------------------- */
 
+.settings-themes {
+    max-width: 500px;
+}
+
 .settings-themes h3 {
     margin-bottom: 1.6em;
     font-size: 16px;


### PR DESCRIPTION
no issue

Theme uploader form in settings/general is now `max-width: 500px`, which is the same like any other form in settings.

![image](https://cloud.githubusercontent.com/assets/8037602/18000269/92aa99b2-6b7d-11e6-8dba-0ef30fbb026f.png)
