### PR TITLE
add manual pretender shutdown to remove warnings in test logs

### DIFF
--- a/tests/helpers/destroy-app.js
+++ b/tests/helpers/destroy-app.js
@@ -1,5 +1,10 @@
 import run from 'ember-runloop';
 
 export default function destroyApp(application) {
+    // this is required to fix "second Pretender instance" warnings
+    if (server) {
+        server.shutdown();
+    }
+
     run(application, 'destroy');
 }


### PR DESCRIPTION
no issue
- a [recent update](https://github.com/pretenderjs/pretender/pull/178) to Pretender contained a change that throws warnings when multiple pretender instances exist
- using mirage in acceptance tests was [triggering the warning](https://github.com/samselikoff/ember-cli-mirage/issues/915)