### PR TITLE
deps: ember-ajax@2.5.1

### DIFF
--- a/app/controllers/setup/two.js
+++ b/app/controllers/setup/two.js
@@ -2,7 +2,7 @@ import Controller from 'ember-controller';
 import RSVP from 'rsvp';
 import injectService from 'ember-service/inject';
 import injectController from 'ember-controller/inject';
-import {isEmberArray} from 'ember-array/utils';
+import {isInvalidError} from 'ember-ajax/errors';
 
 import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 
@@ -56,7 +56,7 @@ export default Controller.extend(ValidationEngine, {
     _handleSaveError(resp) {
         this.toggleProperty('submitting');
 
-        if (resp && resp.errors && isEmberArray(resp.errors)) {
+        if (isInvalidError(resp)) {
             this.set('flowErrors', resp.errors[0].message);
         } else {
             this.get('notifications').showAPIError(resp, {key: 'setup.blog-details'});

--- a/app/services/ajax.js
+++ b/app/services/ajax.js
@@ -148,15 +148,17 @@ export default AjaxService.extend({
         if (payload && typeof payload === 'object') {
             payload.errors = payload.error || payload.errors || payload.message || undefined;
 
-            if (isEmberArray(payload.errors)) {
-                payload.errors = payload.errors.map(function(error) {
-                    if (typeof error === 'string') {
-                        return {message: error};
-                    } else {
-                        return error;
-                    }
-                });
+            if (!isEmberArray(payload.errors)) {
+                payload.errors = [payload.errors];
             }
+
+            payload.errors = payload.errors.map(function(error) {
+                if (typeof error === 'string') {
+                    return {message: error};
+                } else {
+                    return error;
+                }
+            });
         }
 
         return this._super(status, headers, payload);

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "chalk": "1.1.3",
     "codemirror": "5.18.2",
     "csscomb": "3.1.8",
-    "ember-ajax": "2.4.1",
+    "ember-ajax": "2.5.1",
     "ember-cli": "2.7.0",
     "ember-cli-app-version": "2.0.0",
     "ember-cli-babel": "5.1.10",

--- a/tests/integration/services/ajax-test.js
+++ b/tests/integration/services/ajax-test.js
@@ -64,7 +64,8 @@ describeModule(
             ajax.request('/test/').then(() => {
                 expect(false).to.be.true();
             }).catch((error) => {
-                expect(error.errors).to.equal('Test Error');
+                expect(error.errors.length).to.equal(1);
+                expect(error.errors[0].message).to.equal('Test Error');
                 done();
             });
         });
@@ -78,7 +79,8 @@ describeModule(
             ajax.request('/test/').then(() => {
                 expect(false).to.be.true();
             }).catch((error) => {
-                expect(error.errors).to.equal('Test Error');
+                expect(error.errors.length).to.equal(1);
+                expect(error.errors[0].message).to.equal('Test Error');
                 done();
             });
         });
@@ -92,10 +94,9 @@ describeModule(
             ajax.request('/test/').then(() => {
                 expect(false).to.be.true();
             }).catch((error) => {
-                expect(error.errors).to.deep.equal([
-                    {message: 'First Error'},
-                    {message: 'Second Error'}
-                ]);
+                expect(error.errors.length).to.equal(2);
+                expect(error.errors[0].message).to.equal('First Error');
+                expect(error.errors[1].message).to.equal('Second Error');
                 done();
             });
         });


### PR DESCRIPTION
no issue
- update ember-ajax to 2.5.1
- replace custom error checking in setup/two with ember-ajax's `isInvalidError`
- update error normalisation and associated parsing tests to ensure all error types result in the same object structure