### PR TITLE
Improve test timing with ember-exam

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "start": "ember server",
     "build": "ember build",
-    "test": "ember test",
+    "test": "ember exam --split=2 --parallel",
     "lint": "ember test --launch phantomjs -f 'ESLint'"
   },
   "engines": {
@@ -58,6 +58,7 @@
     "ember-concurrency": "0.7.15",
     "ember-data": "2.9.0",
     "ember-data-filter": "1.13.0",
+    "ember-exam": "0.6.0",
     "ember-export-application-global": "1.1.1",
     "ember-invoke-action": "1.4.0",
     "ember-light-table": "1.6.1",

--- a/testem.js
+++ b/testem.js
@@ -1,6 +1,7 @@
 /* eslint-env node */
 module.exports = {
     'framework': 'mocha',
+    'parallel': 2,
     'test_page': 'tests/index.html?hidepassed',
     'disable_watching': true,
     'launch_in_ci': [


### PR DESCRIPTION
ember-exam now supports mocha, so this updates Travis testing to use ember-exam.

TODO: play around with parallel/split numbers to maximize efficiency