### PR TITLE
Updated ghost-editor to 0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "ember-wormhole": "0.5.0",
     "emberx-file-input": "1.1.0",
     "fs-extra": "1.0.0",
-    "ghost-editor": "0.1.1",
+    "ghost-editor": "0.1.4",
     "glob": "7.1.1",
     "grunt": "1.0.1",
     "grunt-bg-shell": "2.3.3",


### PR DESCRIPTION
For some reason greenkeeper isn't upgrading ghost-editor. This upgrades it to the latest version.