### PR TITLE
Fix empty subscribers import modal

### DIFF
--- a/app/templates/components/modals/import-subscribers.hbs
+++ b/app/templates/components/modals/import-subscribers.hbs
@@ -10,7 +10,7 @@
 <a class="close icon-x" href="" title="Close" {{action "closeModal"}}><span class="hidden">Close</span></a>
 
 <div class="modal-body">
-    {{#liquid-if response class="fade-transition"}}
+    {{#if response}}
         <table class="subscribers-import-results">
             <tr>
                 <td>Imported:</td>
@@ -37,7 +37,7 @@
             uploadStarted=(action "uploadStarted")
             uploadFinished=(action "uploadFinished")
             uploadSuccess=(action "uploadSuccess")}}
-    {{/liquid-if}}
+    {{/if}}
 </div>
 
 <div class="modal-footer">


### PR DESCRIPTION
no issue
- recent changes to the way our modals work has resulted in the subscribers import modal appearing blank. The `liquid-if` used for transitioning between upload and result state doesn't run properly and the styles end up hiding the contents
- this PR is a quick-fix that removes the animated transition so that imports are still possible