### PR TITLE
🛠 Make greenkeeper ignore grunt dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,5 +99,16 @@
     "paths": [
       "lib/asset-delivery"
     ]
+  },
+  "greenkeeper": {
+    "ignore": [
+      "grunt",
+      "grunt-bg-shell",
+      "grunt-contrib-clean",
+      "grunt-contrib-jshint",
+      "grunt-contrib-watch",
+      "grunt-jscs",
+      "grunt-shell"
+    ]
   }
 }


### PR DESCRIPTION
No need to ignore/ping these on the lts branch as greenkeeper doesn't run on that branch. However, it seems smart to shove this into the package.json so that we don't get bugged by greenkeeper about grunt stuff now we're moving away from it.

closes #290

- We're moving away from grunt, so lets not worry about version bumps for now