### PR TITLE
Revert "Update ember-one-way-controls to version 1.1.1 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "ember-light-table": "0.1.9",
     "ember-load-initializers": "0.5.1",
     "ember-myth": "0.1.1",
-    "ember-one-way-controls": "1.1.1",
+    "ember-one-way-controls": "0.9.2",
     "ember-power-select": "0.10.11",
     "ember-resolver": "2.1.0",
     "ember-route-action-helper": "1.0.0",


### PR DESCRIPTION
Reverts TryGhost/Ghost-Admin#252

Using this version of `ember-one-way-controls` results in a bug that prevents the spacebar working when editing post titles.

I'm not sure if it's related to our own code or the addon but reverting to the known-working version for now.