### PR TITLE
Update Gruntfile.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -104,7 +104,7 @@ module.exports = function(grunt) {
             },
 
             'bower-install': {
-                command: 'bower install'
+                command: 'bower install --allow-root'
             },
 
             ember: {


### PR DESCRIPTION
add --allow-root for the ESUDO error about using 'bower install' in docker