### PR TITLE
💄 LTS node version in `engines` (+v6.9 -v0.10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "ember test"
   },
   "engines": {
-    "node": "~0.10.0 || ~0.12.0 || ^4.2.0"
+    "node": "~0.12.0 || ^4.2.0 || ^6.9.0"
   },
   "devDependencies": {
     "bluebird": "3.4.6",


### PR DESCRIPTION
refs TryGhost/Ghost#7466
- Node v6.9 became LTS on 18th Oct
- Node v0.10 is EOL on 31st Oct
- These values are consistent with Ghost, for the v0.11 LTS stream of Ghost
- On Ghost master, these values match ember-cli
