### PR TITLE
Fix inability to write posts as an author

### DIFF
--- a/app/models/post.js
+++ b/app/models/post.js
@@ -82,7 +82,7 @@ export default Model.extend(Comparable, ValidationEngine, {
     metaTitle: attr('string'),
     metaDescription: attr('string'),
     author: belongsTo('user', {async: true}),
-    authorId: attr('number'),
+    authorId: attr('string'),
     updatedAtUTC: attr('moment-utc'),
     updatedBy: attr(),
     publishedAtUTC: attr('moment-utc'),
@@ -149,7 +149,7 @@ export default Model.extend(Comparable, ValidationEngine, {
     },
 
     isAuthoredByUser(user) {
-        return parseInt(user.get('id'), 10) === parseInt(this.get('authorId'), 10);
+        return user.get('id') === this.get('authorId');
     },
 
     // a custom sort function is needed in order to sort the posts list the same way the server would:
@@ -175,7 +175,8 @@ export default Model.extend(Comparable, ValidationEngine, {
             return 1;
         }
 
-        idResult = compare(parseInt(postA.get('id')), parseInt(postB.get('id')));
+        // TODO: revisit the ID sorting because we no longer have auto-incrementing IDs
+        idResult = compare(postA.get('id'), postB.get('id'));
         statusResult = statusCompare(postA, postB);
         updatedAtResult = compare(updated1.valueOf(), updated2.valueOf());
         publishedAtResult = publishedAtCompare(postA, postB);

--- a/tests/unit/models/post-test.js
+++ b/tests/unit/models/post-test.js
@@ -46,17 +46,15 @@ describeModel(
         });
 
         it('isAuthoredByUser is correct', function () {
-            /* eslint-disable camelcase */
             let model = this.subject({
-                authorId: 15
+                authorId: 'abcd1234'
             });
-            /* eslint-enable camelcase */
-            let user = EmberObject.create({id: '15'});
+            let user = EmberObject.create({id: 'abcd1234'});
 
             expect(model.isAuthoredByUser(user)).to.be.ok;
 
             run(function () {
-                model.set('authorId', 1);
+                model.set('authorId', 'wxyz9876');
 
                 expect(model.isAuthoredByUser(user)).to.not.be.ok;
             });


### PR DESCRIPTION
closes TryGhost/Ghost#7730
- treat `Post.authorID` as a string not a number as it's now an objectid
- update `isAuthoredByUser` method so that author's posts aren't hidden from them
- update the post compare method so that it doesn't try to parse objectids as integers (may need revisiting now that we don't have auto-increment IDs to fall back on)