### PR TITLE
✨ Move internal tags out of labs

### DIFF
--- a/app/mirage/fixtures/settings.js
+++ b/app/mirage/fixtures/settings.js
@@ -125,7 +125,7 @@ export default [
         id: 12,
         uuid: 'd806f358-7996-4c74-b153-8876959c4b70',
         key: 'labs',
-        value: '{"subscribers":true,"internalTags":true}',
+        value: '{"subscribers":true}',
         type: 'blog',
         created_at: '2015-01-12T18:29:01.000Z',
         created_by: 1,

--- a/app/models/tag.js
+++ b/app/models/tag.js
@@ -32,19 +32,18 @@ export default Model.extend(ValidationEngine, {
 
     setVisibility() {
         let internalRegex = /^#.?/;
-
         this.set('visibility', internalRegex.test(this.get('name')) ? 'internal' : 'public');
     },
 
     save() {
-        if (this.get('feature.internalTags') && this.get('changedAttributes.name') && !this.get('isDeleted')) {
+        if (this.get('changedAttributes.name') && !this.get('isDeleted')) {
             this.setVisibility();
         }
         return this._super(...arguments);
     },
 
-    setVisibilityOnNew: observer('feature.internalTags', 'isNew', 'isSaving', 'name', function () {
-        if (this.get('isNew') && !this.get('isSaving') && this.get('feature.internalTags')) {
+    setVisibilityOnNew: observer('isNew', 'isSaving', 'name', function () {
+        if (this.get('isNew') && !this.get('isSaving')) {
             this.setVisibility();
         }
     })

--- a/app/services/feature.js
+++ b/app/services/feature.js
@@ -30,7 +30,6 @@ export default Service.extend({
 
     publicAPI: feature('publicAPI'),
     subscribers: feature('subscribers'),
-    internalTags: feature('internalTags'),
 
     _settings: null,
 

--- a/app/templates/components/gh-tag.hbs
+++ b/app/templates/components/gh-tag.hbs
@@ -3,10 +3,8 @@
         <span class="tag-title">{{tag.name}}</span>
         <span class="label label-default">/{{tag.slug}}</span>
 
-        {{#if feature.internalTags}}
-            {{#if tag.isInternal}}
-                <span class="label label-blue">internal</span>
-            {{/if}}
+        {{#if tag.isInternal}}
+            <span class="label label-blue">internal</span>
         {{/if}}
 
         <p class="tag-description">{{tag.description}}</p>

--- a/app/templates/posts.hbs
+++ b/app/templates/posts.hbs
@@ -41,13 +41,11 @@
                     					{{/if}}
                                     {{/if}}
                                 </span>
-                                {{#if feature.internalTags}}
-                                    <div class="internal-tags-list">
-                                        {{#each post.internalTags as |tag|}}
-                                            <span class="label label-default">{{tag.name}}</span>
-                                        {{/each}}
-                                    </div>
-                                {{/if}}
+                                <div class="internal-tags-list">
+                                    {{#each post.internalTags as |tag|}}
+                                        <span class="label label-default">{{tag.name}}</span>
+                                    {{/each}}
+                                </div>
                             </section>
                         {{/link-to}}
                     {{/gh-posts-list-item}}

--- a/app/templates/settings/labs.hbs
+++ b/app/templates/settings/labs.hbs
@@ -53,9 +53,6 @@
                     {{#gh-feature-flag "subscribers"}}
                         Subscribers - Collect email addresses from your readers, more info in <a href="http://support.ghost.org/subscribers-beta/">the docs</a>
                     {{/gh-feature-flag}}
-                    {{#gh-feature-flag "internalTags"}}
-                        Internal Tags - tags which don't show up in your theme, more info in <a href="http://support.ghost.org/internal-tags-beta/">the docs</a>.
-                    {{/gh-feature-flag}}
                 </div>
             </fieldset>
         </form>


### PR DESCRIPTION
Related to Ghost#7519, which removes all the server-side logic for the internalTags labs flag.

refs Ghost#6165

- it's time to move internal Tags out of labs!
- remove the checkbox & all lab/feature flag code for internalTags