### PR TITLE
remove custom token endpoint when using Ghost OAuth

### DIFF
--- a/app/authenticators/oauth2-ghost.js
+++ b/app/authenticators/oauth2-ghost.js
@@ -1,6 +1,5 @@
 /* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 import Oauth2Authenticator from './oauth2';
-import computed from 'ember-computed';
 import RSVP from 'rsvp';
 import run from 'ember-runloop';
 import {assign} from 'ember-platform';
@@ -8,10 +7,6 @@ import {isEmpty} from 'ember-utils';
 import {wrap} from 'ember-array/utils';
 
 export default Oauth2Authenticator.extend({
-    serverTokenEndpoint: computed('ghostPaths.apiRoot', function () {
-        return `${this.get('ghostPaths.apiRoot')}/authentication/ghost`;
-    }),
-
     // TODO: all this is doing is changing the `data` structure, we should
     // probably create our own token auth, maybe look at
     // https://github.com/jpadilla/ember-simple-auth-token
@@ -21,9 +16,13 @@ export default Oauth2Authenticator.extend({
             let data = identification;
             let serverTokenEndpoint = this.get('serverTokenEndpoint');
             let scopesString = wrap(scope).join(' ');
+
+            data.grant_type = 'authorization_code';
+
             if (!isEmpty(scopesString)) {
                 data.scope = scopesString;
             }
+
             this.makeRequest(serverTokenEndpoint, data).then((response) => {
                 run(() => {
                     let expiresAt = this._absolutizeExpirationTime(response.expires_in);

--- a/app/mirage/config/authentication.js
+++ b/app/mirage/config/authentication.js
@@ -1,15 +1,33 @@
 /* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 import Mirage from 'ember-cli-mirage';
 import {isBlank} from 'ember-utils';
+import $ from 'jquery';
 
 export default function mockAuthentication(server) {
-    server.post('/authentication/token', function () {
-        return {
-            access_token: '5JhTdKI7PpoZv4ROsFoERc6wCHALKFH5jxozwOOAErmUzWrFNARuH1q01TYTKeZkPW7FmV5MJ2fU00pg9sm4jtH3Z1LjCf8D6nNqLYCfFb2YEKyuvG7zHj4jZqSYVodN2YTCkcHv6k8oJ54QXzNTLIDMlCevkOebm5OjxGiJpafMxncm043q9u1QhdU9eee3zouGRMVVp8zkKVoo5zlGMi3zvS2XDpx7xsfk8hKHpUgd7EDDQxmMueifWv7hv6n',
-            expires_in: 3600,
-            refresh_token: 'XP13eDjwV5mxOcrq1jkIY9idhdvN3R1Br5vxYpYIub2P5Hdc8pdWMOGmwFyoUshiEB62JWHTl8H1kACJR18Z8aMXbnk5orG28br2kmVgtVZKqOSoiiWrQoeKTqrRV0t7ua8uY5HdDUaKpnYKyOdpagsSPn3WEj8op4vHctGL3svOWOjZhq6F2XeVPMR7YsbiwBE8fjT3VhTB3KRlBtWZd1rE0Qo2EtSplWyjGKv1liAEiL0ndQoLeeSOCH4rTP7',
-            token_type: 'Bearer'
-        };
+    server.post('/authentication/token', function (db, request) {
+        let params = $.deparam(request.requestBody);
+
+        if (params.grant_type === 'authorization_code') {
+            // OAuth sign-in
+            if (!db.users.length) {
+                let [role] = db.roles.where({name: 'Owner'});
+                server.create('user', {email: 'oauthtest@example.com', roles: [role]});
+            }
+
+            return {
+                access_token: '5JhTdKI7PpoZv4ROsFoERc6wCHALKFH5jxozwOOAErmUzWrFNARuH1q01TYTKeZkPW7FmV5MJ2fU00pg9sm4jtH3Z1LjCf8D6nNqLYCfFb2YEKyuvG7zHj4jZqSYVodN2YTCkcHv6k8oJ54QXzNTLIDMlCevkOebm5OjxGiJpafMxncm043q9u1QhdU9eee3zouGRMVVp8zkKVoo5zlGMi3zvS2XDpx7xsfk8hKHpUgd7EDDQxmMueifWv7hv6n',
+                expires_in: 3600,
+                refresh_token: 'XP13eDjwV5mxOcrq1jkIY9idhdvN3R1Br5vxYpYIub2P5Hdc8pdWMOGmwFyoUshiEB62JWHTl8H1kACJR18Z8aMXbnk5orG28br2kmVgtVZKqOSoiiWrQoeKTqrRV0t7ua8uY5HdDUaKpnYKyOdpagsSPn3WEj8op4vHctGL3svOWOjZhq6F2XeVPMR7YsbiwBE8fjT3VhTB3KRlBtWZd1rE0Qo2EtSplWyjGKv1liAEiL0ndQoLeeSOCH4rTP7'
+            };
+        } else {
+            // Password sign-in
+            return {
+                access_token: '5JhTdKI7PpoZv4ROsFoERc6wCHALKFH5jxozwOOAErmUzWrFNARuH1q01TYTKeZkPW7FmV5MJ2fU00pg9sm4jtH3Z1LjCf8D6nNqLYCfFb2YEKyuvG7zHj4jZqSYVodN2YTCkcHv6k8oJ54QXzNTLIDMlCevkOebm5OjxGiJpafMxncm043q9u1QhdU9eee3zouGRMVVp8zkKVoo5zlGMi3zvS2XDpx7xsfk8hKHpUgd7EDDQxmMueifWv7hv6n',
+                expires_in: 3600,
+                refresh_token: 'XP13eDjwV5mxOcrq1jkIY9idhdvN3R1Br5vxYpYIub2P5Hdc8pdWMOGmwFyoUshiEB62JWHTl8H1kACJR18Z8aMXbnk5orG28br2kmVgtVZKqOSoiiWrQoeKTqrRV0t7ua8uY5HdDUaKpnYKyOdpagsSPn3WEj8op4vHctGL3svOWOjZhq6F2XeVPMR7YsbiwBE8fjT3VhTB3KRlBtWZd1rE0Qo2EtSplWyjGKv1liAEiL0ndQoLeeSOCH4rTP7',
+                token_type: 'Bearer'
+            };
+        }
     });
 
     server.post('/authentication/passwordreset', function (db, request) {
@@ -83,21 +101,6 @@ export default function mockAuthentication(server) {
             setup: [
                 {status: true}
             ]
-        };
-    });
-
-    /* OAuth ---------------------------------------------------------------- */
-
-    server.post('/authentication/ghost', function (db) {
-        if (!db.users.length) {
-            let [role] = db.roles.where({name: 'Owner'});
-            server.create('user', {email: 'oauthtest@example.com', roles: [role]});
-        }
-
-        return {
-            access_token: '5JhTdKI7PpoZv4ROsFoERc6wCHALKFH5jxozwOOAErmUzWrFNARuH1q01TYTKeZkPW7FmV5MJ2fU00pg9sm4jtH3Z1LjCf8D6nNqLYCfFb2YEKyuvG7zHj4jZqSYVodN2YTCkcHv6k8oJ54QXzNTLIDMlCevkOebm5OjxGiJpafMxncm043q9u1QhdU9eee3zouGRMVVp8zkKVoo5zlGMi3zvS2XDpx7xsfk8hKHpUgd7EDDQxmMueifWv7hv6n',
-            expires_in: 3600,
-            refresh_token: 'XP13eDjwV5mxOcrq1jkIY9idhdvN3R1Br5vxYpYIub2P5Hdc8pdWMOGmwFyoUshiEB62JWHTl8H1kACJR18Z8aMXbnk5orG28br2kmVgtVZKqOSoiiWrQoeKTqrRV0t7ua8uY5HdDUaKpnYKyOdpagsSPn3WEj8op4vHctGL3svOWOjZhq6F2XeVPMR7YsbiwBE8fjT3VhTB3KRlBtWZd1rE0Qo2EtSplWyjGKv1liAEiL0ndQoLeeSOCH4rTP7'
         };
     });
 }


### PR DESCRIPTION
issue TryGhost/Ghost#7562, requires TryGhost/Ghost#7571
- removes the custom endpoint so that we always use `/authentication/token`