### PR TITLE
[WIP] Markdown card

### DIFF
--- a/app/routes/editor/edit.js
+++ b/app/routes/editor/edit.js
@@ -3,6 +3,7 @@ import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 import base from 'ghost-admin/mixins/editor-base-route';
 import isNumber from 'ghost-admin/utils/isNumber';
 import isFinite from 'ghost-admin/utils/isFinite';
+import ghostPaths from 'ghost-admin/utils/ghost-paths';
 
 export default AuthenticatedRoute.extend(base, {
     titleToken: 'Editor',
@@ -52,11 +53,12 @@ export default AuthenticatedRoute.extend(base, {
 
     setupController(controller) {
         this._super(...arguments);
-
         controller.set('shouldFocusEditor', this.get('_transitionedFromNew'));
         controller.set('cards' , []);
         controller.set('atoms' , []);
         controller.set('toolbar' , []);
+        controller.set('apiRoot', ghostPaths().apiRoot);
+        controller.set('assetPath', ghostPaths().assetRoot);
     },
 
     actions: {

--- a/app/routes/editor/new.js
+++ b/app/routes/editor/new.js
@@ -1,5 +1,6 @@
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 import base from 'ghost-admin/mixins/editor-base-route';
+import ghostPaths from 'ghost-admin/utils/ghost-paths';
 
 export default AuthenticatedRoute.extend(base, {
     titleToken: 'Editor',
@@ -25,7 +26,7 @@ export default AuthenticatedRoute.extend(base, {
         });
     },
 
-    setupController() {
+    setupController(controller) {
         let psm = this.controllerFor('post-settings-menu');
 
         // make sure there are no titleObserver functions hanging around
@@ -36,6 +37,13 @@ export default AuthenticatedRoute.extend(base, {
         psm.send('resetPubDate');
 
         this._super(...arguments);
+
+        controller.set('cards' , []);
+        controller.set('atoms' , []);
+        controller.set('toolbar' , []);
+        controller.set('apiRoot', ghostPaths().apiRoot);
+        controller.set('assetPath', ghostPaths().assetRoot);
+
     },
 
     actions: {

--- a/app/styles/layouts/editor.css
+++ b/app/styles/layouts/editor.css
@@ -7,6 +7,7 @@
 
 .gh-editor-title {
     flex-grow: 1;
+    margin-bottom: 2vw;
 }
 
 .gh-editor-title input {
@@ -16,7 +17,7 @@
     border: 0;
     background: transparent;
     color: var(--darkgrey);
-    font-size: 2.6rem;
+    font-size: 3.2rem;
     font-weight: bold;
 }
 
@@ -399,4 +400,32 @@
 
 .modal-markdown-help-table th {
     text-align: left;
+}
+
+
+/* NEW editor
+/* ---------------------------------------------------------- */
+
+.gh-editor-header {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 100;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0 20px;
+    height: 65px;
+}
+
+.gh-editor-container {
+    padding: 100px 4vw 40px;
+    width: 100%;
+    overflow-y: auto;
+}
+
+.gh-editor-inner {
+    max-width: 700px;
+    margin: 0 auto;
 }

--- a/app/templates/editor/edit.hbs
+++ b/app/templates/editor/edit.hbs
@@ -1,13 +1,9 @@
 <section class="gh-view">
-    <header class="view-header">
-        {{#gh-view-title classNames="gh-editor-title" openMobileMenu="openMobileMenu"}}
-            {{gh-trim-focus-input model.titleScratch type="text" id="entry-title" placeholder="Your Post Title" tabindex="1" shouldFocus=shouldFocusTitle focus-out="updateTitle" update=(action (perform updateTitle))}}
-        {{/gh-view-title}}
-        {{#if scheduleCountdown}}
-            <time datetime="{{post.publishedAtUTC}}" class="gh-notification gh-notification-schedule">
-                Post will be published {{scheduleCountdown}}.
-            </time>
-        {{/if}}
+
+    <header class="gh-editor-header">
+        <div class="gh-editor-status">
+            Draft
+        </div>
         <section class="view-actions">
             <button type="button" class="post-settings" title="Post Settings" {{action "openSettingsMenu"}}>
                 <i class="icon-settings"></i>
@@ -29,13 +25,29 @@
             }}
         </section>
     </header>
-    {{ghost-editor
-        value=(readonly model.scratch)
-        onChange=(action (mut model.scratch))
-        onFirstChange=(action "autoSaveNew")
-        onTeardown=(action "cancelTimers")
-        shouldFocusEditor=shouldFocusEditor
-    }}
+
+    <div class="gh-editor-container">
+        <div class="gh-editor-inner">
+            {{#gh-view-title classNames="gh-editor-title" openMobileMenu="openMobileMenu"}}
+                {{gh-trim-focus-input model.titleScratch type="text" id="entry-title" placeholder="Your Post Title" tabindex="1" shouldFocus=shouldFocusTitle focus-out="updateTitle" update=(action (perform updateTitle))}}
+            {{/gh-view-title}}
+            {{#if scheduleCountdown}}
+                <time datetime="{{post.publishedAtUTC}}" class="gh-notification gh-notification-schedule">
+                    Post will be published {{scheduleCountdown}}.
+                </time>
+            {{/if}}
+            {{ghost-editor
+                    value=(readonly model.scratch)
+                    onChange=(action (mut model.scratch))
+                    onFirstChange=(action "autoSaveNew")
+                    onTeardown=(action "cancelTimers")
+                    shouldFocusEditor=shouldFocusEditor
+                    apiRoot=apiRoot
+                    assetPath=assetPath
+                }}
+        </div>
+    </div>
+
 </section>
 
 {{#if showDeletePostModal}}
@@ -57,3 +69,8 @@
                           close=(action "toggleReAuthenticateModal")
                           modifier="action wide"}}
 {{/if}}
+
+
+
+
+

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "ember-wormhole": "0.4.1",
     "emberx-file-input": "1.1.0",
     "fs-extra": "0.30.0",
-    "ghost-editor": "0.0.10",
+    "ghost-editor": "0.0.12",
     "glob": "7.1.1",
     "grunt": "1.0.1",
     "grunt-bg-shell": "2.3.3",


### PR DESCRIPTION
Refs TryGhost/Ghost#7429
- Added mobiledoc card, this uses the mobiledoc editor from within Ghost. In the future we'll pull this out and replace it with a textarea as the preview is too small to fit in the content.
- Made the HTML editor a codemirror editor (pulled in from ghost-admin to save duplicating libraries).
- Ghost-Admin now passes the paths for the ghost-api and the image directory for tools.
- Fixed the scrolling issue.
- Integrated UI updates