### PR TITLE
deps: ember@2.9.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "ghost-admin",
   "dependencies": {
     "devicejs": "0.2.7",
-    "ember": "2.8.2",
+    "ember": "2.9.0",
     "ember-cli-shims": "0.1.3",
     "ember-mocha": "0.9.1",
     "Faker": "3.1.0",


### PR DESCRIPTION
no issue
- Glimmer2 was backed out of the 2.9 branch as it wasn't considered ready yet, 2.9 is therefore safe to upgrade to as changes are very minimal from the previous 2.8.2 version