### PR TITLE
add manual pretender shutdown to fix acceptance tests

### DIFF
--- a/tests/helpers/destroy-app.js
+++ b/tests/helpers/destroy-app.js
@@ -1,5 +1,10 @@
 import run from 'ember-runloop';
 
 export default function destroyApp(application) {
+    // this is required to fix "second Pretender instance" warnings
+    if (server) {
+        server.shutdown();
+    }
+
     run(application, 'destroy');
 }


### PR DESCRIPTION
no issue
- ensure our mirage server is shutdown during app teardown in acceptance tests
- a [recent update](https://github.com/pretenderjs/pretender/pull/178) to Pretender contained a breaking change that throws an error when multiple pretender instances exist
- using mirage in acceptance tests was [triggering the error](https://github.com/samselikoff/ember-cli-mirage/issues/915)
