### PR TITLE
🐛 fix more asset paths

### DIFF
--- a/app/components/gh-posts-list-item.js
+++ b/app/components/gh-posts-list-item.js
@@ -33,7 +33,7 @@ export default Component.extend(ActiveLinkWrapper, {
     }),
 
     authorAvatar: computed('post.author.image', function () {
-        return this.get('post.author.image') || `${this.get('ghostPaths.subdir')}/ghost/img/user-image.png`;
+        return this.get('post.author.image') || `${this.get('ghostPaths.assetRoot')}/img/user-image.png`;
     }),
 
     authorAvatarBackground: computed('authorAvatar', function () {

--- a/app/components/gh-profile-image.js
+++ b/app/components/gh-profile-image.js
@@ -44,7 +44,7 @@ export default Component.extend({
     },
 
     defaultImage: computed('ghostPaths', function () {
-        let url = `${this.get('ghostPaths.subdir')}/ghost/img/user-image.png`;
+        let url = `${this.get('ghostPaths.assetRoot')}/img/user-image.png`;
         return htmlSafe(`background-image: url(${url})`);
     }),
 
@@ -71,7 +71,7 @@ export default Component.extend({
 
             this.get('ajax').request(gravatarUrl)
                 .catch((error) => {
-                    let defaultImageUrl = `url("${this.get('ghostPaths.subdir')}/ghost/img/user-image.png")`;
+                    let defaultImageUrl = `url("${this.get('ghostPaths.assetRoot')}/img/user-image.png")`;
 
                     if (isNotFoundError(error)) {
                         this.$('.placeholder-img')[0].style.backgroundImage = htmlSafe(defaultImageUrl);

--- a/app/components/gh-user-active.js
+++ b/app/components/gh-user-active.js
@@ -11,7 +11,7 @@ export default Component.extend({
     ghostPaths: injectService(),
 
     userDefault: computed('ghostPaths', function () {
-        return `${this.get('ghostPaths.subdir')}/ghost/img/user-image.png`;
+        return `${this.get('ghostPaths.assetRoot')}/img/user-image.png`;
     }),
 
     userImageBackground: computed('user.image', 'userDefault', function () {

--- a/app/controllers/team/user.js
+++ b/app/controllers/team/user.js
@@ -57,7 +57,7 @@ export default Controller.extend({
 
     // duplicated in gh-user-active -- find a better home and consolidate?
     userDefault: computed('ghostPaths', function () {
-        return `${this.get('ghostPaths.subdir')}/ghost/img/user-image.png`;
+        return `${this.get('ghostPaths.assetRoot')}/img/user-image.png`;
     }),
 
     userImageBackground: computed('user.image', 'userDefault', function () {
@@ -68,7 +68,7 @@ export default Controller.extend({
     // end duplicated
 
     coverDefault: computed('ghostPaths', function () {
-        return `${this.get('ghostPaths.subdir')}/ghost/img/user-cover.png`;
+        return `${this.get('ghostPaths.assetRoot')}/img/user-cover.png`;
     }),
 
     coverImageBackground: computed('user.cover', 'coverDefault', function () {


### PR DESCRIPTION
no issue
- #309 introduced a change to our asset path but some images, particularly around the team page and user avatars were missed, this fixes those URLs to use the new `ghostPaths.assetRoot` helper