### PR TITLE
Styling: Added ellipsis to post editor title for overflowed text.

### DIFF
--- a/app/styles/layouts/editor.css
+++ b/app/styles/layouts/editor.css
@@ -16,6 +16,7 @@
     border: 0;
     background: transparent;
     color: var(--darkgrey);
+    text-overflow: ellipsis;
     font-size: 2.6rem;
     font-weight: bold;
 }


### PR DESCRIPTION
This commit modifies the title input at the top of the post editor within the admin panel. Long titles are now cut off with an ellipsis rather than a hard break.

Sorry if this commit is a bit small, still new to contributing to the Ghost Project and Github projects in general.

Cheers.
