### PR TITLE
Add code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,7 @@ before_script:
   - export DISPLAY=:99; sh -e /etc/init.d/xvfb start; sleep 3;
 
 script:
-  - if [ "$TEST_SUITE" == "lint" ]; then npm run lint; else npm test; fi
+  - COVERAGE=true npm test
+
+after_success:
+  - npm run coverage

--- a/app/mirage/config.js
+++ b/app/mirage/config.js
@@ -32,6 +32,7 @@ export default function () {
 
 // Mock all endpoints here as there is no real API during testing
 export function testConfig() {
+    this.passthrough('/write-coverage'); // For code coverage
     // this.urlPrefix = '';    // make this `http://localhost:8080`, for example, if your API is on a different server
     this.namespace = '/ghost/api/v0.1';    // make this `api`, for example, if your API is namespaced
     // this.timing = 400;      // delay for each request, automatically set to 0 during testing

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "start": "ember server",
     "build": "ember build",
     "test": "ember test",
-    "lint": "ember test --launch phantomjs -f 'ESLint'"
+    "lint": "ember test --launch phantomjs -f 'ESLint'",
+    "coverage": "cat ./coverage/lcov.info | coveralls"
   },
   "engines": {
     "node": "~0.12.0 || ^4.2.0"
@@ -33,12 +34,14 @@
     "broccoli-merge-trees": "1.2.1",
     "broccoli-uglify-js": "0.2.0",
     "codemirror": "5.22.0",
+    "coveralls": "2.11.15",
     "csscomb": "3.1.8",
     "ember-ajax": "2.5.3",
     "ember-cli": "2.10.0",
     "ember-cli-app-version": "2.0.1",
     "ember-cli-babel": "5.2.1",
     "ember-cli-chai": "0.3.0",
+    "ember-cli-code-coverage": "0.3.8",
     "ember-cli-content-security-policy": "0.5.0",
     "ember-cli-dependency-checker": "1.3.0",
     "ember-cli-deprecation-workflow": "0.2.3",


### PR DESCRIPTION
- add code coverage via ember-cli-code-coverage and coveralls
- improve test running by filtering out eslint tests during main test run