### PR TITLE
✨ Ghost OAuth

### DIFF
--- a/app/authenticators/oauth2-ghost.js
+++ b/app/authenticators/oauth2-ghost.js
@@ -1,0 +1,41 @@
+/* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
+import Oauth2Authenticator from './oauth2';
+import computed from 'ember-computed';
+import RSVP from 'rsvp';
+import run from 'ember-runloop';
+import {assign} from 'ember-platform';
+import {isEmpty} from 'ember-utils';
+import {wrap} from 'ember-array/utils';
+
+export default Oauth2Authenticator.extend({
+    serverTokenEndpoint: computed('ghostPaths.apiRoot', function () {
+        return `${this.get('ghostPaths.apiRoot')}/authentication/ghost`;
+    }),
+
+    // TODO: all this is doing is changing the `data` structure, we should
+    // probably create our own token auth, maybe look at
+    // https://github.com/jpadilla/ember-simple-auth-token
+    authenticate(identification, password, scope = []) {
+        return new RSVP.Promise((resolve, reject) => {
+            // const data                = { 'grant_type': 'password', username: identification, password };
+            let data = identification;
+            let serverTokenEndpoint = this.get('serverTokenEndpoint');
+            let scopesString = wrap(scope).join(' ');
+            if (!isEmpty(scopesString)) {
+                data.scope = scopesString;
+            }
+            this.makeRequest(serverTokenEndpoint, data).then((response) => {
+                run(() => {
+                    let expiresAt = this._absolutizeExpirationTime(response.expires_in);
+                    this._scheduleAccessTokenRefresh(response.expires_in, expiresAt, response.refresh_token);
+                    if (!isEmpty(expiresAt)) {
+                        response = assign(response, {'expires_at': expiresAt});
+                    }
+                    resolve(response);
+                });
+            }, (xhr) => {
+                run(null, reject, xhr.responseJSON || xhr.responseText);
+            });
+        });
+    }
+});

--- a/app/controllers/signin.js
+++ b/app/controllers/signin.js
@@ -5,7 +5,6 @@ import injectController from 'ember-controller/inject';
 import {isEmberArray} from 'ember-array/utils';
 
 import {
-    VersionMismatchError,
     isVersionMismatchError
 } from 'ghost-admin/services/ajax';
 import ValidationEngine from 'ghost-admin/mixins/validation-engine';
@@ -15,55 +14,23 @@ export default Controller.extend(ValidationEngine, {
     loggingIn: false,
     authProperties: ['identification', 'password'],
 
+    ajax: injectService(),
+    application: injectController(),
+    config: injectService(),
     ghostPaths: injectService(),
     notifications: injectService(),
     session: injectService(),
-    application: injectController(),
-    ajax: injectService(),
+
     flowErrors: '',
 
     // ValidationEngine settings
     validationType: 'signin',
 
     actions: {
-        authenticate() {
+        validateAndAuthenticate() {
             let model = this.get('model');
             let authStrategy = 'authenticator:oauth2';
 
-            // Authentication transitions to posts.index, we can leave spinner running unless there is an error
-            this.get('session').authenticate(authStrategy, model.get('identification'), model.get('password')).catch((error) => {
-                this.toggleProperty('loggingIn');
-
-                if (error && error.errors) {
-                    // we don't get back an ember-data/ember-ajax error object
-                    // back so we need to pass in a null status in order to
-                    // test against the payload
-                    if (isVersionMismatchError(null, error)) {
-                        let versionMismatchError = new VersionMismatchError(error);
-                        return this.get('notifications').showAPIError(versionMismatchError);
-                    }
-
-                    error.errors.forEach((err) => {
-                        err.message = err.message.htmlSafe();
-                    });
-
-                    this.set('flowErrors', error.errors[0].message.string);
-
-                    if (error.errors[0].message.string.match(/user with that email/)) {
-                        this.get('model.errors').add('identification', '');
-                    }
-
-                    if (error.errors[0].message.string.match(/password is incorrect/)) {
-                        this.get('model.errors').add('password', '');
-                    }
-                } else {
-                    // Connection errors don't return proper status message, only req.body
-                    this.get('notifications').showAlert('There was a problem on the server.', {type: 'error', key: 'session.authenticate.failed'});
-                }
-            });
-        },
-
-        validateAndAuthenticate() {
             this.set('flowErrors', '');
             // Manually trigger events for input fields, ensuring legacy compatibility with
             // browsers and password managers that don't send proper events on autofill
@@ -73,7 +40,7 @@ export default Controller.extend(ValidationEngine, {
             this.get('hasValidated').addObjects(this.authProperties);
             this.validate({property: 'signin'}).then(() => {
                 this.toggleProperty('loggingIn');
-                this.send('authenticate');
+                this.send('authenticate', authStrategy, [model.get('identification'), model.get('password')]);
             }).catch(() => {
                 this.set('flowErrors', 'Please fill out the form to sign in.');
             });

--- a/app/controllers/team/user.js
+++ b/app/controllers/team/user.js
@@ -19,6 +19,7 @@ export default Controller.extend({
     _scratchTwitter: null,
 
     ajax: injectService(),
+    config: injectService(),
     dropdown: injectService(),
     ghostPaths: injectService(),
     notifications: injectService(),
@@ -48,6 +49,10 @@ export default Controller.extend({
             this.get('user.isAuthor')))) {
             return true;
         }
+    }),
+
+    canChangePassword: computed('config.ghostOAuth', 'isAdminUserOnOwnerProfile', function () {
+        return !this.get('config.ghostOAuth') && !this.get('isAdminUserOnOwnerProfile');
     }),
 
     // duplicated in gh-user-active -- find a better home and consolidate?

--- a/app/mirage/config/authentication.js
+++ b/app/mirage/config/authentication.js
@@ -36,6 +36,21 @@ export default function mockAuthentication(server) {
         }
     });
 
+    server.get('/authentication/invitation/', function (db, request) {
+        let {email} = request.queryParams;
+        let [invite] = db.invites.where({email});
+        let user = db.users.find(invite.created_by);
+        let valid = !!invite;
+        let invitedBy = user && user.name;
+
+        return {
+            invitation: [{
+                valid,
+                invitedBy
+            }]
+        };
+    });
+
     /* Setup ---------------------------------------------------------------- */
 
     server.post('/authentication/setup', function (db, request) {
@@ -68,6 +83,21 @@ export default function mockAuthentication(server) {
             setup: [
                 {status: true}
             ]
+        };
+    });
+
+    /* OAuth ---------------------------------------------------------------- */
+
+    server.post('/authentication/ghost', function (db) {
+        if (!db.users.length) {
+            let [role] = db.roles.where({name: 'Owner'});
+            server.create('user', {email: 'oauthtest@example.com', roles: [role]});
+        }
+
+        return {
+            access_token: '5JhTdKI7PpoZv4ROsFoERc6wCHALKFH5jxozwOOAErmUzWrFNARuH1q01TYTKeZkPW7FmV5MJ2fU00pg9sm4jtH3Z1LjCf8D6nNqLYCfFb2YEKyuvG7zHj4jZqSYVodN2YTCkcHv6k8oJ54QXzNTLIDMlCevkOebm5OjxGiJpafMxncm043q9u1QhdU9eee3zouGRMVVp8zkKVoo5zlGMi3zvS2XDpx7xsfk8hKHpUgd7EDDQxmMueifWv7hv6n',
+            expires_in: 3600,
+            refresh_token: 'XP13eDjwV5mxOcrq1jkIY9idhdvN3R1Br5vxYpYIub2P5Hdc8pdWMOGmwFyoUshiEB62JWHTl8H1kACJR18Z8aMXbnk5orG28br2kmVgtVZKqOSoiiWrQoeKTqrRV0t7ua8uY5HdDUaKpnYKyOdpagsSPn3WEj8op4vHctGL3svOWOjZhq6F2XeVPMR7YsbiwBE8fjT3VhTB3KRlBtWZd1rE0Qo2EtSplWyjGKv1liAEiL0ndQoLeeSOCH4rTP7'
         };
     });
 }

