### PR TITLE
Long theme names break themes table layout

### DIFF
--- a/app/styles/layouts/settings.css
+++ b/app/styles/layouts/settings.css
@@ -190,7 +190,6 @@
 .theme-list-item-body .name {
     display: inline-block;
     color: var(--darkgrey);
-    white-space: nowrap;
     font-weight: 400;
     user-select: all;
 }
@@ -201,9 +200,15 @@
 }
 
 .theme-list-item-body {
-    flex: 1 1 auto;
+    flex: 1;
     align-items: stretch;
     line-height: 1;
+}
+
+.theme-list-item-aside {
+    flex: 1;
+    display: flex;
+    justify-content: flex-end;
 }
 
 .theme-list-action:last-child {


### PR DESCRIPTION
# Why?

In reference to [#7373](https://github.com/TryGhost/Ghost/issues/7373)

When adding long theme names the theme layout is broken. Ew!
# What Changed?
- Removed `white-space: nowrap;' to the theme name container to allow breaking.
- Added `flex: 1;` to sibling elements (`.theme-list-item-body` and `.theme-list-item-aside`)
- Aligned links inside `.theme-list-item-aside` to the right. 
# Examples

Desktop 
![c05c14aa-80fc-11e6-9b34-71a9e21ea81b](https://cloud.githubusercontent.com/assets/1138619/19089884/b172f78a-8a41-11e6-8884-b979903af856.png)

Mobile
![5ed8148e-8108-11e6-8a09-6e579e6d62d1](https://cloud.githubusercontent.com/assets/1138619/19089891/b53f22b2-8a41-11e6-8030-6d8370246592.png)
