### PR TITLE
Show error message for invalid data in PostsPerPage LTS

### DIFF
--- a/app/controllers/settings/general.js
+++ b/app/controllers/settings/general.js
@@ -89,14 +89,6 @@ export default Controller.extend(SettingsSaveMixin, {
     },
 
     actions: {
-        checkPostsPerPage() {
-            let postsPerPage = this.get('model.postsPerPage');
-
-            if (postsPerPage < 1 || postsPerPage > 1000 || isNaN(postsPerPage)) {
-                this.set('model.postsPerPage', 5);
-            }
-        },
-
         setTheme(theme) {
             this.set('model.activeTheme', theme.name);
             this.send('save');

--- a/app/templates/settings/general.hbs
+++ b/app/templates/settings/general.hbs
@@ -65,10 +65,13 @@
             <fieldset>
 
                 <div class="form-group">
-                    <label for="postsPerPage">Posts per page</label>
-                    {{! `pattern` brings up numeric keypad allowing any number of digits}}
-                    {{gh-input model.postsPerPage id="postsPerPage" name="general[postsPerPage]" focus-out="checkPostsPerPage" min="1" max="1000" type="number" pattern="[0-9]*" update=(action (mut model.postsPerPage))}}
-                    <p>How many posts should be displayed on each page</p>
+                    {{#gh-form-group errors=model.errors hasValidated=model.hasValidated property="postsPerPage"}}
+                        <label for="postsPerPage">Posts per page</label>
+                        {{! `pattern` brings up numeric keypad allowing any number of digits}}
+                        {{gh-input model.postsPerPage id="postsPerPage" name="general[postsPerPage]" focusOut=(action "validate" "postsPerPage" target=model) min="1" max="1000" type="number" pattern="[0-9]*" update=(action (mut model.postsPerPage))}}
+                        {{gh-error-message errors=model.errors property="postsPerPage"}}
+                        <p>How many posts should be displayed on each page</p>
+                    {{/gh-form-group}}
                 </div>
 
                 <div class="form-group for-checkbox">


### PR DESCRIPTION
closes #7746
- Added gh-form-group around PostsPerPage
- Changed focusOut action to validate
- Removed now redundant `checkPostsPerPage()` call
