### PR TITLE
[WIP] Full-page OAuth redirects

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -9,6 +9,9 @@ import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mi
 import ShortcutsRoute from 'ghost-admin/mixins/shortcuts-route';
 import ctrlOrCmd from 'ghost-admin/utils/ctrl-or-cmd';
 import windowProxy from 'ghost-admin/utils/window-proxy';
+import ParseQueryString from 'torii/lib/parse-query-string';
+
+const queryStringParser = ParseQueryString.create({url: window.location.href, keys: ['code']});
 
 function K() {
     return this;
@@ -27,6 +30,36 @@ export default Route.extend(ApplicationRouteMixin, ShortcutsRoute, {
     dropdown: injectService(),
     notifications: injectService(),
     upgradeNotification: injectService(),
+    torii: injectService(),
+
+    beforeModel(transition) {
+        // TODO: load config from API
+
+        if (this.get('config.ghostOAuth')) {
+            let queryParams = queryStringParser.parse();
+
+            // exchange access grant code for access_token/refresh_token if we have one
+            if (queryParams.code) {
+                // TODO: check for consistent state param
+                let data = {
+                    authorizationCode: queryParams.code
+                };
+                return this.get('session').authenticate('authenticator:oauth2-ghost', data);
+            }
+
+            // redirect to auth server immediately if we have no local session
+            if (!this.get('session.isAuthenticated')) {
+                transition.abort();
+                // TODO: send correct type
+                return this.get('torii').open('ghost-oauth2-redirect', {type: 'setup'});
+            }
+
+            // TODO: handle local but invalid session - can we pre-emptively check
+            // expiry and fetch a fresh token?
+        }
+
+        return this._super(...arguments);
+    },
 
     afterModel(model, transition) {
         this._super(...arguments);

--- a/app/torii-providers/ghost-oauth2-redirect.js
+++ b/app/torii-providers/ghost-oauth2-redirect.js
@@ -1,0 +1,14 @@
+import GhostOauth2 from './ghost-oauth2';
+import windowProxy from 'ghost-admin/utils/window-proxy';
+
+export default GhostOauth2.extend({
+    open(options) {
+        if (options.type) {
+            this.set('type', options.type);
+        }
+        if (options.email) {
+            this.set('email', options.email);
+        }
+        windowProxy.changeLocation(this.buildUrl());
+    }
+});


### PR DESCRIPTION
Streamline the login flows to be as hands-off as possible by using full page redirects that can automatically pick up active sessions on the authentication server.

- perform a full-page redirect to the central Ghost OAuth service on app boot if no valid session exists
  - ensures that users can always access their blogs if they have an active session on the central auth server without needing to click any additional buttons

NOTES:
- initially attempted as an Instance Initialiser in order to try skipping a little more processing before the redirect but it's not possible to defer readiness in instance initialisers. Standard initialisers can defer readiness but we can't guarantee that the various parts that we rely on (session, torii, etc) are set up when we need them and any async behaviour is discouraged in initialisers as it breaks loading/error substates. The `beforeModel` hook on the application route is the best-practice location for this type of logic and in my testing so far has a no user-measurable effect on loading time before the redirect is initiated.

TODO:
- [ ] implement the same state checking code as the normal torii provider
- [ ] handle setup situation
  - as soon as an account is created/connected Ghost treats that as the setup flow being completed so if we immediately perform the auth redirect before any setup flow is reached then the user never sees the setup screens
- [ ] check token expiration and attempt to refresh the `access_token` if it's expired before performing any other network requests
- [ ] redirect to auth server if we get a 401 rather than redirecting to local sign-in page
  - [ ] handle special-case re-authentication in the editor (current popup flow?)
- [ ] handle logged in user not having access to the blog
- [ ] review invite flows
- [ ] log out of auth server when logging out of blog

QUESTIONS:
- Should logging out of the blog log you out of the central auth server?
  - currently this has an odd behaviour in that clicking "Log out" will attempt to redirect you to yourblog.com/ghost/signin which will redirect you to the auth server, pick up your active session and automatically log you back in!