### PR TITLE
Markdown card

### DIFF
--- a/app/routes/editor/edit.js
+++ b/app/routes/editor/edit.js
@@ -3,6 +3,7 @@ import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 import base from 'ghost-admin/mixins/editor-base-route';
 import isNumber from 'ghost-admin/utils/isNumber';
 import isFinite from 'ghost-admin/utils/isFinite';
+import ghostPaths from 'ghost-admin/utils/ghost-paths';
 
 export default AuthenticatedRoute.extend(base, {
     titleToken: 'Editor',
@@ -57,6 +58,8 @@ export default AuthenticatedRoute.extend(base, {
         controller.set('cards' , []);
         controller.set('atoms' , []);
         controller.set('toolbar' , []);
+        controller.set('apiRoot', ghostPaths().apiRoot);
+        controller.set('assetPath', ghostPaths().assetRoot);
     },
 
     actions: {

--- a/app/templates/editor/edit.hbs
+++ b/app/templates/editor/edit.hbs
@@ -35,6 +35,8 @@
         onFirstChange=(action "autoSaveNew")
         onTeardown=(action "cancelTimers")
         shouldFocusEditor=shouldFocusEditor
+        apiRoot=apiRoot
+        assetPath=assetPath
     }}
 </section>
 

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "ember-wormhole": "0.4.1",
     "emberx-file-input": "1.1.0",
     "fs-extra": "0.30.0",
-    "ghost-editor": "0.0.10",
+    "ghost-editor": "0.0.11",
     "glob": "7.1.1",
     "grunt": "1.0.1",
     "grunt-bg-shell": "2.3.3",


### PR DESCRIPTION
Refs TryGhost/Ghost#7429
Depends on: https://github.com/TryGhost/Ghost/pull/7568

Just a quick update in lieu of a larger overhaul to come through next PR:

- Added mobiledoc card, this uses the mobiledoc editor from within Ghost. In the future we'll pull this out and replace it with a textarea as the preview is too small to fit in the content.
- Made the HTML editor a codemirror editor (pulled in from ghost-admin to save duplicating libraries).
- Ghost-Admin now passes the paths for the ghost-api and the image directory for tools.
- Fixed the scrolling issue.
- Added an obnoxious label on top of each card so you know what they do.