### PR TITLE
Fetch config from endpoint rather than meta tags

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -31,10 +31,6 @@
     <meta name="msapplication-square150x150logo" content="{{asset "img/medium.png" ghost="true"}}" />
     <meta name="msapplication-square310x310logo" content="{{asset "img/large.png" ghost="true"}}" />
 
-    {{#each configuration as |config key|}}
-        <meta name="env-{{key}}" content="{{config.value}}" data-type="{{config.type}}" />
-    {{/each}}
-
     <link rel="stylesheet" href="{{asset "vendor.css" ghost="true" minifyInProduction="true"}}" />
     <link rel="stylesheet" href="{{asset "ghost.css" ghost="true" minifyInProduction="true"}}" />
 

--- a/app/mirage/config.js
+++ b/app/mirage/config.js
@@ -1,4 +1,5 @@
 import mockAuthentication from './config/authentication';
+import mockConfiguration from './config/configuration';
 import mockInvites from './config/invites';
 import mockPosts from './config/posts';
 import mockRoles from './config/roles';
@@ -37,6 +38,7 @@ export function testConfig() {
     // this.logging = true;
 
     mockAuthentication(this);
+    mockConfiguration(this);
     mockInvites(this);
     mockPosts(this);
     mockRoles(this);
@@ -55,16 +57,6 @@ export function testConfig() {
 
     this.post('/slack/test', function () {
         return {};
-    });
-
-    /* Configuration -------------------------------------------------------- */
-
-    this.get('/configuration/timezones/', function (db) {
-        return {
-            configuration: [{
-                timezones: db.timezones
-            }]
-        };
     });
 
     /* External sites ------------------------------------------------------- */

--- a/app/mirage/config/configuration.js
+++ b/app/mirage/config/configuration.js
@@ -1,0 +1,21 @@
+import {isEmpty} from 'ember-utils';
+
+export default function mockConfiguration(server) {
+    server.get('/configuration/', function (db) {
+        if (isEmpty(db.configurations)) {
+            server.loadFixtures('configurations');
+        }
+
+        return {
+            configuration: [db.configurations.find(1)]
+        };
+    });
+
+    server.get('/configuration/timezones/', function (db) {
+        return {
+            configuration: [{
+                timezones: db.timezones
+            }]
+        };
+    });
+}

--- a/app/mirage/fixtures/configurations.js
+++ b/app/mirage/fixtures/configurations.js
@@ -1,0 +1,20 @@
+export default [{
+    blogTitle: 'Test Blog',
+    blogUrl: 'http://localhost:7357/',
+    clientId: 'ghost-admin',
+    clientSecret: '1234ClientSecret',
+    fileStorage: 'true',
+    // these are valid attrs but we want password auth by default in tests
+    // ghostAuthId: '1234GhostAuthId',
+    // ghostAuthUrl: 'http://devauth.ghost.org:8080',
+    internalTags: 'false',
+    publicAPI: 'false',
+    routeKeywords: {
+        tag: 'tag',
+        author: 'author',
+        page: 'page',
+        preview: 'p',
+        private: 'private'
+    },
+    useGravatar: 'true'
+}];

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -28,6 +28,10 @@ export default Route.extend(ApplicationRouteMixin, ShortcutsRoute, {
     notifications: injectService(),
     upgradeNotification: injectService(),
 
+    beforeModel() {
+        return this.get('config').fetch();
+    },
+
     afterModel(model, transition) {
         this._super(...arguments);
 

--- a/app/services/config.js
+++ b/app/services/config.js
@@ -1,4 +1,3 @@
-import $ from 'jquery';
 import Ember from 'ember';
 import Service from 'ember-service';
 import computed from 'ember-computed';
@@ -7,46 +6,20 @@ import {isBlank} from 'ember-utils';
 
 // ember-cli-shims doesn't export _ProxyMixin ot testing
 const {_ProxyMixin} = Ember;
-const {isNumeric} = $;
-
-function _mapType(val, type) {
-    if (val === '') {
-        return null;
-    } else if (type === 'bool') {
-        return (val === 'true') ? true : false;
-    } else if (type === 'int' && isNumeric(val)) {
-        return +val;
-    } else if (type === 'json') {
-        try {
-            return JSON.parse(val);
-        } catch (e) {
-            return val;
-        }
-    } else { // assume string if type is null or matches nothing else
-        return val;
-    }
-}
 
 export default Service.extend(_ProxyMixin, {
     ajax: injectService(),
     ghostPaths: injectService(),
 
-    content: computed(function () {
-        let metaConfigTags = $('meta[name^="env-"]');
-        let config = {};
+    content: {},
 
-        metaConfigTags.each((i, el) => {
-            let key = el.name;
-            let value = el.content;
-            let type = el.getAttribute('data-type');
+    fetch() {
+        let configUrl = this.get('ghostPaths.url').api('configuration');
 
-            let propertyName = key.substring(4);
-
-            config[propertyName] = _mapType(value, type);
+        return this.get('ajax').request(configUrl).then((config) => {
+            this.set('content', config.configuration[0]);
         });
-
-        return config;
-    }),
+    },
 
     availableTimezones: computed(function () {
         let timezonesUrl = this.get('ghostPaths.url').api('configuration', 'timezones');

--- a/app/torii-providers/ghost-oauth2.js
+++ b/app/torii-providers/ghost-oauth2.js
@@ -7,7 +7,9 @@ let GhostOauth2 = Oauth2.extend({
     config: injectService(),
 
     name:    'ghost-oauth2',
-    baseUrl: 'http://devauth.ghost.org:8080/oauth2/authorize',
+    baseUrl: computed(function () {
+        return `${this.get('config.ghostAuthUrl')}/oauth2/authorize`;
+    }),
     apiKey: computed(function () {
         return this.get('config.ghostAuthId');
     }),

--- a/tests/acceptance/setup-test.js
+++ b/tests/acceptance/setup-test.js
@@ -7,15 +7,16 @@ import {
     afterEach
 } from 'mocha';
 import { expect } from 'chai';
-import startApp from 'ghost-admin/tests/helpers/start-app';
-import destroyApp from 'ghost-admin/tests/helpers/destroy-app';
-import { invalidateSession, authenticateSession } from 'ghost-admin/tests/helpers/ember-simple-auth';
+import startApp from '../helpers/start-app';
+import destroyApp from '../helpers/destroy-app';
+import { invalidateSession, authenticateSession } from '../helpers/ember-simple-auth';
+import { enableGhostOAuth } from '../helpers/configuration';
 import Mirage from 'ember-cli-mirage';
 import $ from 'jquery';
 import {
     stubSuccessfulOAuthConnect,
     stubFailedOAuthConnect
-} from 'ghost-admin/tests/helpers/oauth';
+} from '../helpers/oauth';
 
 describe('Acceptance: Setup', function () {
     let application;
@@ -427,17 +428,10 @@ describe('Acceptance: Setup', function () {
                 };
             });
 
-            // simulate active oauth config
-            $('head').append('<meta name="env-ghostAuthId" content="6e0704b3-c653-4c12-8da7-584232b5c629" />');
-
             // ensure we have settings (to pass validation) and roles available
+            enableGhostOAuth(server);
             server.loadFixtures('settings');
             server.loadFixtures('roles');
-        });
-
-        afterEach(function () {
-            // ensure we don't leak OAuth config to other tests
-            $('meta[name="env-ghostAuthId"]').remove();
         });
 
         it('displays the connect form and validates', function () {

--- a/tests/acceptance/signin-test.js
+++ b/tests/acceptance/signin-test.js
@@ -9,12 +9,13 @@ import { expect } from 'chai';
 import $ from 'jquery';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
-import { invalidateSession, authenticateSession } from 'ghost-admin/tests/helpers/ember-simple-auth';
+import { invalidateSession, authenticateSession } from '../helpers/ember-simple-auth';
+import { enableGhostOAuth } from '../helpers/configuration';
 import Mirage from 'ember-cli-mirage';
 import {
     stubSuccessfulOAuthConnect,
     stubFailedOAuthConnect
-} from 'ghost-admin/tests/helpers/oauth';
+} from '../helpers/oauth';
 
 describe('Acceptance: Signin', function() {
     let application;
@@ -136,13 +137,7 @@ describe('Acceptance: Signin', function() {
 
     describe('using Ghost OAuth', function () {
         beforeEach(function () {
-            // simulate active oauth config
-            $('head').append('<meta name="env-ghostAuthId" content="6e0704b3-c653-4c12-8da7-584232b5c629" />');
-        });
-
-        afterEach(function () {
-            // ensure we don't leak OAuth config to other tests
-            $('meta[name="env-ghostAuthId"]').remove();
+            enableGhostOAuth(server);
         });
 
         it('can sign in successfully', function () {

--- a/tests/acceptance/signup-test.js
+++ b/tests/acceptance/signup-test.js
@@ -9,10 +9,11 @@ import { expect } from 'chai';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
 import $ from 'jquery';
+import { enableGhostOAuth } from '../helpers/configuration';
 import {
     stubSuccessfulOAuthConnect,
     stubFailedOAuthConnect
-} from 'ghost-admin/tests/helpers/oauth';
+} from '../helpers/oauth';
 
 describe('Acceptance: Signup', function() {
     let application;
@@ -146,8 +147,7 @@ describe('Acceptance: Signup', function() {
 
     describe('using Ghost OAuth', function () {
         beforeEach(function () {
-            // simulate active oauth config
-            $('head').append('<meta name="env-ghostAuthId" content="6e0704b3-c653-4c12-8da7-584232b5c629" />');
+            enableGhostOAuth(server);
 
             let user = server.create('user', {name: 'Test Invite Creator'});
 
@@ -157,11 +157,6 @@ describe('Acceptance: Signup', function() {
                 created_by: user.id
             });
             /* jscs:enable requireCamelCaseOrUpperCaseIdentifiers */
-        });
-
-        afterEach(function () {
-            // ensure we don't leak OAuth config to other tests
-            $('meta[name="env-ghostAuthId"]').remove();
         });
 
         it('can sign up sucessfully', function () {

--- a/tests/acceptance/team-test.js
+++ b/tests/acceptance/team-test.js
@@ -8,8 +8,9 @@ import {
 import { expect } from 'chai';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
-import { invalidateSession, authenticateSession } from 'ghost-admin/tests/helpers/ember-simple-auth';
-import { errorOverride, errorReset } from 'ghost-admin/tests/helpers/adapter-error';
+import { invalidateSession, authenticateSession } from '../helpers/ember-simple-auth';
+import { errorOverride, errorReset } from '../helpers/adapter-error';
+import { enableGhostOAuth } from '../helpers/configuration';
 import Mirage from 'ember-cli-mirage';
 import $ from 'jquery';
 
@@ -718,15 +719,8 @@ describe('Acceptance: Team', function () {
 
         describe('using Ghost OAuth', function () {
             beforeEach(function () {
-                // simulate active oauth config
-                $('head').append('<meta name="env-ghostAuthId" content="6e0704b3-c653-4c12-8da7-584232b5c629" />');
-
                 server.loadFixtures();
-            });
-
-            afterEach(function () {
-                // ensure we don't leak OAuth config to other tests
-                $('meta[name="env-ghostAuthId"]').remove();
+                enableGhostOAuth(server);
             });
 
             it('doesn\'t show the password reset form', function () {

--- a/tests/helpers/configuration.js
+++ b/tests/helpers/configuration.js
@@ -1,0 +1,12 @@
+import {isEmpty} from 'ember-utils';
+
+export function enableGhostOAuth(server) {
+    if (isEmpty(server.db.configurations)) {
+        server.loadFixtures('configurations');
+    }
+
+    server.db.configurations.update(1, {
+        ghostAuthId: '6e0704b3-c653-4c12-8da7-584232b5c629',
+        ghostAuthUrl: 'http://devauth.ghost.org:8080'
+    });
+}

--- a/tests/index.html
+++ b/tests/index.html
@@ -10,15 +10,6 @@
     {{content-for "head"}}
     {{content-for "test-head"}}
 
-    <meta name="env-fileStorage" content="true" />
-    <meta name="env-apps" content="false" />
-    <meta name="env-blogUrl" content="http://localhost:7357/" />
-    <meta name="env-blogTitle" content="Test Blog" />
-    <meta name="env-routeKeywords" content="{&quot;tag&quot;:&quot;tag&quot;,&quot;author&quot;:&quot;author&quot;,&quot;page&quot;:&quot;page&quot;,&quot;preview&quot;:&quot;p&quot;,&quot;private&quot;:&quot;private&quot;}" />
-    <meta name="env-clientId" content="ghost-admin" />
-    <meta name="env-clientSecret" content="5076dc643873" />
-    <!-- <meta name="env-ghostAuthId" content="6e0704b3-c653-4c12-8da7-584232b5c629" /> -->
-
     <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
     <link rel="stylesheet" href="{{rootURL}}assets/ghost.css">
     <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">

--- a/tests/integration/services/feature-test.js
+++ b/tests/integration/services/feature-test.js
@@ -144,6 +144,7 @@ describeModule(
             addTestFlag();
 
             let service = this.subject();
+            service.get('config').set('testFlag', false);
 
             service.fetch().then(() => {
                 expect(service.get('testFlag')).to.be.false;
@@ -165,6 +166,7 @@ describeModule(
             addTestFlag();
 
             let service = this.subject();
+            service.get('config').set('testFlag', false);
 
             service.fetch().then(() => {
                 expect(service.get('testFlag')).to.be.false;
@@ -195,6 +197,7 @@ describeModule(
             addTestFlag();
 
             let service = this.subject();
+            service.get('config').set('testFlag', false);
 
             service.fetch().then(() => {
                 expect(service.get('testFlag')).to.be.false;

--- a/tests/unit/services/config-test.js
+++ b/tests/unit/services/config-test.js
@@ -16,15 +16,5 @@ describeModule(
             let service = this.subject();
             expect(service).to.be.ok;
         });
-
-        it('correctly parses a client secret', function () {
-            $('<meta>').attr('name', 'env-clientSecret')
-                .attr('content', '23e435234423')
-                .appendTo('head');
-
-            let service = this.subject();
-
-            expect(service.get('clientSecret')).to.equal('23e435234423');
-        });
     }
 );


### PR DESCRIPTION
issue https://github.com/TryGhost/Ghost/issues/7628, requires https://github.com/TryGhost/Ghost/pull/7631
- update `config` service to fetch from public configuration endpoint
- add `beforeModel` to `application` route to fetch config and pause further processing until the request is complete
- remove `<meta name="env-*">` tags from generated `default.hbs` and internal testing `index.html`
- add mirage config to mock configuration endpoint
- update `ghost-oauth2` torii provider to use auth server URL from server-provided config