### PR TITLE
🐛  Allow .zip file upload for file import

### DIFF
--- a/app/controllers/settings/labs.js
+++ b/app/controllers/settings/labs.js
@@ -11,7 +11,7 @@ export default Controller.extend({
     submitting: false,
     showDeleteAllModal: false,
 
-    importMimeType: 'application/json',
+    importMimeType: ['application/json', 'application/zip'],
 
     ghostPaths: injectService(),
     notifications: injectService(),


### PR DESCRIPTION
closes TryGhost/Ghost#7277

Adds `application/zip` to supported import file types.