--- a/app/routes/setup.js
+++ b/app/routes/setup.js
@@ -11,20 +11,23 @@ export default Route.extend(styleBody, {
     ghostPaths: injectService(),
     session: injectService(),
     ajax: injectService(),
+    config: injectService(),
 
     // use the beforeModel hook to check to see whether or not setup has been
     // previously completed.  If it has, stop the transition into the setup page.
     beforeModel() {
         this._super(...arguments);
 
-        if (this.get('session.isAuthenticated')) {
+        // with OAuth auth users are authenticated on step 2 so we
+        // can't use the session.isAuthenticated shortcut
+        if (!this.get('config.ghostOAuth') && this.get('session.isAuthenticated')) {
             this.transitionTo(Configuration.routeIfAlreadyAuthenticated);
             return;
         }
 
         let authUrl = this.get('ghostPaths.url').api('authentication', 'setup');
 
-        // If user is not logged in, check the state of the setup process via the API
+        // check the state of the setup process via the API
         return this.get('ajax').request(authUrl)
             .then((result) => {
                 let [setup] = result.setup;

--- a/app/routes/setup/two.js
+++ b/app/routes/setup/two.js
@@ -1,52 +1,17 @@
 import Route from 'ember-route';
 import injectService from 'ember-service/inject';
-import EmberObject from 'ember-object';
-import styleBody from 'ghost-admin/mixins/style-body';
-import Configuration from 'ember-simple-auth/configuration';
-import DS from 'ember-data';
 import {
     VersionMismatchError,
     isVersionMismatchError
 } from 'ghost-admin/services/ajax';
 
-const {Errors} = DS;
-
-export default Route.extend(styleBody, {
-    titleToken: 'Sign In',
-
-    classNames: ['ghost-login'],
+export default Route.extend({
 
     session: injectService(),
     notifications: injectService(),
 
-    beforeModel() {
-        this._super(...arguments);
-
-        if (this.get('session.isAuthenticated')) {
-            this.transitionTo(Configuration.routeIfAlreadyAuthenticated);
-        }
-    },
-
-    model() {
-        return EmberObject.create({
-            identification: '',
-            password: '',
-            errors: Errors.create()
-        });
-    },
-
-    // the deactivate hook is called after a route has been exited.
-    deactivate() {
-        let controller = this.controllerFor('signin');
-
-        this._super(...arguments);
-
-        // clear the properties that hold the credentials when we're no longer on the signin screen
-        controller.set('model.identification', '');
-        controller.set('model.password', '');
-    },
-
     actions: {
+        // TODO: reduce duplication with setup/signin/signup routes
         authenticateWithGhostOrg() {
             let authStrategy = 'authenticator:oauth2-ghost';
 
@@ -54,7 +19,7 @@ export default Route.extend(styleBody, {
             this.set('controller.flowErrors', '');
 
             this.get('torii')
-                .open('ghost-oauth2', {type: 'signin'})
+                .open('ghost-oauth2', {type: 'setup'})
                 .then((authentication) => {
                     this.send('authenticate', authStrategy, [authentication]);
                 })
@@ -65,12 +30,16 @@ export default Route.extend(styleBody, {
         },
 
         authenticate(strategy, authentication) {
+            // we don't want to redirect after sign-in during setup
+            this.set('session.skipAuthSuccessHandler', true);
+
             // Authentication transitions to posts.index, we can leave spinner running unless there is an error
             this.get('session')
                 .authenticate(strategy, ...authentication)
+                .then(() => {
+                    this.get('controller.errors').remove('session');
+                })
                 .catch((error) => {
-                    this.toggleProperty('controller.loggingIn');
-
                     if (error && error.errors) {
                         // we don't get back an ember-data/ember-ajax error object
                         // back so we need to pass in a null status in order to
@@ -85,18 +54,13 @@ export default Route.extend(styleBody, {
                         });
 
                         this.set('controller.flowErrors', error.errors[0].message.string);
-
-                        if (error.errors[0].message.string.match(/user with that email/)) {
-                            this.get('controller.model.errors').add('identification', '');
-                        }
-
-                        if (error.errors[0].message.string.match(/password is incorrect/)) {
-                            this.get('controller.model.errors').add('password', '');
-                        }
                     } else {
                         // Connection errors don't return proper status message, only req.body
                         this.get('notifications').showAlert('There was a problem on the server.', {type: 'error', key: 'session.authenticate.failed'});
                     }
+                })
+                .finally(() => {
+                    this.toggleProperty('controller.loggingIn');
                 });
         }
     }

--- a/app/routes/signup.js
+++ b/app/routes/signup.js
@@ -2,6 +2,11 @@ import Route from 'ember-route';
 import RSVP from 'rsvp';
 import injectService from 'ember-service/inject';
 import EmberObject from 'ember-object';
+import {assign} from 'ember-platform';
+import {
+    VersionMismatchError,
+    isVersionMismatchError
+} from 'ghost-admin/services/ajax';
 
 import DS from 'ember-data';
 import Configuration from 'ember-simple-auth/configuration';
@@ -61,6 +66,8 @@ export default Route.extend(styleBody, {
                     return resolve(this.transitionTo('signin'));
                 }
 
+                model.set('invitedBy', response.invitation[0].invitedBy);
+
                 resolve(model);
             }).catch(() => {
                 resolve(model);
@@ -73,5 +80,64 @@ export default Route.extend(styleBody, {
 
         // clear the properties that hold the sensitive data from the controller
         this.controllerFor('signup').setProperties({email: '', password: '', token: ''});
+    },
+
+    actions: {
+        authenticateWithGhostOrg() {
+            let authStrategy = 'authenticator:oauth2-ghost';
+            let inviteToken = this.get('controller.model.token');
+            let email = this.get('controller.model.email');
+
+            this.toggleProperty('controller.loggingIn');
+            this.set('controller.flowErrors', '');
+
+            this.get('torii')
+                .open('ghost-oauth2', {email, type: 'invite'})
+                .then((authentication) => {
+                    let _authentication = assign({}, authentication, {inviteToken});
+                    this.send('authenticate', authStrategy, [_authentication]);
+                })
+                .catch(() => {
+                    this.toggleProperty('controller.loggingIn');
+                    this.set('controller.flowErrors', 'Authentication with Ghost.org denied or failed');
+                });
+        },
+
+        // TODO: this is duplicated with the signin route - maybe extract into a mixin?
+        authenticate(strategy, authentication) {
+            // Authentication transitions to posts.index, we can leave spinner running unless there is an error
+            this.get('session')
+                .authenticate(strategy, ...authentication)
+                .catch((error) => {
+                    this.toggleProperty('controller.loggingIn');
+
+                    if (error && error.errors) {
+                        // we don't get back an ember-data/ember-ajax error object
+                        // back so we need to pass in a null status in order to
+                        // test against the payload
+                        if (isVersionMismatchError(null, error)) {
+                            let versionMismatchError = new VersionMismatchError(error);
+                            return this.get('notifications').showAPIError(versionMismatchError);
+                        }
+
+                        error.errors.forEach((err) => {
+                            err.message = err.message.htmlSafe();
+                        });
+
+                        this.set('controller.flowErrors', error.errors[0].message.string);
+
+                        if (error.errors[0].message.string.match(/user with that email/)) {
+                            this.get('controller.model.errors').add('identification', '');
+                        }
+
+                        if (error.errors[0].message.string.match(/password is incorrect/)) {
+                            this.get('controller.model.errors').add('password', '');
+                        }
+                    } else {
+                        // Connection errors don't return proper status message, only req.body
+                        this.get('notifications').showAlert('There was a problem on the server.', {type: 'error', key: 'session.authenticate.failed'});
+                    }
+                });
+        }
     }
 });

--- a/app/services/config.js
+++ b/app/services/config.js
@@ -3,8 +3,9 @@ import Ember from 'ember';
 import Service from 'ember-service';
 import computed from 'ember-computed';
 import injectService from 'ember-service/inject';
+import {isBlank} from 'ember-utils';
 
-// ember-cli-shims doesn't export _ProxyMixin
+// ember-cli-shims doesn't export _ProxyMixin ot testing
 const {_ProxyMixin} = Ember;
 const {isNumeric} = $;
 
@@ -47,7 +48,7 @@ export default Service.extend(_ProxyMixin, {
         return config;
     }),
 
-    availableTimezones: computed(function() {
+    availableTimezones: computed(function () {
         let timezonesUrl = this.get('ghostPaths.url').api('configuration', 'timezones');
 
         return this.get('ajax').request(timezonesUrl).then((configTimezones) => {
@@ -57,5 +58,9 @@ export default Service.extend(_ProxyMixin, {
 
             return timezonesObj;
         });
+    }),
+
+    ghostOAuth: computed('ghostAuthId', function () {
+        return !isBlank(this.get('ghostAuthId'));
     })
 });

--- a/app/templates/components/modals/re-authenticate.hbs
+++ b/app/templates/components/modals/re-authenticate.hbs
@@ -4,12 +4,18 @@
 <a class="close icon-x" href="" title="Close" {{action "closeModal"}}><span class="hidden">Close</span></a>
 
 <div class="modal-body {{if authenticationError 'error'}}">
-    <form id="login" class="login-form" method="post" novalidate="novalidate" {{action "confirm" on="submit"}}>
-        {{#gh-validation-status-container class="password-wrap" errors=errors property="password" hasValidated=hasValidated}}
-            {{gh-input password class="password" type="password" placeholder="Password" name="password" update=(action (mut password))}}
-        {{/gh-validation-status-container}}
-        {{#gh-spin-button class="btn btn-blue" type="submit" submitting=submitting}}Log in{{/gh-spin-button}}
-   </form>
+
+    {{#if config.ghostOAuth}}
+        {{#gh-spin-button class="login btn btn-blue btn-block" type="submit" action="confirm" tabindex="3" submitting=loggingIn autoWidth="false"}}Sign in with Ghost{{/gh-spin-button}}
+    {{else}}
+        <form id="login" class="login-form" method="post" novalidate="novalidate" {{action "confirm" on="submit"}}>
+            {{#gh-validation-status-container class="password-wrap" errors=errors property="password" hasValidated=hasValidated}}
+                {{gh-input password class="password" type="password" placeholder="Password" name="password" update=(action (mut password))}}
+            {{/gh-validation-status-container}}
+            {{#gh-spin-button class="btn btn-blue" type="submit" submitting=submitting}}Log in{{/gh-spin-button}}
+        </form>
+    {{/if}}
+
    {{#if authenticationError}}
      <p class="response">{{authenticationError}}</p>
    {{/if}}

--- a/app/templates/setup/two.hbs
+++ b/app/templates/setup/two.hbs
@@ -1,44 +1,76 @@
-<header>
-    <h1>Create your account</h1>
-</header>
+{{#if config.ghostOAuth}}
+    <header>
+        <h1>Setup your blog</h1>
+    </header>
 
-<form id="setup" class="gh-flow-create">
-    {{!-- Horrible hack to prevent Chrome from incorrectly auto-filling inputs --}}
-    <input style="display:none;" type="text" name="fakeusernameremembered"/>
-    <input style="display:none;" type="password" name="fakepasswordremembered"/>
+    <form id="setup" class="gh-flow-create" {{action "setup" on="submit"}}>
+        {{#gh-form-group errors=errors hasValidated=hasValidated property="session"}}
+            {{#gh-spin-button class="login btn btn-blue btn-block" type="button" action="authenticateWithGhostOrg" tabindex="3" submitting=loggingIn autoWidth="false"}}
+                {{#if session.isAuthenticated}}
+                    Connected: {{session.user.email}}
+                {{else}}
+                    Sign in with Ghost
+                {{/if}}
+            {{/gh-spin-button}}
+            {{gh-error-message errors=errors property="session"}}
+        {{/gh-form-group}}
 
-    {{gh-profile-image fileStorage=config.fileStorage email=email setImage="setImage"}}
-    {{#gh-form-group errors=errors hasValidated=hasValidated property="email"}}
-        <label for="email-address">Email address</label>
-        <span class="input-icon icon-mail">
-            {{gh-trim-focus-input email tabindex="1" type="email" name="email" placeholder="Eg. john@example.com" autocorrect="off" focusOut=(action "preValidate" "email") update=(action (mut email))}}
-        </span>
-        {{gh-error-message errors=errors property="email"}}
-    {{/gh-form-group}}
-    {{#gh-form-group errors=errors hasValidated=hasValidated property="name"}}
-        <label for="full-name">Full name</label>
-        <span class="input-icon icon-user">
-            {{gh-input name tabindex="2" type="text" name="name" placeholder="Eg. John H. Watson"  autocorrect="off" focusOut=(action "preValidate" "name") update=(action (mut name))}}
-        </span>
-        {{gh-error-message errors=errors property="name"}}
-    {{/gh-form-group}}
-    {{#gh-form-group errors=errors hasValidated=hasValidated property="password"}}
-        <label for="password">Password</label>
-        <span class="input-icon icon-lock">
-            {{gh-input password tabindex="3" type="password" name="password" placeholder="At least 8 characters" autocorrect="off" focusOut=(action "preValidate" "password") update=(action (mut password))}}
-        </span>
-        {{gh-error-message errors=errors property="password"}}
-    {{/gh-form-group}}
-    {{#gh-form-group errors=errors hasValidated=hasValidated property="blogTitle"}}
-        <label for="blog-title">Blog title</label>
-        <span class="input-icon icon-content">
-            {{gh-input blogTitle tabindex="4" type="text" name="blog-title" placeholder="Eg. The Daily Awesome" autocorrect="off" focusOut=(action "preValidate" "blogTitle") update=(action (mut blogTitle))}}
-        </span>
-        {{gh-error-message errors=errors property="blogTitle"}}
-    {{/gh-form-group}}
-    {{#gh-spin-button type="submit" tabindex="5" class="btn btn-green btn-lg btn-block" action="setup" submitting=submitting autoWidth="false"}}
+        {{#gh-form-group errors=errors hasValidated=hasValidated property="blogTitle"}}
+            <label for="blog-title">Blog title</label>
+            <span class="input-icon icon-content">
+                {{gh-input blogTitle tabindex="4" type="text" name="blog-title" placeholder="Eg. The Daily Awesome" autocorrect="off" focusOut=(action "preValidate" "blogTitle") update=(action (mut blogTitle)) onenter=(action "setup")}}
+            </span>
+            {{gh-error-message errors=errors property="blogTitle"}}
+        {{/gh-form-group}}
+    </form>
+
+    {{#gh-spin-button type="submit" tabindex="5" class="btn btn-green btn-lg btn-block" action=(action 'setup') disabled=submitDisabled submitting=submitting autoWidth="false"}}
         Last step: Invite your team <i class="icon-chevron"></i>
     {{/gh-spin-button}}
-</form>
+{{else}}
+
+    <header>
+        <h1>Create your account</h1>
+    </header>
+
+    <form id="setup" class="gh-flow-create">
+        {{!-- Horrible hack to prevent Chrome from incorrectly auto-filling inputs --}}
+        <input style="display:none;" type="text" name="fakeusernameremembered"/>
+        <input style="display:none;" type="password" name="fakepasswordremembered"/>
+
+        {{gh-profile-image fileStorage=config.fileStorage email=email setImage="setImage"}}
+        {{#gh-form-group errors=errors hasValidated=hasValidated property="email"}}
+            <label for="email-address">Email address</label>
+            <span class="input-icon icon-mail">
+                {{gh-trim-focus-input email tabindex="1" type="email" name="email" placeholder="Eg. john@example.com" autocorrect="off" focusOut=(action "preValidate" "email") update=(action (mut email))}}
+            </span>
+            {{gh-error-message errors=errors property="email"}}
+        {{/gh-form-group}}
+        {{#gh-form-group errors=errors hasValidated=hasValidated property="name"}}
+            <label for="full-name">Full name</label>
+            <span class="input-icon icon-user">
+                {{gh-input name tabindex="2" type="text" name="name" placeholder="Eg. John H. Watson"  autocorrect="off" focusOut=(action "preValidate" "name") update=(action (mut name))}}
+            </span>
+            {{gh-error-message errors=errors property="name"}}
+        {{/gh-form-group}}
+        {{#gh-form-group errors=errors hasValidated=hasValidated property="password"}}
+            <label for="password">Password</label>
+            <span class="input-icon icon-lock">
+                {{gh-input password tabindex="3" type="password" name="password" placeholder="At least 8 characters" autocorrect="off" focusOut=(action "preValidate" "password") update=(action (mut password))}}
+            </span>
+            {{gh-error-message errors=errors property="password"}}
+        {{/gh-form-group}}
+        {{#gh-form-group errors=errors hasValidated=hasValidated property="blogTitle"}}
+            <label for="blog-title">Blog title</label>
+            <span class="input-icon icon-content">
+                {{gh-input blogTitle tabindex="4" type="text" name="blog-title" placeholder="Eg. The Daily Awesome" autocorrect="off" focusOut=(action "preValidate" "blogTitle") update=(action (mut blogTitle))}}
+            </span>
+            {{gh-error-message errors=errors property="blogTitle"}}
+        {{/gh-form-group}}
+        {{#gh-spin-button type="submit" tabindex="5" class="btn btn-green btn-lg btn-block" action="setup" submitting=submitting autoWidth="false"}}
+            Last step: Invite your team <i class="icon-chevron"></i>
+        {{/gh-spin-button}}
+    </form>
+{{/if}}
 
 <p class="main-error">{{{flowErrors}}}</p>

--- a/app/templates/signin.hbs
+++ b/app/templates/signin.hbs
@@ -1,19 +1,29 @@
 <div class="gh-flow">
     <div class="gh-flow-content-wrap">
         <section class="gh-flow-content">
+            {{#if config.ghostOAuth}}
+                <header>
+                    <h1>{{config.blogTitle}}</h1>
+                </header>
+            {{/if}}
+
             <form id="login" class="gh-signin" method="post" novalidate="novalidate">
-                {{#gh-form-group errors=model.errors hasValidated=hasValidated property="identification"}}
-                    <span class="input-icon icon-mail">
-                        {{gh-trim-focus-input model.identification class="email" type="email" placeholder="Email Address" name="identification" autocapitalize="off" autocorrect="off" tabindex="1" focusOut=(action "validate" "identification") update=(action (mut model.identification))}}
-                    </span>
-                {{/gh-form-group}}
-                {{#gh-form-group errors=model.errors hasValidated=hasValidated property="password"}}
-                    <span class="input-icon icon-lock forgotten-wrap">
-                        {{gh-input model.password class="password" type="password" placeholder="Password" name="password" tabindex="2" autocorrect="off" update=(action (mut model.password))}}
-                        {{#gh-spin-button class="forgotten-link btn btn-link" type="button" action="forgotten" tabindex="4" submitting=submitting autoWidth="true"}}Forgot?{{/gh-spin-button}}
-                    </span>
-                {{/gh-form-group}}
-                {{#gh-spin-button class="login btn btn-blue btn-block" type="submit" action="validateAndAuthenticate" tabindex="3" submitting=loggingIn autoWidth="false"}}Sign in{{/gh-spin-button}}
+                {{#if config.ghostOAuth}}
+                    {{#gh-spin-button class="login btn btn-blue btn-block" type="submit" action="authenticateWithGhostOrg" tabindex="3" submitting=loggingIn autoWidth="false"}}Sign in with Ghost{{/gh-spin-button}}
+                {{else}}
+                    {{#gh-form-group errors=model.errors hasValidated=hasValidated property="identification"}}
+                        <span class="input-icon icon-mail">
+                            {{gh-trim-focus-input model.identification class="email" type="email" placeholder="Email Address" name="identification" autocapitalize="off" autocorrect="off" tabindex="1" focusOut=(action "validate" "identification") update=(action (mut model.identification))}}
+                        </span>
+                    {{/gh-form-group}}
+                    {{#gh-form-group errors=model.errors hasValidated=hasValidated property="password"}}
+                        <span class="input-icon icon-lock forgotten-wrap">
+                            {{gh-input model.password class="password" type="password" placeholder="Password" name="password" tabindex="2" autocorrect="off" update=(action (mut model.password))}}
+                            {{#gh-spin-button class="forgotten-link btn btn-link" type="button" action="forgotten" tabindex="4" submitting=submitting autoWidth="true"}}Forgot?{{/gh-spin-button}}
+                        </span>
+                    {{/gh-form-group}}
+                    {{#gh-spin-button class="login btn btn-blue btn-block" type="submit" action="validateAndAuthenticate" tabindex="3" submitting=loggingIn autoWidth="false"}}Sign in{{/gh-spin-button}}
+                {{/if}}
             </form>
 
             <p class="main-error">{{{flowErrors}}}</p>

--- a/app/templates/signup.hbs
+++ b/app/templates/signup.hbs
@@ -2,42 +2,59 @@
 
     <div class="gh-flow-content-wrap">
         <section class="gh-flow-content">
-            <header>
-                <h1>Create your account</h1>
-            </header>
+            {{#if config.ghostOAuth}}
+                <header>
+                        <h1>{{config.blogTitle}}</h1>
+                        <p>
+                            {{!-- TODO: show invite creator's name/email --}}
+                            Accept your invite from <strong>{{model.invitedBy}}</strong>
+                        </p>
+                </header>
 
-            <form id="signup" class="gh-flow-create" method="post" novalidate="novalidate">
-                {{!-- Hack to stop Chrome's broken auto-fills --}}
-                <input style="display:none;" type="text" name="fakeusernameremembered"/>
-                <input style="display:none;" type="password" name="fakepasswordremembered"/>
+                <form id="signup" class="gh-signin" method="post" novalidate="novalidate">
+                    {{#gh-spin-button class="login btn btn-blue btn-block" type="submit" action="authenticateWithGhostOrg" tabindex="3" submitting=loggingIn autoWidth="false"}}
+                        Sign in with Ghost to accept
+                    {{/gh-spin-button}}
+                </form>
+            {{else}}
+                <header>
+                    <h1>Create your account</h1>
+                </header>
 
-                {{gh-profile-image fileStorage=config.fileStorage email=model.email setImage="setImage"}}
+                <form id="signup" class="gh-flow-create" method="post" novalidate="novalidate">
+                    {{!-- Hack to stop Chrome's broken auto-fills --}}
+                    <input style="display:none;" type="text" name="fakeusernameremembered"/>
+                    <input style="display:none;" type="password" name="fakepasswordremembered"/>
 
-                {{#gh-form-group}}
-                    <label for="email-address">Email address</label>
-                    <span class="input-icon icon-mail">
-                        {{gh-input model.email type="email" name="email" placeholder="Eg. john@example.com" disabled="disabled" autocorrect="off"}}
-                    </span>
-                {{/gh-form-group}}
+                    {{gh-profile-image fileStorage=config.fileStorage email=model.email setImage="setImage"}}
 
-                {{#gh-form-group errors=model.errors hasValidated=hasValidated property="name"}}
-                    <label for="full-name">Full name</label>
-                    <span class="input-icon icon-user">
-                        {{gh-trim-focus-input model.name tabindex="1" type="text" name="name" placeholder="Eg. John H. Watson" onenter=(action "signup") autocorrect="off" focusOut=(action "validate" "name") update=(action (mut model.name))}}
-                    </span>
-                    {{gh-error-message errors=model.errors property="name"}}
-                {{/gh-form-group}}
+                    {{#gh-form-group}}
+                        <label for="email-address">Email address</label>
+                        <span class="input-icon icon-mail">
+                            {{gh-input model.email type="email" name="email" placeholder="Eg. john@example.com" disabled="disabled" autocorrect="off"}}
+                        </span>
+                    {{/gh-form-group}}
 
-                {{#gh-form-group errors=model.errors hasValidated=hasValidated property="password"}}
-                    <label for="password">Password</label>
-                    <span class="input-icon icon-lock">
-                        {{gh-input model.password tabindex="2" type="password" name="password" placeholder="At least 8 characters" onenter=(action "signup") autocorrect="off" focusOut=(action "validate" "password") update=(action (mut model.password))}}
-                    </span>
-                    {{gh-error-message errors=model.errors property="password"}}
-                {{/gh-form-group}}
-            </form>
+                    {{#gh-form-group errors=model.errors hasValidated=hasValidated property="name"}}
+                        <label for="full-name">Full name</label>
+                        <span class="input-icon icon-user">
+                            {{gh-trim-focus-input model.name tabindex="1" type="text" name="name" placeholder="Eg. John H. Watson" onenter=(action "signup") autocorrect="off" focusOut=(action "validate" "name") update=(action (mut model.name))}}
+                        </span>
+                        {{gh-error-message errors=model.errors property="name"}}
+                    {{/gh-form-group}}
 
-            {{#gh-spin-button tabindex="3" type="submit" class="btn btn-green btn-lg btn-block" action="signup" submitting=submitting autoWidth="false"}}Create Account{{/gh-spin-button}}
+                    {{#gh-form-group errors=model.errors hasValidated=hasValidated property="password"}}
+                        <label for="password">Password</label>
+                        <span class="input-icon icon-lock">
+                            {{gh-input model.password tabindex="2" type="password" name="password" placeholder="At least 8 characters" onenter=(action "signup") autocorrect="off" focusOut=(action "validate" "password") update=(action (mut model.password))}}
+                        </span>
+                        {{gh-error-message errors=model.errors property="password"}}
+                    {{/gh-form-group}}
+                </form>
+
+                {{#gh-spin-button tabindex="3" type="submit" class="btn btn-green btn-lg btn-block" action="signup" submitting=submitting autoWidth="false"}}Create Account{{/gh-spin-button}}
+            {{/if}}
+
             <p class="main-error">{{{flowErrors}}}</p>
         </section>
     </div>

--- a/app/templates/team/user.hbs
+++ b/app/templates/team/user.hbs
@@ -171,9 +171,10 @@
             </fieldset>
 
         </form> {{! user details form }}
-        <form class="user-profile" novalidate="novalidate" autocomplete="off" {{action (perform user.saveNewPassword) on="submit"}}>
-            {{!-- If an administrator is viewing Owner's profile then hide inputs for change password --}}
-            {{#unless isAdminUserOnOwnerProfile}}
+
+        {{!-- If an administrator is viewing Owner's profile or we're using Ghost.org OAuth then hide inputs for change password --}}
+        {{#if canChangePassword}}
+            <form id="password-reset" class="user-profile" novalidate="novalidate" autocomplete="off" {{action (perform user.saveNewPassword) on="submit"}}>
                 <fieldset>
                     {{#unless isNotOwnProfile}}
                         {{#gh-form-group errors=user.errors hasValidated=user.hasValidated property="password"}}
@@ -199,7 +200,7 @@
                         {{#gh-task-button class="btn btn-red button-change-password" task=user.saveNewPassword}}Change Password{{/gh-task-button}}
                     </div>
                 </fieldset>
-            {{/unless}}
-        </form> {{! change password form }}
+            </form> {{! change password form }}
+        {{/if}}
     </div>
 </section>

--- a/app/torii-providers/ghost-oauth2.js
+++ b/app/torii-providers/ghost-oauth2.js
@@ -1,0 +1,33 @@
+import Oauth2 from 'torii/providers/oauth2-code';
+import injectService from 'ember-service/inject';
+import computed from 'ember-computed';
+
+let GhostOauth2 = Oauth2.extend({
+
+    config: injectService(),
+
+    name:    'ghost-oauth2',
+    baseUrl: 'http://devauth.ghost.org:8080/oauth2/authorize',
+    apiKey: computed(function () {
+        return this.get('config.ghostAuthId');
+    }),
+
+    optionalUrlParams: ['type', 'email'],
+
+    responseParams: ['code'],
+
+    // we want to redirect to the ghost admin app by default
+    redirectUri: window.location.href.replace(/(\/ghost)(.*)/, '$1/'),
+
+    open(options) {
+        if (options.type) {
+            this.set('type', options.type);
+        }
+        if (options.email) {
+            this.set('email', options.email);
+        }
+        return this._super(...arguments);
+    }
+});
+
+export default GhostOauth2;

--- a/app/validators/new-user.js
+++ b/app/validators/new-user.js
@@ -4,16 +4,22 @@ export default BaseValidator.extend({
     properties: ['name', 'email', 'password'],
 
     name(model) {
+        let usingOAuth = model.get('config.ghostOAuth');
         let name = model.get('name');
 
-        if (!validator.isLength(name, 1)) {
+        if (!usingOAuth && !validator.isLength(name, 1)) {
             model.get('errors').add('name', 'Please enter a name.');
             this.invalidate();
         }
     },
 
     email(model) {
+        let usingOAuth = model.get('config.ghostOAuth');
         let email = model.get('email');
+
+        if (usingOAuth) {
+            return;
+        }
 
         if (validator.empty(email)) {
             model.get('errors').add('email', 'Please enter an email.');
@@ -25,9 +31,10 @@ export default BaseValidator.extend({
     },
 
     password(model) {
+        let usingOAuth = model.get('config.ghostOAuth');
         let password = model.get('password');
 
-        if (!validator.isLength(password, 8)) {
+        if (!usingOAuth && !validator.isLength(password, 8)) {
             model.get('errors').add('password', 'Password must be at least 8 characters long');
             this.invalidate();
         }

--- a/app/validators/setup.js
+++ b/app/validators/setup.js
@@ -1,13 +1,24 @@
 import NewUserValidator from 'ghost-admin/validators/new-user';
 
 export default NewUserValidator.create({
-    properties: ['name', 'email', 'password', 'blogTitle'],
+    properties: ['name', 'email', 'password', 'blogTitle', 'session'],
 
     blogTitle(model) {
         let blogTitle = model.get('blogTitle');
 
         if (!validator.isLength(blogTitle, 1)) {
             model.get('errors').add('blogTitle', 'Please enter a blog title.');
+            this.invalidate();
+        }
+    },
+
+    session(model) {
+        let usingOAuth = model.get('config.ghostOAuth');
+        let isAuthenticated = model.get('session.isAuthenticated');
+
+        if (usingOAuth && !isAuthenticated) {
+            model.get('errors').add('session', 'Please connect a Ghost.org account before continuing');
+            model.get('hasValidated').pushObject('session');
             this.invalidate();
         }
     }

--- a/config/environment.js
+++ b/config/environment.js
@@ -35,6 +35,10 @@ module.exports = function (environment) {
             authenticationRoute: 'signin',
             routeAfterAuthentication: 'posts',
             routeIfAlreadyAuthenticated: 'posts'
+        },
+
+        torii: {
+            
         }
     };
 

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "moment-timezone": "0.5.5",
     "password-generator": "2.0.2",
     "top-gh-contribs": "2.0.4",
+    "torii": "0.8.0",
     "walk-sync": "0.3.1"
   },
   "ember-addon": {

--- a/tests/acceptance/signin-test.js
+++ b/tests/acceptance/signin-test.js
@@ -11,6 +11,10 @@ import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
 import { invalidateSession, authenticateSession } from 'ghost-admin/tests/helpers/ember-simple-auth';
 import Mirage from 'ember-cli-mirage';
+import {
+    stubSuccessfulOAuthConnect,
+    stubFailedOAuthConnect
+} from 'ghost-admin/tests/helpers/oauth';
 
 describe('Acceptance: Signin', function() {
     let application;
@@ -126,6 +130,56 @@ describe('Acceptance: Signin', function() {
 
             andThen(() => {
                 expect(currentURL(), 'currentURL').to.equal('/');
+            });
+        });
+    });
+
+    describe('using Ghost OAuth', function () {
+        beforeEach(function () {
+            // simulate active oauth config
+            $('head').append('<meta name="env-ghostAuthId" content="6e0704b3-c653-4c12-8da7-584232b5c629" />');
+        });
+
+        afterEach(function () {
+            // ensure we don't leak OAuth config to other tests
+            $('meta[name="env-ghostAuthId"]').remove();
+        });
+
+        it('can sign in successfully', function () {
+            server.loadFixtures('roles');
+            stubSuccessfulOAuthConnect(application);
+
+            visit('/signin');
+
+            andThen(() => {
+                expect(currentURL(), 'current url').to.equal('/signin');
+
+                expect(
+                    find('button.login').text().trim(),
+                    'login button text'
+                ).to.equal('Sign in with Ghost');
+            });
+
+            click('button.login');
+
+            andThen(() => {
+                expect(currentURL(), 'url after connect').to.equal('/');
+            });
+        });
+
+        it('handles a failed connect', function () {
+            stubFailedOAuthConnect(application);
+
+            visit('/signin');
+            click('button.login');
+
+            andThen(() => {
+                expect(currentURL(), 'current url').to.equal('/signin');
+
+                expect(
+                    find('.main-error').text().trim(),
+                    'sign-in error'
+                ).to.match(/Authentication with Ghost\.org denied or failed/i);
             });
         });
     });

--- a/tests/acceptance/team-test.js
+++ b/tests/acceptance/team-test.js
@@ -716,6 +716,44 @@ describe('Acceptance: Team', function () {
             });
         });
 
+        describe('using Ghost OAuth', function () {
+            beforeEach(function () {
+                // simulate active oauth config
+                $('head').append('<meta name="env-ghostAuthId" content="6e0704b3-c653-4c12-8da7-584232b5c629" />');
+
+                server.loadFixtures();
+            });
+
+            afterEach(function () {
+                // ensure we don't leak OAuth config to other tests
+                $('meta[name="env-ghostAuthId"]').remove();
+            });
+
+            it('doesn\'t show the password reset form', function () {
+                visit(`/team/${admin.slug}`);
+
+                andThen(() => {
+                    // ensure that the normal form is displayed so we don't get
+                    // false positives
+                    expect(
+                        find('input#user-slug').length,
+                        'profile form is displayed'
+                    ).to.equal(1);
+
+                    // check that the password form is hidden
+                    expect(
+                        find('#password-reset').length,
+                        'presence of password reset form'
+                    ).to.equal(0);
+
+                    expect(
+                        find('#user-password-new').length,
+                        'presence of new password field'
+                    ).to.equal(0);
+                });
+            });
+        });
+
         describe('own user', function () {
             beforeEach(function () {
                 server.loadFixtures();

--- a/tests/helpers/oauth.js
+++ b/tests/helpers/oauth.js
@@ -1,0 +1,39 @@
+import {faker} from 'ember-cli-mirage';
+import RSVP from 'rsvp';
+
+let generateCode = function generateCode() {
+    return faker.internet.password(32, false, /[a-zA-Z0-9]/);
+};
+
+let generateSecret = function generateSecret() {
+    return faker.internet.password(12, false, /[a-f0-9]/);
+};
+
+const stubSuccessfulOAuthConnect = function stubSuccessfulOAuthConnect(application) {
+    let provider = application.__container__.lookup('torii-provider:ghost-oauth2');
+
+    provider.open = function () {
+        return RSVP.Promise.resolve({
+            /* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
+            authorizationCode: generateCode(),
+            client_id: 'ghost-admin',
+            client_secret: generateSecret(),
+            provider: 'ghost-oauth2',
+            redirectUrl: 'http://localhost:2368/ghost/'
+            /* jscs:enable requireCamelCaseOrUpperCaseIdentifiers */
+        });
+    };
+};
+
+const stubFailedOAuthConnect = function stubFailedOAuthConnect(application) {
+    let provider = application.__container__.lookup('torii-provider:ghost-oauth2');
+
+    provider.open = function () {
+        return RSVP.Promise.reject();
+    };
+};
+
+export {
+    stubSuccessfulOAuthConnect,
+    stubFailedOAuthConnect
+};

--- a/tests/index.html
+++ b/tests/index.html
@@ -17,6 +17,7 @@
     <meta name="env-routeKeywords" content="{&quot;tag&quot;:&quot;tag&quot;,&quot;author&quot;:&quot;author&quot;,&quot;page&quot;:&quot;page&quot;,&quot;preview&quot;:&quot;p&quot;,&quot;private&quot;:&quot;private&quot;}" />
     <meta name="env-clientId" content="ghost-admin" />
     <meta name="env-clientSecret" content="5076dc643873" />
+    <!-- <meta name="env-ghostAuthId" content="6e0704b3-c653-4c12-8da7-584232b5c629" /> -->
 
     <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
     <link rel="stylesheet" href="{{rootURL}}assets/ghost.css">

--- a/tests/integration/components/gh-theme-table-test.js
+++ b/tests/integration/components/gh-theme-table-test.js
@@ -185,8 +185,6 @@ describeComponent(
                 return $(name).text().trim();
             }).toArray();
 
-            console.log(packageNames);
-
             expect(
                 packageNames,
                 'themes are ordered by label, folder names shown for duplicates'


### PR DESCRIPTION
issue TryGhost/Ghost#7452, requires TryGhost/Ghost#7451
- use a `ghostOAuth` config flag to switch between the old-style per-install auth and centralized OAuth auth based on config provided by the server
- add OAuth flows for:
  - setup
  - sign-in
  - sign-up
  - re-authentication
- add custom `oauth-ghost` authenticator to support our custom data structure
- add test helpers to stub successful/failed oauth authentication
- hide change password form if using OAuth (temporary - a way to change password via oauth provider will be added later)

TODO:
- [x] remove hardcoded config value once it's available from the server
- [x] add tests for patronus flows
  - [x] setup
  - [x] sign-in
  - [x] sign-up
- [x] 🐛 submitting setup without connecting OAuth account throws error rather than displaying in-line errors
- [x] hide change password forms when using OAuth
  - [x] tests
- [x] display name/email of user who created the invite when signing up (requires change on server-side to function correctly)
- [x] update re-authentication modal to show OAuth connect button