### PR TITLE
deps ember-cli-htmlbars-inline-precompile@0.3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "ember-cli-deprecation-workflow": "0.2.3",
     "ember-cli-fastclick": "1.3.0",
     "ember-cli-htmlbars": "1.1.0",
-    "ember-cli-htmlbars-inline-precompile": "0.3.5",
+    "ember-cli-htmlbars-inline-precompile": "0.3.6",
     "ember-cli-jshint": "2.0.1",
     "ember-cli-mirage": "0.1.14",
     "ember-cli-mocha": "0.10.4",


### PR DESCRIPTION
This seemed to fix the lts tests locally

![image](https://cloud.githubusercontent.com/assets/5167581/21679854/6b8d5138-d303-11e6-91b7-bcf46d7da656.png)
