### PR TITLE
remove ember-watson dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "ember-simple-auth": "1.1.0",
     "ember-sinon": "0.6.0",
     "ember-sortable": "1.9.0",
-    "ember-watson": "0.8.3",
     "ember-wormhole": "0.5.1",
     "emberx-file-input": "1.1.0",
     "eslint-plugin-ember-suave": "1.0.0",


### PR DESCRIPTION
no issue
- ember-watson does not need to be included in our dependency list, it has limited one-time usage and is better used as a global install for developers who want to run any of it's codemods