### PR TITLE
LTS backport: Safari doesn't show dragged-over state for file uploads (#288)

### DIFF
--- a/app/components/gh-file-uploader.js
+++ b/app/components/gh-file-uploader.js
@@ -108,7 +108,7 @@ export default Component.extend({
         event.stopPropagation();
         event.preventDefault();
 
-        this.set('dragClass', '--drag-over');
+        this.set('dragClass', '-drag-over');
     },
 
     dragLeave(event) {

--- a/app/components/gh-image-uploader.js
+++ b/app/components/gh-image-uploader.js
@@ -101,7 +101,7 @@ export default Component.extend({
         event.preventDefault();
 
         if (showUploadForm) {
-            this.set('dragClass', '--drag-over');
+            this.set('dragClass', '-drag-over');
         }
     },
 

--- a/app/styles/components/settings-menu.css
+++ b/app/styles/components/settings-menu.css
@@ -114,7 +114,7 @@
     padding: 35px 45px;
 }
 
-.settings-menu-content .gh-image-uploader.--with-image {
+.settings-menu-content .gh-image-uploader.-with-image {
     margin-top: 0;
     min-height: 50px;
     max-height: 250px;

--- a/app/styles/components/uploader.css
+++ b/app/styles/components/uploader.css
@@ -16,11 +16,11 @@
     text-align: center;
 }
 
-.gh-image-uploader.--drag-over {
+.gh-image-uploader.-drag-over {
     border: 2px solid;
 }
 
-.gh-image-uploader.--with-image {
+.gh-image-uploader.-with-image {
     background: rgba(0, 0, 0, 0.1);
     border-radius: 2px;
 }

--- a/app/templates/components/gh-image-uploader-with-preview.hbs
+++ b/app/templates/components/gh-image-uploader-with-preview.hbs
@@ -1,5 +1,5 @@
 {{#if image}}
-    <div class="gh-image-uploader --with-image">
+    <div class="gh-image-uploader -with-image">
         <div><img src={{image}}></div>
         <a class="image-cancel icon-trash" title="Delete" {{action remove}}>
             <span class="hidden">Delete</span>

--- a/app/templates/components/modals/upload-image.hbs
+++ b/app/templates/components/modals/upload-image.hbs
@@ -1,6 +1,6 @@
 <div class="modal-body">
     {{#if url}}
-        <div class="gh-image-uploader --with-image">
+        <div class="gh-image-uploader -with-image">
             <div><img src={{url}}></div>
             <a class="image-cancel icon-trash" title="Delete" {{action 'removeImage'}}>
                 <span class="hidden">Delete</span>

--- a/tests/integration/components/gh-file-uploader-test.js
+++ b/tests/integration/components/gh-file-uploader-test.js
@@ -334,13 +334,13 @@ describeComponent(
                 this.$('.gh-image-uploader').trigger(dragover);
             });
 
-            expect(this.$('.gh-image-uploader').hasClass('--drag-over'), 'has drag-over class').to.be.true;
+            expect(this.$('.gh-image-uploader').hasClass('-drag-over'), 'has drag-over class').to.be.true;
 
             run(() => {
                 this.$('.gh-image-uploader').trigger('dragleave');
             });
 
-            expect(this.$('.gh-image-uploader').hasClass('--drag-over'), 'has drag-over class').to.be.false;
+            expect(this.$('.gh-image-uploader').hasClass('-drag-over'), 'has drag-over class').to.be.false;
         });
 
         it('triggers file upload on file drop', function (done) {

--- a/tests/integration/components/gh-image-uploader-test.js
+++ b/tests/integration/components/gh-image-uploader-test.js
@@ -406,13 +406,13 @@ describeComponent(
                     this.$('.gh-image-uploader').trigger(dragover);
                 });
 
-                expect(this.$('.gh-image-uploader').hasClass('--drag-over'), 'has drag-over class').to.be.true;
+                expect(this.$('.gh-image-uploader').hasClass('-drag-over'), 'has drag-over class').to.be.true;
 
                 run(() => {
                     this.$('.gh-image-uploader').trigger('dragleave');
                 });
 
-                expect(this.$('.gh-image-uploader').hasClass('--drag-over'), 'has drag-over class').to.be.false;
+                expect(this.$('.gh-image-uploader').hasClass('-drag-over'), 'has drag-over class').to.be.false;
             });
 
             it('triggers file upload on file drop', function (done) {

--- a/tests/integration/components/gh-image-uploader-with-preview-test.js
+++ b/tests/integration/components/gh-image-uploader-with-preview-test.js
@@ -20,7 +20,7 @@ describeComponent(
 
             this.render(hbs`{{gh-image-uploader-with-preview image=image}}`);
 
-            expect(this.$('.gh-image-uploader.--with-image').length).to.equal(1);
+            expect(this.$('.gh-image-uploader.-with-image').length).to.equal(1);
             expect(this.$('img').attr('src')).to.equal('http://example.com/test.png');
         });
 


### PR DESCRIPTION
closes TryGhost/Ghost#7310
- Removes double dashes from modifier classes as safari won’t allow this.