### PR TITLE
🎨  Change asset path to /ghost/assets

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -216,7 +216,7 @@ module.exports = function(grunt) {
         ).then(function (results) {
             var contributors = mergeContribs(results[1], results[2]),
                 contributorTemplate = '<article>\n    <a href="<%= githubUrl %>" title="<%= name %>">\n' +
-                    '        <img src="{{gh-path "admin" "/img/contributors"}}/<%= name %>" alt="<%= name %>" />\n' +
+                    '        <img src="{{gh-path "asset" "/img/contributors"}}/<%= name %>" alt="<%= name %>" />\n' +
                     '    </a>\n</article>',
 
                 downloadImagePromise = function (url, name) {

--- a/app/components/gh-cm-editor.js
+++ b/app/components/gh-cm-editor.js
@@ -25,9 +25,9 @@ const CmEditorComponent =  Component.extend(InvokeActionMixin, {
     didInsertElement() {
         this._super(...arguments);
 
-        this.get('lazyLoader').loadStyle('codemirror', 'codemirror/codemirror.css');
+        this.get('lazyLoader').loadStyle('codemirror', 'assets/codemirror/codemirror.css');
 
-        this.get('lazyLoader').loadScript('codemirror', 'codemirror/codemirror.js').then(() => {
+        this.get('lazyLoader').loadScript('codemirror', 'assets/codemirror/codemirror.js').then(() => {
             scheduleOnce('afterRender', this, function () {
                 this._initCodeMirror();
             });

--- a/app/helpers/gh-path.js
+++ b/app/helpers/gh-path.js
@@ -7,7 +7,7 @@ import ghostPaths from 'ghost-admin/utils/ghost-paths';
 // {{gh-path}} or {{gh-path 'blog'}} for Ghost's root (/myblog/)
 // {{gh-path 'admin'}} for Ghost's admin root (/myblog/ghost/)
 // {{gh-path 'api'}} for Ghost's api root (/myblog/ghost/api/v0.1/)
-// {{gh-path 'admin' '/assets/hi.png'}} for resolved url (/myblog/ghost/assets/hi.png)
+// {{gh-path 'asset' '/img/hi.png'}} for resolved url (/myblog/ghost/assets/img/hi.png)
 
 export default helper(function (params) {
     let paths = ghostPaths();
@@ -18,7 +18,7 @@ export default helper(function (params) {
         path = 'blog';
     }
 
-    if (!/^(blog|admin|api)$/.test(path)) {
+    if (!/^(blog|admin|asset|api)$/.test(path)) {
         url = path;
         path = 'blog';
     }
@@ -29,6 +29,9 @@ export default helper(function (params) {
             break;
         case 'admin':
             base = paths.adminRoot;
+            break;
+        case 'asset':
+            base = paths.assetRoot;
             break;
         case 'api':
             base = paths.apiRoot;

--- a/app/templates/about.hbs
+++ b/app/templates/about.hbs
@@ -4,7 +4,7 @@
     </header>
     <section class="view-content">
         <header class="gh-about-header">
-            <img class="gh-logo" src="{{gh-path 'admin' '/img/ghost-logo.png'}}" alt="Ghost" />
+            <img class="gh-logo" src="{{gh-path 'asset' '/img/ghost-logo.png'}}" alt="Ghost" />
         </header>
 
         {{gh-upgrade-notification}}

--- a/app/templates/error.hbs
+++ b/app/templates/error.hbs
@@ -1,7 +1,7 @@
 <div class="gh-view">
     <section class="error-content error-404 js-error-container">
         <section class="error-details">
-             <img class="error-ghost" src="{{gh-path 'admin' '/img/404-ghost@2x.png'}}" srcset="{{gh-path 'admin' '/img/404-ghost.png'}} 1x, {{gh-path 'admin' '/img/404-ghost@2x.png'}} 2x" />
+             <img class="error-ghost" src="{{gh-path 'asset' '/img/404-ghost@2x.png'}}" srcset="{{gh-path 'asset' '/img/404-ghost.png'}} 1x, {{gh-path 'asset' '/img/404-ghost@2x.png'}} 2x" />
              <section class="error-message">
                  <h1 class="error-code">{{code}}</h1>
                  <h2 class="error-description">{{message}}</h2>

--- a/app/templates/settings/apps/index.hbs
+++ b/app/templates/settings/apps/index.hbs
@@ -10,7 +10,7 @@
                 {{#link-to "settings.apps.slack" id="slack-link"}}
                 <article class="apps-card-app">
                     <div class="apps-card-content">
-                        <figure class="apps-card-app-icon" style="background-image:url({{gh-path 'admin' '/img/slackicon.png'}})"></figure>
+                        <figure class="apps-card-app-icon" style="background-image:url({{gh-path 'asset' '/img/slackicon.png'}})"></figure>
                         <div class="apps-card-meta">
                             <h3 class="apps-card-app-title">Slack</h3>
                             <p class="apps-card-app-desc">A team communication tool</p>

--- a/app/templates/settings/apps/slack.hbs
+++ b/app/templates/settings/apps/slack.hbs
@@ -10,7 +10,7 @@
     <section class="view-content">
         <section class="app-grid">
             <div class="app-cell">
-                <img class="app-icon" src="{{gh-path 'admin' '/img/slackicon.png'}}" />
+                <img class="app-icon" src="{{gh-path 'asset' '/img/slackicon.png'}}" />
             </div>
             <div class="app-cell">
                 <h3>Slack</h3>

--- a/app/templates/setup/one.hbs
+++ b/app/templates/setup/one.hbs
@@ -4,7 +4,7 @@
 </header>
 
 <figure class="gh-flow-screenshot">
-    <img src="{{gh-path 'admin' 'img/install-welcome.png'}}" alt="Ghost screenshot" />
+    <img src="{{gh-path 'asset' 'img/install-welcome.png'}}" alt="Ghost screenshot" />
 </figure>
 
 {{#link-to "setup.two" classNames="btn btn-green btn-lg"}}

--- a/app/templates/setup/three.hbs
+++ b/app/templates/setup/three.hbs
@@ -3,7 +3,7 @@
     <p>Ghost works best when shared with others. Collaborate, get feedback on your posts &amp; work together on ideas.</p>
 </header>
 
-<div><img class="gh-flow-faces" src="{{gh-path 'admin' 'img/users.png'}}" alt="" /></div>
+<div><img class="gh-flow-faces" src="{{gh-path 'asset' 'img/users.png'}}" alt="" /></div>
 
 <form class="gh-flow-invite">
     {{#gh-form-group errors=errors hasValidated=hasValidated property="users"}}

--- a/app/utils/ghost-paths.js
+++ b/app/utils/ghost-paths.js
@@ -17,6 +17,7 @@ export default function () {
     let path = window.location.pathname;
     let subdir = path.substr(0, path.search('/ghost/'));
     let adminRoot = `${subdir}/ghost/`;
+    let assetRoot = `${subdir}/ghost/assets/`;
     let apiRoot = `${subdir}/ghost/api/v0.1`;
 
     function assetUrl(src) {
@@ -25,6 +26,7 @@ export default function () {
 
     return {
         adminRoot,
+        assetRoot,
         apiRoot,
         subdir,
         blogRoot: `${subdir}/`,

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -42,7 +42,8 @@ codemirrorAssets = function () {
                 var jsTree = concat(tree, {
                     outputFile: 'assets/codemirror/codemirror.js',
                     headerFiles: ['lib/codemirror.js'],
-                    inputFiles: ['mode/**/*']
+                    inputFiles: ['mode/**/*'],
+                    sourceMapConfig: {enabled: false}
                 });
 
                 var cssTree = concat(tree, {


### PR DESCRIPTION
See TryGhost/Ghost#7503 for a hopefully clear explanation of why I'm making this change 

I have changed to having both an `admin` and an `asset` path because, although I can't find any usages of `admin`, I didn't want to hijack the term "admin" to mean "asset". 
