### PR TITLE
Remove UUID attrs from all models except Post

### DIFF
--- a/app/mirage/factories/role.js
+++ b/app/mirage/factories/role.js
@@ -6,6 +6,5 @@ export default Mirage.Factory.extend({
     description(i) { return `Role ${i}`; },
     name() { return ''; },
     updated_at() { return '2013-11-25T14:48:11.000Z'; },
-    updated_by() { return 1; },
-    uuid(i) { return `role-${i}`; }
+    updated_by() { return 1; }
 });

--- a/app/mirage/factories/setting.js
+++ b/app/mirage/factories/setting.js
@@ -1,7 +1,6 @@
 import Mirage from 'ember-cli-mirage';
 
 export default Mirage.Factory.extend({
-    uuid(i) { return `setting-${i}`; },
     key(i) { return `setting-${i}`; },
     value() { return null; },
     type() { return 'blog'; },

--- a/app/mirage/factories/subscriber.js
+++ b/app/mirage/factories/subscriber.js
@@ -8,7 +8,6 @@ let statuses = ['pending', 'subscribed'];
 
 /* eslint-disable camelcase, brace-style */
 export default Mirage.Factory.extend({
-    uuid(i) { return `subscriber-${i}`; },
     name() { return `${faker.name.firstName()} ${faker.name.lastName()}`; },
     email() { return faker.internet.email(); },
     status() { return statuses[Math.floor(Math.random() * statuses.length)]; },

--- a/app/mirage/factories/tag.js
+++ b/app/mirage/factories/tag.js
@@ -13,7 +13,6 @@ export default Mirage.Factory.extend({
     slug(i) { return  `tag-${i}`; },
     updated_at() { return  '2015-10-19T16:25:07.756Z'; },
     updated_by() { return  1; },
-    uuid(i) { return  `tag-${i}`; },
     count() {
         return {
             posts: 1

--- a/app/mirage/factories/user.js
+++ b/app/mirage/factories/user.js
@@ -19,7 +19,6 @@ export default Mirage.Factory.extend({
     tour() { return null; },
     updated_at() { return '2015-11-02T16:12:05.000Z'; },
     updated_by() { return '2015-09-02T13:41:50.000Z'; },
-    uuid(i) { return `user-${i}`; },
     website() { return 'http://example.com'; },
 
     roles() { return []; }

--- a/app/mirage/fixtures/roles.js
+++ b/app/mirage/fixtures/roles.js
@@ -2,7 +2,6 @@
 export default [
     {
         id: 1,
-        uuid: 'b2576c4e-fa4e-41d4-8236-ced75f735222',
         name: 'Administrator',
         description: 'Administrators',
         created_at: '2015-11-13T16:01:29.131Z',
@@ -12,7 +11,6 @@ export default [
     },
     {
         id: 2,
-        uuid: '6ee03efb-322e-4f6e-9c91-bc228b5eec6b',
         name: 'Editor',
         description: 'Editors',
         created_at: '2015-11-13T16:01:29.131Z',
@@ -22,7 +20,6 @@ export default [
     },
     {
         id: 3,
-        uuid: 'de481b62-63f8-42c7-b5b9-6c5f5a877f53',
         name: 'Author',
         description: 'Authors',
         created_at: '2015-11-13T16:01:29.131Z',
@@ -32,7 +29,6 @@ export default [
     },
     {
         id: 4,
-        uuid: 'ac8cbaf6-e6be-4129-b0fb-ec9ddfa61056',
         name: 'Owner',
         description: 'Blog Owner',
         created_at: '2015-11-13T16:01:29.132Z',

--- a/app/mirage/fixtures/settings.js
+++ b/app/mirage/fixtures/settings.js
@@ -8,7 +8,6 @@ export default [
         type: 'blog',
         updated_at: '2015-10-04T16:26:05.195Z',
         updated_by: 1,
-        uuid: '39e16daf-43fa-4bf0-87d4-44948ba8bf4c',
         value: 'Test Blog'
     },
     {
@@ -19,12 +18,10 @@ export default [
         type: 'blog',
         updated_at: '2015-10-04T16:26:05.198Z',
         updated_by: 1,
-        uuid: 'e6c8b636-6925-4c4a-a5d9-1dc0870fb8ea',
         value: 'Thoughts, stories and ideas.'
     },
     {
         id: 3,
-        uuid: '4339ce48-b485-418a-acc2-1d34cf17a5e3',
         key: 'logo',
         value: '/content/images/2013/Nov/logo.png',
         type: 'blog',
@@ -35,7 +32,6 @@ export default [
     },
     {
         id: 4,
-        uuid: 'e41b6c2a-7f72-45ea-96d8-ee016f06d78b',
         key: 'cover',
         value: '/content/images/2014/Feb/cover.jpg',
         type: 'blog',
@@ -46,7 +42,6 @@ export default [
     },
     {
         id: 5,
-        uuid: '4558457e-9f61-47a5-9d45-8b83829bf1cf',
         key: 'defaultLang',
         value: 'en_US',
         type: 'blog',
@@ -63,12 +58,10 @@ export default [
         type: 'blog',
         updated_at: '2015-10-04T16:26:05.211Z',
         updated_by: 1,
-        uuid: '775e6ca1-bcc3-4347-a53d-15d5d76c04a4',
         value: '5'
     },
     {
         id: 7,
-        uuid: '3c93b240-d22b-473f-9063-537023e06c2d',
         key: 'forceI18n',
         value: 'true',
         type: 'blog',
@@ -79,7 +72,6 @@ export default [
     },
     {
         id: 8,
-        uuid: '4e58389f-f173-4387-b28c-0435623882ad',
         key: 'activeTheme',
         value: 'casper',
         type: 'theme',
@@ -90,7 +82,6 @@ export default [
     },
     {
         id: 9,
-        uuid: '8052c2bf-9c19-4d6c-8944-7465321d00be',
         key: 'permalinks',
         value: '/:slug/',
         type: 'blog',
@@ -107,7 +98,6 @@ export default [
         type: 'blog',
         updated_at: '2015-09-23T13:32:49.858Z',
         updated_by: 1,
-        uuid: 'df7f3151-bc08-4a77-be9d-dd315b630d51',
         value: ''
     },
     {
@@ -118,12 +108,10 @@ export default [
         type: 'blog',
         updated_at: '2015-09-23T13:32:49.858Z',
         updated_by: 1,
-        uuid: '0649d45e-828b-4dd0-8381-3dff6d1d5ddb',
         value: ''
     },
     {
         id: 12,
-        uuid: 'd806f358-7996-4c74-b153-8876959c4b70',
         key: 'labs',
         value: '{"subscribers":true}',
         type: 'blog',
@@ -140,7 +128,6 @@ export default [
         type: 'blog',
         updated_at: '2015-09-23T13:32:49.868Z',
         updated_by: 1,
-        uuid: '4cc51d1c-fcbd-47e6-a71b-fdd1abb223fc',
         value: JSON.stringify([
             {label: 'Home', url: '/'},
             {label: 'About', url: '/about'}
@@ -154,7 +141,6 @@ export default [
         type: 'blog',
         updated_at: '2015-09-23T13:32:49.868Z',
         updated_by: 1,
-        uuid: 'e306ec3e-d079-11e5-ab30-625662870761',
         value: false
     },
     {
@@ -165,7 +151,6 @@ export default [
         type: 'blog',
         updated_at: '2015-09-23T13:32:49.868Z',
         updated_by: 1,
-        uuid: 'f8e8cbda-d079-11e5-ab30-625662870761',
         value: ''
     },
     {
@@ -176,7 +161,6 @@ export default [
         type: 'blog',
         updated_at: '2016-05-05T18:33:09.168Z',
         updated_by: 1,
-        uuid: 'dd4ebaa8-dedb-40ff-a663-ec64a92d4111',
         value: '[{"url":""}]'
     },
     {
@@ -187,7 +171,6 @@ export default [
         type: 'blog',
         updated_at: '2016-05-08T15:20:25.953Z',
         updated_by: 1,
-        uuid: 'd4387e5c-3230-46dd-a89b-0d8a40365c35',
         value: 'test'
     },
     {
@@ -198,7 +181,6 @@ export default [
         type: 'blog',
         updated_at: '2016-05-08T15:20:25.954Z',
         updated_by: 1,
-        uuid: '5130441f-e4c7-4750-9692-a22d841ab049',
         value: '@test'
     },
     {
@@ -209,7 +191,6 @@ export default [
         type: 'blog',
         updated_at: '2015-09-23T13:32:49.868Z',
         updated_by: 1,
-        uuid: '310c9169-9613-48b0-8bc4-d1e1c9be85b8',
         value: 'Etc/UTC'
     },
     {

--- a/app/models/role.js
+++ b/app/models/role.js
@@ -4,7 +4,6 @@ import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 
 export default Model.extend({
-    uuid: attr('string'),
     name: attr('string'),
     description: attr('string'),
     createdAtUTC: attr('moment-utc'),

--- a/app/models/subscriber.js
+++ b/app/models/subscriber.js
@@ -6,7 +6,6 @@ import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 export default Model.extend(ValidationEngine, {
     validationType: 'subscriber',
 
-    uuid: attr('string'),
     name: attr('string'),
     email: attr('string'),
     status: attr('string'),

--- a/app/models/tag.js
+++ b/app/models/tag.js
@@ -1,7 +1,8 @@
 /* eslint-disable camelcase */
-import {equal} from 'ember-computed';
+import computed, {equal} from 'ember-computed';
 import observer from 'ember-metal/observer';
 import injectService from 'ember-service/inject';
+import {guidFor} from 'ember-metal/utils';
 
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
@@ -10,7 +11,6 @@ import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 export default Model.extend(ValidationEngine, {
     validationType: 'tag',
 
-    uuid: attr('string'),
     name: attr('string'),
     slug: attr('string'),
     description: attr('string'),
@@ -29,6 +29,13 @@ export default Model.extend(ValidationEngine, {
     isPublic: equal('visibility', 'public'),
 
     feature: injectService(),
+
+    // HACK: ugly hack to main compatibility with selectize as used in the
+    // PSM tags input
+    // TODO: remove once we've switched over to EPS for the tags input
+    uuid: computed(function () {
+        return guidFor(this);
+    }),
 
     setVisibility() {
         let internalRegex = /^#.?/;

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -11,7 +11,6 @@ import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 export default Model.extend(ValidationEngine, {
     validationType: 'user',
 
-    uuid: attr('string'),
     name: attr('string'),
     slug: attr('string'),
     email: attr('string'),

--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -14,9 +14,6 @@ export default RESTSerializer.extend({
         let root = pluralize(type.modelName);
         let data = this.serialize(record, options);
 
-        // Don't ever pass uuid's
-        delete data.uuid;
-
         hash[root] = [data];
     },
 

--- a/app/serializers/tag.js
+++ b/app/serializers/tag.js
@@ -19,7 +19,6 @@ export default ApplicationSerializer.extend({
 
         // Properties that exist on the model but we don't want sent in the payload
 
-        delete data.uuid;
         delete data.count;
 
         hash[root] = [data];


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/7494
- remove `uuid` attrs from all models except Post
- remove uuids from mirage factories and fixtures
- add a workaround for tags where the selectize-based tags input on the PSM relies on a unique identifier for each tag which doesn't get sent back to the server when saving (fixes the broken tags input caused by uuid removal in https://github.com/TryGhost/Ghost/pull/7495)