### PR TITLE
💄 expires_in is always in seconds

### DIFF
--- a/app/routes/setup.js
+++ b/app/routes/setup.js
@@ -44,8 +44,13 @@ export default Route.extend(styleBody, {
                     client_id: this.get('config.clientId'),
                     client_secret: this.get('config.clientSecret')
                 }}).then((data) => {
+                    let now = (new Date()).getTime();
+
                     delete data.errors;
                     data.authenticator = 'authenticator:oauth2';
+                    data.token_type = 'Bearer';
+                    // server returns seconds, ESA stores expiry in ms
+                    data.expires_at = new Date(now + data.expires_in * 1000).getTime();
 
                     this.get('session.session.store').persist({authenticated: data});
                     this.get('session.session').restore();


### PR DESCRIPTION
no issue
- the `/authentication/setup/three/` endpoint is now returning seconds in order to be consistent with all other oauth2 responses, this PR updates our response handling to convert seconds to ms and store the coorect `expires_at` value
- adds `token_type: 'Bearer'` to the session config to fully match a normally acquired session