### PR TITLE
deps: ember-ajax@2.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "chalk": "1.1.3",
     "codemirror": "5.20.2",
     "csscomb": "3.1.8",
-    "ember-ajax": "ember-cli/ember-ajax#b32b9ee5ede69e09a162eb98d354f7de6297f679",
+    "ember-ajax": "2.5.2",
     "ember-cli": "2.9.0",
     "ember-cli-app-version": "2.0.0",
     "ember-cli-babel": "5.1.10",


### PR DESCRIPTION
no issue
- the changes for which we had pinned to a specific commit are now part of a proper release