### PR TITLE
🐛 fix oAuth login for blog urls which contain `/ghost`

### DIFF
--- a/app/torii-providers/ghost-oauth2.js
+++ b/app/torii-providers/ghost-oauth2.js
@@ -19,7 +19,10 @@ let GhostOauth2 = Oauth2.extend({
     responseParams: ['code'],
 
     // we want to redirect to the ghost admin app by default
-    redirectUri: window.location.href.replace(/(\/ghost)(.*)/, '$1/'),
+    init() {
+        this._super(...arguments);
+        this.set('redirectUri', `${this.get('config.blogUrl')}/ghost/`);
+    },
 
     open(options) {
         if (options.type) {


### PR DESCRIPTION
no issue
- use the configured `blogUrl` value rather than using `window.location.href` with a poor regex that was incorrectly matching on domains containing multiple `/ghost` parts such as `http://ghost.local:2368/ghost`