### PR TITLE
add extra escaping when using htmlSafe on user input

### DIFF
--- a/app/components/gh-posts-list-item.js
+++ b/app/components/gh-posts-list-item.js
@@ -9,7 +9,7 @@ import ActiveLinkWrapper from 'ghost-admin/mixins/active-link-wrapper';
 import {invokeAction} from 'ember-invoke-action';
 
 // ember-cli-shims doesn't export these
-const {ObjectProxy, PromiseProxyMixin} = Ember;
+const {Handlebars, ObjectProxy, PromiseProxyMixin} = Ember;
 
 const ObjectPromiseProxy = ObjectProxy.extend(PromiseProxyMixin);
 
@@ -37,7 +37,9 @@ export default Component.extend(ActiveLinkWrapper, {
     }),
 
     authorAvatarBackground: computed('authorAvatar', function () {
-        return htmlSafe(`background-image: url(${this.get('authorAvatar')})`);
+        let authorAvatar = this.get('authorAvatar');
+        let safeUrl = Handlebars.Utils.escapeExpression(authorAvatar);
+        return htmlSafe(`background-image: url(${safeUrl})`);
     }),
 
     blogTimezone: computed('timeZone.blogTimezone', function () {

--- a/app/components/gh-tag-settings-form.js
+++ b/app/components/gh-tag-settings-form.js
@@ -65,6 +65,7 @@ export default Component.extend({
 
         if (seoURL.length > 70) {
             seoURL = seoURL.substring(0, 70).trim();
+            seoURL = Handlebars.Utils.escapeExpression(seoURL);
             seoURL = htmlSafe(`${seoURL}&hellip;`);
         }
 

--- a/app/components/gh-user-active.js
+++ b/app/components/gh-user-active.js
@@ -1,7 +1,11 @@
+import Ember from 'ember';
 import Component from 'ember-component';
 import computed from 'ember-computed';
 import injectService from 'ember-service/inject';
 import {htmlSafe} from 'ember-string';
+
+// ember-cli-shims doesn't export these
+const {Handlebars} = Ember;
 
 export default Component.extend({
     tagName: '',
@@ -16,8 +20,9 @@ export default Component.extend({
 
     userImageBackground: computed('user.image', 'userDefault', function () {
         let url = this.get('user.image') || this.get('userDefault');
+        let safeUrl = Handlebars.Utils.escapeExpression(url);
 
-        return htmlSafe(`background-image: url(${url})`);
+        return htmlSafe(`background-image: url(${safeUrl})`);
     }),
 
     lastLoginUTC: computed('user.lastLoginUTC', function () {

--- a/app/controllers/post-settings-menu.js
+++ b/app/controllers/post-settings-menu.js
@@ -113,6 +113,7 @@ export default Controller.extend(SettingsMenuMixin, {
 
         if (seoURL.length > 70) {
             seoURL = seoURL.substring(0, 70).trim();
+            seoURL = Handlebars.Utils.escapeExpression(seoURL);
             seoURL = htmlSafe(`${seoURL}&hellip;`);
         }
 

--- a/app/controllers/team/user.js
+++ b/app/controllers/team/user.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import Controller from 'ember-controller';
 import computed, {alias, and, not, or, readOnly} from 'ember-computed';
 import injectService from 'ember-service/inject';
@@ -9,6 +10,9 @@ import {task, taskGroup} from 'ember-concurrency';
 
 import isNumber from 'ghost-admin/utils/isNumber';
 import boundOneWay from 'ghost-admin/utils/bound-one-way';
+
+// ember-cli-shims doesn't export this
+const {Handlebars} = Ember;
 
 export default Controller.extend({
     showDeleteUserModal: false,
@@ -62,8 +66,9 @@ export default Controller.extend({
 
     userImageBackground: computed('user.image', 'userDefault', function () {
         let url = this.get('user.image') || this.get('userDefault');
+        let safeUrl = Handlebars.Utils.escapeExpression(url);
 
-        return htmlSafe(`background-image: url(${url})`);
+        return htmlSafe(`background-image: url(${safeUrl})`);
     }),
     // end duplicated
 
@@ -73,8 +78,9 @@ export default Controller.extend({
 
     coverImageBackground: computed('user.cover', 'coverDefault', function () {
         let url = this.get('user.cover') || this.get('coverDefault');
+        let safeUrl = Handlebars.Utils.escapeExpression(url);
 
-        return htmlSafe(`background-image: url(${url})`);
+        return htmlSafe(`background-image: url(${safeUrl})`);
     }),
 
     coverTitle: computed('user.name', function () {


### PR DESCRIPTION
no issue
- ensure that we always pre-escape user input when it's used within `htmlSafe` marked output

I tried to exploit areas we use `htmlSafe` pretty heavily and was unable to (Handlebars/HTMLbars does a good job of preventing this sort of thing) so this PR isn't strictly necessary but I think it's good practice and makes sure that we are demonstrating the best use of `htmlSafe` throughout the codebase.