### PR TITLE
✨  Blog icon upload

### DIFF
--- a/app/controllers/settings/general.js
+++ b/app/controllers/settings/general.js
@@ -14,6 +14,7 @@ export default Controller.extend(SettingsSaveMixin, {
 
     showUploadLogoModal: false,
     showUploadCoverModal: false,
+    showUploadIconModal: false,
     showDeleteThemeModal: notEmpty('themeToDelete'),
 
     ajax: injectService(),
@@ -24,8 +25,15 @@ export default Controller.extend(SettingsSaveMixin, {
     _scratchFacebook: null,
     _scratchTwitter: null,
 
+    iconMimeTypes: 'image/png,image/x-icon',
+    iconExtensions: ['ico', 'png'],
+
     logoImageSource: computed('model.logo', function () {
         return this.get('model.logo') || '';
+    }),
+
+    iconImageSource: computed('model.icon', function () {
+        return this.get('model.icon') || '';
     }),
 
     coverImageSource: computed('model.cover', function () {
@@ -129,6 +137,10 @@ export default Controller.extend(SettingsSaveMixin, {
 
         toggleUploadLogoModal() {
             this.toggleProperty('showUploadLogoModal');
+        },
+
+        toggleUploadIconModal() {
+            this.toggleProperty('showUploadIconModal');
         },
 
         validateFacebookUrl() {

--- a/app/models/setting.js
+++ b/app/models/setting.js
@@ -10,6 +10,7 @@ export default Model.extend(ValidationEngine, {
     description: attr('string'),
     logo: attr('string'),
     cover: attr('string'),
+    icon: attr('string'),
     defaultLang: attr('string'),
     postsPerPage: attr('number'),
     forceI18n: attr('boolean'),

--- a/app/templates/components/gh-image-uploader.hbs
+++ b/app/templates/components/gh-image-uploader.hbs
@@ -19,10 +19,11 @@
                 <div class="description">{{description}}</div>
             {{/gh-file-input}}
         </div>
-
-        <a class="image-url" {{action "switchForm" "url-input"}}>
-            <i class="icon-link"><span class="hidden">URL</span></i>
-        </a>
+        {{#if allowUrlInput}}
+            <a class="image-url" {{action "switchForm" "url-input"}}>
+                <i class="icon-link"><span class="hidden">URL</span></i>
+            </a>
+        {{/if}}
     {{else}}
         {{!-- URL input --}}
         <form class="url-form">

--- a/app/templates/components/modals/upload-image.hbs
+++ b/app/templates/components/modals/upload-image.hbs
@@ -12,6 +12,10 @@
             saveButton=false
             update=(action 'fileUploaded')
             onInput=(action (mut newUrl))
+            accept=model.accept
+            extensions=model.extensions
+            allowUrlInput=model.allowUrlInput
+            uploadUrl=model.uploadUrl
         }}
     {{/if}}
 </div>

--- a/app/templates/settings/general.hbs
+++ b/app/templates/settings/general.hbs
@@ -39,11 +39,30 @@
 
                 {{#if showUploadLogoModal}}
                     {{gh-fullscreen-modal "upload-image"
-                            model=(hash model=model imageProperty="logo")
+                            model=(hash model=model imageProperty="logo" allowUrlInput=true)
                             close=(action "toggleUploadLogoModal")
                             modifier="action wide"}}
                 {{/if}}
             </div>
+
+            {{#if config.fileStorage}}
+                <div class="form-group">
+                    <label>Blog Icon</label>
+                    {{#if model.icon}}
+                        <img class="blog-icon" src="{{model.icon}}" alt="icon" role="button" {{action "toggleUploadIconModal"}}>
+                    {{else}}
+                        <button type="button" class="btn btn-green js-modal-logo" {{action "toggleUploadIconModal"}}>Upload Image</button>
+                    {{/if}}
+                    <p>Upload a square blog icon ('.ico' or '.png', max. 100kb, 32px * 32px up to 1,000px * 1,000px) for your publication</p>
+
+                    {{#if showUploadIconModal}}
+                        {{gh-fullscreen-modal "upload-image"
+                                model=(hash model=model imageProperty="icon" accept=iconMimeTypes extensions=iconExtensions allowUrlInput=false uploadUrl="/uploads/icon/")
+                                close=(action "toggleUploadIconModal")
+                                modifier="action wide"}}
+                    {{/if}}
+                </div>
+            {{/if}}
 
             <div class="form-group">
                 <label>Blog Cover</label>
@@ -56,7 +75,7 @@
 
                 {{#if showUploadCoverModal}}
                     {{gh-fullscreen-modal "upload-image"
-                            model=(hash model=model imageProperty="cover")
+                            model=(hash model=model imageProperty="cover" allowUrlInput=true)
                             close=(action "toggleUploadCoverModal")
                             modifier="action wide"}}
                 {{/if}}

--- a/app/templates/team/user.hbs
+++ b/app/templates/team/user.hbs
@@ -53,7 +53,7 @@
             <button class="btn btn-default user-cover-edit" {{action "toggleUploadCoverModal"}}>Change Cover</button>
             {{#if showUploadCoverModal}}
                 {{gh-fullscreen-modal "upload-image"
-                                      model=(hash model=user imageProperty="cover")
+                                      model=(hash model=user imageProperty="cover" allowUrlInput=true)
                                       close=(action "toggleUploadCoverModal")
                                       modifier="action wide"}}
             {{/if}}
@@ -72,7 +72,7 @@
                     <button type="button" {{action "toggleUploadImageModal"}} class="edit-user-image">Edit Picture</button>
                     {{#if showUploadImageModal}}
                         {{gh-fullscreen-modal "upload-image"
-                                              model=(hash model=user imageProperty="image")
+                                              model=(hash model=user imageProperty="image" allowUrlInput=true)
                                               close=(action "toggleUploadImageModal")
                                               modifier="action wide"}}
                     {{/if}}

--- a/mirage/fixtures/settings.js
+++ b/mirage/fixtures/settings.js
@@ -227,5 +227,15 @@ export default [
         updated_at: '2017-01-09T08:49:42.991Z',
         updated_by: 1,
         value: 'true'
+    },
+    {
+        id: 22,
+        key: 'icon',
+        value: '/content/images/2014/Feb/favicon.ico',
+        type: 'blog',
+        created_at: '2013-11-25T14:48:11.000Z',
+        created_by: 1,
+        updated_at: '2015-10-27T17:39:58.276Z',
+        updated_by: 1
     }
 ];

--- a/tests/acceptance/settings/general-test.js
+++ b/tests/acceptance/settings/general-test.js
@@ -16,11 +16,11 @@ import mockThemes from 'ghost-admin/mirage/config/themes';
 describe('Acceptance: Settings - General', function () {
     let application;
 
-    beforeEach(function() {
+    beforeEach(function () {
         application = startApp();
     });
 
-    afterEach(function() {
+    afterEach(function () {
         destroyApp(application);
     });
 
@@ -28,7 +28,7 @@ describe('Acceptance: Settings - General', function () {
         invalidateSession(application);
         visit('/settings/general');
 
-        andThen(function() {
+        andThen(function () {
             expect(currentURL(), 'currentURL').to.equal('/signin');
         });
     });
@@ -104,6 +104,27 @@ describe('Acceptance: Settings - General', function () {
 
             andThen(() => {
                 expect(find('.fullscreen-modal .modal-content .gh-image-uploader .description').text()).to.equal('Upload an image');
+                expect(find('.fullscreen-modal .modal-content .gh-image-uploader .image-url').length, 'url upload').to.equal(1);
+            });
+
+            // click cancel button
+            click('.fullscreen-modal .modal-footer .btn.btn-minor');
+
+            andThen(() => {
+                expect(find('.fullscreen-modal').length).to.equal(0);
+            });
+
+            click('.blog-icon');
+
+            andThen(() => {
+                expect(find('.fullscreen-modal .modal-content .gh-image-uploader').length, 'modal selector').to.equal(1);
+            });
+
+            click('.fullscreen-modal .modal-content .gh-image-uploader .image-cancel');
+
+            andThen(() => {
+                expect(find('.fullscreen-modal .modal-content .gh-image-uploader .description').text()).to.equal('Upload an image');
+                expect(find('.fullscreen-modal .modal-content .gh-image-uploader .image-url').length, 'url upload').to.equal(0);
             });
 
             // click cancel button


### PR DESCRIPTION
refs TryGhost/Ghost#7688
needs TryGhost/Ghost#7893

Adds new upload functionality for a blog icon in general settings.
Icons will be uploaded to a new endpoint `uploads/icons` to trigger different validations.

Todo:
- [X] add client side validation
- [X] remove form switch for URL upload (only for blog icon)
- [ ] get feedback/spec for design & wording
- [X] write tests