### PR TITLE
✨ display warnings after theme upload

### DIFF
--- a/app/components/modals/upload-theme.js
+++ b/app/components/modals/upload-theme.js
@@ -8,6 +8,7 @@ import {
 } from 'ghost-admin/services/ajax';
 import run from 'ember-runloop';
 import injectService from 'ember-service/inject';
+import get from 'ember-metal/get';
 
 export default ModalComponent.extend({
 
@@ -91,7 +92,14 @@ export default ModalComponent.extend({
         },
 
         uploadSuccess(response) {
-            this.set('theme', response.themes[0]);
+            let [theme] = response.themes;
+
+            this.set('theme', theme);
+
+            if (get(theme, 'warnings.length') > 0) {
+                this.set('validationWarnings', theme.warnings);
+            }
+
             // invoke the passed in confirm action
             invokeAction(this, 'model.uploadSuccess', this.get('theme'));
         },

--- a/app/templates/components/modals/upload-theme.hbs
+++ b/app/templates/components/modals/upload-theme.hbs
@@ -1,7 +1,11 @@
 <header class="modal-header">
     <h1>
         {{#if theme}}
-            Upload successful!
+            {{#if validationWarnings}}
+                Uploaded with warnings
+            {{else}}
+                Upload successful!
+            {{/if}}
         {{else if validationErrors}}
             Invalid theme
         {{else}}
@@ -13,10 +17,35 @@
 
 <div class="modal-body">
     {{#if theme}}
-        <p>
-            "{{themeName}}" uploaded successfully.
-            {{#if canActivateTheme}}Do you want to activate it now?{{/if}}
-        </p>
+        {{#if validationWarnings}}
+            <ul class="theme-validation-errors">
+                <li>
+                    <p>
+                        "{{themeName}}" uploaded successfully but some warnings were generated...
+                    </p>
+                </li>
+                {{#each validationWarnings as |error|}}
+                    <li>
+                        {{#if error.details}}
+                            {{{error.details}}}
+                        {{else}}
+                            {{{error.rule}}}
+                        {{/if}}
+
+                        <ul>
+                            {{#each error.failures as |failure|}}
+                                <li><code>{{failure.ref}}</code>{{#if failure.message}}: {{failure.message}}{{/if}}</li>
+                            {{/each}}
+                        </ul>
+                    </li>
+                {{/each}}
+            </ul>
+        {{else}}
+            <p>
+                "{{themeName}}" uploaded successfully.
+                {{#if canActivateTheme}}Do you want to activate it now?{{/if}}
+            </p>
+        {{/if}}
     {{else if displayOverwriteWarning}}
         <p>
             "{{fileThemeName}}" will overwrite an existing theme of the same name. Are you sure?


### PR DESCRIPTION
refs TryGhost/Ghost#7362, requires TryGhost/Ghost#7367
- display any gscan warnings we get back from a successful upload (very useful for the downgrade of missing `{{asset}}` helpers from an error to a warning)