### PR TITLE
🐛 fix session restoration on setup/three with temp token

### DIFF
--- a/app/routes/setup.js
+++ b/app/routes/setup.js
@@ -37,16 +37,22 @@ export default Route.extend(styleBody, {
             // simulate a completed step 2 and skip other setup bits
             this.controllerFor('setup.two').set('blogCreated', true);
 
+            /* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
             return this.get('ajax')
                 .post(tokenExchangeUrl, {data: {
                     token,
                     client_id: this.get('config.clientId'),
                     client_secret: this.get('config.clientSecret')
                 }}).then((data) => {
-                    return this.get('session').session.store.restore(data);
+                    delete data.errors;
+                    data.authenticator = 'authenticator:oauth2';
+
+                    this.get('session.session.store').persist({authenticated: data});
+                    this.get('session.session').restore();
                 }).catch(() => {
                     return this.transitionTo('signin');
                 });
+            /* jscs:enable requireCamelCaseOrUpperCaseIdentifiers */
         }
 
         let authUrl = this.get('ghostPaths.url').api('authentication', 'setup');


### PR DESCRIPTION
no issue
- fixes an issue where landing on setup/three with a temporary token would appear to work until you clicked the invite or skip buttons at which point you landed back on the signin screen
- ESA requires data to be persisted to the store (LocalStorage/cookie) before a session can be "restored"