### PR TITLE
Double default gravatar size

### DIFF
--- a/app/components/gh-profile-image.js
+++ b/app/components/gh-profile-image.js
@@ -24,7 +24,7 @@ import {isNotFoundError} from 'ember-ajax/errors';
  */
 export default Component.extend({
     email: '',
-    size: 90,
+    size: 180,
     debounce: 300,
 
     validEmail: '',


### PR DESCRIPTION
Gravatar images are horribly pixelated on retina screens due to being pulled by default at 90px size. This PR increases default size to 180px to provide better rendering, at minimal file-size increase.

before:
![image](https://cloud.githubusercontent.com/assets/120485/18608077/42b413a2-7cdf-11e6-8b9d-9af458f212a9.png)

after:
![image](https://cloud.githubusercontent.com/assets/120485/18608081/5b133d88-7cdf-11e6-8f8b-f8c646e46aba.png)
