### PR TITLE
fix tests on LTS

### DIFF
--- a/tests/helpers/destroy-app.js
+++ b/tests/helpers/destroy-app.js
@@ -1,5 +1,11 @@
 import run from 'ember-runloop';
+import $ from 'jquery';
 
 export default function destroyApp(application) {
+    // this is required because it gets injected during acceptance tests but
+    // not removed meaning that the integration tests grab this element rather
+    // than their rendered content
+    $('.liquid-target-container').remove();
+
     run(application, 'destroy');
 }


### PR DESCRIPTION
no issue
- `liquid-tether` which we use for modals leaves container elements behind when it's used within acceptance tests which then interfere with the integration tests because integration tests expect the first element in the testing container to be the rendered component