### PR TITLE
🐛 fix duplicate server alerts + default alert bg color

### DIFF
--- a/app/models/notification.js
+++ b/app/models/notification.js
@@ -5,5 +5,6 @@ export default Model.extend({
     dismissible: attr('boolean'),
     status: attr('string'),
     type: attr('string'),
-    message: attr('string')
+    message: attr('string'),
+    key: attr('string')
 });

--- a/app/serializers/notification.js
+++ b/app/serializers/notification.js
@@ -1,0 +1,7 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend({
+    attrs: {
+        key: {key: 'location'}
+    }
+});

--- a/app/styles/components/notifications.css
+++ b/app/styles/components/notifications.css
@@ -141,6 +141,7 @@
     align-items: center;
     padding: 14px 15px;
     border-bottom: #dfe1e3 1px solid;
+    background-color: white;
 }
 
 .gh-alert-content {

--- a/tests/unit/serializers/notification-test.js
+++ b/tests/unit/serializers/notification-test.js
@@ -1,0 +1,47 @@
+import { expect } from 'chai';
+import { describeModel, it } from 'ember-mocha';
+import run from 'ember-runloop';
+import Pretender from 'pretender';
+
+describeModel(
+    'notification',
+    'Unit: Serializer: notification',
+    {
+        // Specify the other units that are required for this test.
+        needs: ['serializer:notification']
+    },
+
+    function () {
+        let server;
+
+        beforeEach(function () {
+            server = new Pretender();
+        });
+
+        afterEach(function () {
+            server.shutdown();
+        });
+
+        it('converts location->key when deserializing', function () {
+            server.get('/notifications', function () {
+                let response = {
+                    notifications: [{
+                        id: 1,
+                        dismissible: false,
+                        status: 'alert',
+                        type: 'info',
+                        location: 'test.foo',
+                        message: 'This is a test'
+                    }]
+                };
+
+                return [200, {'Content-Type': 'application/json'}, JSON.stringify(response)];
+            });
+
+            return this.store().findAll('notification').then((notifications) => {
+                expect(notifications.get('length')).to.equal(1);
+                expect(notifications.get('firstObject.key')).to.equal('test.foo');
+            });
+        });
+    }
+);


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/7305

The `location` property of server-side notifications was being ignored by the client and so wasn't being used to de-duplicate alerts.

- adds `key` attribute to `Notification` model
- adds a serializer for notifications that renames the `location` key sent by the server to `key`
- set the default background color of alerts to white so that alerts with no `type` set do not inherit the background color (useful in Ghost Desktop which has a transparent background color set)