### PR TITLE
Dependency updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "ember-one-way-controls": "1.1.2",
     "ember-power-select": "1.2.0",
     "ember-resolver": "2.1.1",
-    "ember-route-action-helper": "2.0.1",
+    "ember-route-action-helper": "2.0.2",
     "ember-simple-auth": "1.1.0",
     "ember-sinon": "0.6.0",
     "ember-sortable": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "ember-cli-app-version": "2.0.1",
     "ember-cli-babel": "5.2.1",
     "ember-cli-chai": "0.3.2",
-    "ember-cli-code-coverage": "0.3.8",
+    "ember-cli-code-coverage": "0.3.10",
     "ember-cli-content-security-policy": "0.5.0",
     "ember-cli-dependency-checker": "1.3.0",
     "ember-cli-deprecation-workflow": "0.2.3",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "matchdep": "1.0.1",
     "moment": "2.17.1",
     "moment-timezone": "0.5.11",
-    "password-generator": "2.0.6",
+    "password-generator": "2.1.0",
     "top-gh-contribs": "2.0.4",
     "torii": "0.8.1",
     "walk-sync": "0.3.1"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "ember-load-initializers": "0.6.3",
     "ember-myth": "0.1.1",
     "ember-one-way-controls": "1.1.2",
-    "ember-power-select": "1.1.0",
+    "ember-power-select": "1.2.0",
     "ember-resolver": "2.1.1",
     "ember-route-action-helper": "2.0.1",
     "ember-simple-auth": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ember-cli-active-link-wrapper": "0.3.2",
     "ember-cli-app-version": "2.0.1",
     "ember-cli-babel": "5.2.1",
-    "ember-cli-chai": "0.3.0",
+    "ember-cli-chai": "0.3.2",
     "ember-cli-code-coverage": "0.3.8",
     "ember-cli-content-security-policy": "0.5.0",
     "ember-cli-dependency-checker": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "coveralls": "2.11.15",
     "csscomb": "3.1.8",
     "ember-ajax": "2.5.3",
-    "ember-cli": "2.10.0",
+    "ember-cli": "2.10.1",
     "ember-cli-active-link-wrapper": "0.3.2",
     "ember-cli-app-version": "2.0.1",
     "ember-cli-babel": "5.2.1",

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -6,11 +6,10 @@ import config from '../../config/environment';
 import fileUpload from './file-upload';
 
 export default function startApp(attrs) {
-    let attributes = assign({}, config.APP);
     let application;
 
-    // use defaults, but you can override;
-    attributes = assign(attributes, attrs);
+    let attributes = assign({}, config.APP);
+    attributes = assign(attributes, attrs); // use defaults, but you can override;
 
     run(function () {
         application = Application.create(attributes);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2386,9 +2386,9 @@ ember-resolver@2.1.1:
     ember-cli-babel "^5.1.6"
     ember-cli-version-checker "^1.1.6"
 
-ember-route-action-helper@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/ember-route-action-helper/-/ember-route-action-helper-2.0.1.tgz#a317c390d362ece95b854f9ddc448303e65bd811"
+ember-route-action-helper@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/ember-route-action-helper/-/ember-route-action-helper-2.0.2.tgz#6ca3f6189062f657c0c7a447e0ba12362152790f"
   dependencies:
     ember-cli-babel "^5.1.7"
     ember-getowner-polyfill "^1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1311,7 +1311,7 @@ commander@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.0.0.tgz#d1b86f901f8b64bd941bdeadaf924530393be928"
 
-commander@2.3.0, commander@^2.1.0:
+commander@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.3.0.tgz#fd430e889832ec353b9acd1de217c11cb3eef873"
 
@@ -1321,7 +1321,7 @@ commander@2.8.x:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
-commander@^2.5.0, commander@^2.6.0, commander@^2.9.0:
+commander@^2.1.0, commander@^2.5.0, commander@^2.6.0, commander@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
@@ -1786,9 +1786,9 @@ ember-cli-broccoli-sane-watcher@^2.0.3:
     rsvp "^3.0.18"
     sane "^1.1.1"
 
-ember-cli-chai@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-chai/-/ember-cli-chai-0.3.0.tgz#4597b4835783a77f3cd856e4eaa8b8e115497a1f"
+ember-cli-chai@0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/ember-cli-chai/-/ember-cli-chai-0.3.2.tgz#2850fabbcdeaae68e0a48f820a29aa68753183a8"
   dependencies:
     broccoli-funnel "^1.0.9"
     broccoli-merge-trees "^1.1.5"
@@ -5478,7 +5478,19 @@ read@1, read@~1.0.1, read@~1.0.7:
   dependencies:
     mute-stream "~0.0.4"
 
-"readable-stream@1 || 2", readable-stream@^2, "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.2, readable-stream@^2.2.2:
+"readable-stream@1 || 2", readable-stream@^2, readable-stream@^2.0.2, readable-stream@~2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.1.5.tgz#66fa8b720e1438b364681f2ad1a63c618448c9d0"
+  dependencies:
+    buffer-shims "^1.0.0"
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "~1.0.0"
+    process-nextick-args "~1.0.6"
+    string_decoder "~0.10.x"
+    util-deprecate "~1.0.1"
+
+"readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.2.tgz#a9e6fec3c7dda85f8bb1b3ba7028604556fc825e"
   dependencies:
@@ -5503,18 +5515,6 @@ readable-stream@~2.0.5:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.0.6.tgz#8f90341e68a53ccc928788dacfcd11b36eb9b78e"
   dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
-    string_decoder "~0.10.x"
-    util-deprecate "~1.0.1"
-
-readable-stream@~2.1.5:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.1.5.tgz#66fa8b720e1438b364681f2ad1a63c618448c9d0"
-  dependencies:
-    buffer-shims "^1.0.0"
     core-util-is "~1.0.0"
     inherits "~2.0.1"
     isarray "~1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1069,9 +1069,9 @@ caniuse-db@^1.0.30000153, caniuse-db@^1.0.30000214:
   version "1.0.30000611"
   resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000611.tgz#1075d14d9b3cc153caf5e9e35f45565b03304c37"
 
-capture-exit@^1.0.4:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-1.1.0.tgz#d931b32b11c2bd20ae57f34af0c1eb2c18781626"
+capture-exit@^1.0.7:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-1.2.0.tgz#1c5fcc489fd0ab00d4f1ac7ae1072e3173fbab6f"
   dependencies:
     rsvp "^3.3.3"
 
@@ -1311,7 +1311,7 @@ commander@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.0.0.tgz#d1b86f901f8b64bd941bdeadaf924530393be928"
 
-commander@2.3.0:
+commander@2.3.0, commander@^2.1.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.3.0.tgz#fd430e889832ec353b9acd1de217c11cb3eef873"
 
@@ -1321,7 +1321,7 @@ commander@2.8.x:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
-commander@^2.1.0, commander@^2.5.0, commander@^2.6.0, commander@^2.9.0:
+commander@^2.5.0, commander@^2.6.0, commander@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
@@ -1486,6 +1486,13 @@ coveralls@2.11.15:
     log-driver "1.2.5"
     minimist "1.2.0"
     request "2.75.0"
+
+cross-spawn-async@^2.1.1:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz#845ff0c0834a3ded9d160daca6d390906bb288cc"
+  dependencies:
+    lru-cache "^4.0.0"
+    which "^1.2.8"
 
 cross-spawn@^3.0.0:
   version "3.0.1"
@@ -2060,9 +2067,9 @@ ember-cli-version-checker@^1.0.2, ember-cli-version-checker@^1.1.3, ember-cli-ve
   dependencies:
     semver "^5.3.0"
 
-ember-cli@2.10.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/ember-cli/-/ember-cli-2.10.0.tgz#3aefd56a207f60be1ba120aeacd41e7e7a9383d8"
+ember-cli@2.10.1:
+  version "2.10.1"
+  resolved "https://registry.yarnpkg.com/ember-cli/-/ember-cli-2.10.1.tgz#7738f6f1de0711099909a97ca252b9b522f219d9"
   dependencies:
     amd-name-resolver "0.0.6"
     bower "^1.3.12"
@@ -2080,7 +2087,7 @@ ember-cli@2.10.0:
     broccoli-middleware "^0.18.1"
     broccoli-source "^1.1.0"
     broccoli-stew "^1.2.0"
-    capture-exit "^1.0.4"
+    capture-exit "^1.0.7"
     chalk "^1.1.3"
     clean-base-url "^1.0.0"
     compression "^1.4.4"
@@ -2097,6 +2104,7 @@ ember-cli@2.10.0:
     ember-cli-string-utils "^1.0.0"
     ember-try "^0.2.6"
     escape-string-regexp "^1.0.3"
+    execa "^0.4.0"
     exists-sync "0.0.3"
     exit "^0.1.2"
     express "^4.12.3"
@@ -2791,6 +2799,17 @@ exec-sh@^0.2.0:
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.0.tgz#14f75de3f20d286ef933099b2ce50a90359cef10"
   dependencies:
     merge "^1.1.3"
+
+execa@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.4.0.tgz#4eb6467a36a095fabb2970ff9d5e3fb7bce6ebc3"
+  dependencies:
+    cross-spawn-async "^2.1.1"
+    is-stream "^1.1.0"
+    npm-run-path "^1.0.0"
+    object-assign "^4.0.1"
+    path-key "^1.0.0"
+    strip-eof "^1.0.0"
 
 exists-sync@0.0.3:
   version "0.0.3"
@@ -3875,7 +3894,7 @@ is-resolvable@^1.0.0:
   dependencies:
     tryit "^1.0.1"
 
-is-stream@^1.0.1:
+is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -4435,7 +4454,7 @@ lru-cache@2:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
 
-lru-cache@^4.0.1:
+lru-cache@^4.0.0, lru-cache@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.0.2.tgz#1d17679c069cda5d040991a09dbc2c0db377e55e"
   dependencies:
@@ -5459,19 +5478,7 @@ read@1, read@~1.0.1, read@~1.0.7:
   dependencies:
     mute-stream "~0.0.4"
 
-"readable-stream@1 || 2", readable-stream@^2, readable-stream@^2.0.2, readable-stream@~2.1.5:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.1.5.tgz#66fa8b720e1438b364681f2ad1a63c618448c9d0"
-  dependencies:
-    buffer-shims "^1.0.0"
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
-    string_decoder "~0.10.x"
-    util-deprecate "~1.0.1"
-
-"readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.2.2:
+"readable-stream@1 || 2", readable-stream@^2, "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.2, readable-stream@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.2.tgz#a9e6fec3c7dda85f8bb1b3ba7028604556fc825e"
   dependencies:
@@ -5496,6 +5503,18 @@ readable-stream@~2.0.5:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.0.6.tgz#8f90341e68a53ccc928788dacfcd11b36eb9b78e"
   dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "~1.0.0"
+    process-nextick-args "~1.0.6"
+    string_decoder "~0.10.x"
+    util-deprecate "~1.0.1"
+
+readable-stream@~2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.1.5.tgz#66fa8b720e1438b364681f2ad1a63c618448c9d0"
+  dependencies:
+    buffer-shims "^1.0.0"
     core-util-is "~1.0.0"
     inherits "~2.0.1"
     isarray "~1.0.0"
@@ -6287,6 +6306,10 @@ strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
 
+strip-eof@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
+
 strip-indent@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
@@ -6767,7 +6790,7 @@ which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
 
-which@1, which@^1.0.5, which@^1.1.1, which@^1.2.12, which@^1.2.9, which@~1.2.1, which@~1.2.11:
+which@1, which@^1.0.5, which@^1.1.1, which@^1.2.12, which@^1.2.8, which@^1.2.9, which@~1.2.1, which@~1.2.11:
   version "1.2.12"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.12.tgz#de67b5e450269f194909ef23ece4ebe416fa1192"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1744,9 +1744,9 @@ ember-ajax@2.5.3:
   dependencies:
     ember-cli-babel "^5.1.5"
 
-ember-basic-dropdown@^0.19.1:
-  version "0.19.4"
-  resolved "https://registry.yarnpkg.com/ember-basic-dropdown/-/ember-basic-dropdown-0.19.4.tgz#dc4d290018468b43cb93ca25796ca2f118c38869"
+ember-basic-dropdown@^0.20.0:
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/ember-basic-dropdown/-/ember-basic-dropdown-0.20.0.tgz#6db6b452b7a50b70cbe51a0033e7761ae9d867fe"
   dependencies:
     ember-cli-babel "^5.1.10"
     ember-cli-htmlbars "^1.1.1"
@@ -2368,11 +2368,11 @@ ember-one-way-controls@1.1.2:
     ember-invoke-action "1.4.0"
     ember-runtime-enumerable-includes-polyfill "^1.0.1"
 
-ember-power-select@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/ember-power-select/-/ember-power-select-1.1.0.tgz#2ead66f39cea32e8be1ea48b0ba45426ff57b13e"
+ember-power-select@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ember-power-select/-/ember-power-select-1.2.0.tgz#eeba47f06824cf5817e590e902f2d8ab9ab09442"
   dependencies:
-    ember-basic-dropdown "^0.19.1"
+    ember-basic-dropdown "^0.20.0"
     ember-cli-babel "^5.1.10"
     ember-cli-htmlbars "^1.1.1"
     ember-concurrency "^0.7.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5215,9 +5215,9 @@ parseurl@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.1.tgz#c8ab8c9223ba34888aa64a297b28853bec18da56"
 
-password-generator@2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/password-generator/-/password-generator-2.0.6.tgz#ff4164d6da24ab90ff2fe8183d6555e3d2da1b5e"
+password-generator@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/password-generator/-/password-generator-2.1.0.tgz#d7580432951b69851e3d8d0a98fb1dc60b5c56da"
   dependencies:
     optimist "0.6.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1800,9 +1800,9 @@ ember-cli-chai@0.3.2:
     rollup-plugin-commonjs "^5.0.5"
     rollup-plugin-node-resolve "^2.0.0"
 
-ember-cli-code-coverage@0.3.8:
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/ember-cli-code-coverage/-/ember-cli-code-coverage-0.3.8.tgz#b3f8f765f3c9f34d3f2c78e5ace33bc681adad89"
+ember-cli-code-coverage@0.3.10:
+  version "0.3.10"
+  resolved "https://registry.yarnpkg.com/ember-cli-code-coverage/-/ember-cli-code-coverage-0.3.10.tgz#2e0e6fb1b8f414d59d5a50e6f460cf6bebaea464"
   dependencies:
     babel-core "^5.8.38"
     body-parser "^1.15.0"
@@ -1816,6 +1816,7 @@ ember-cli-code-coverage@0.3.8:
     extend "^3.0.0"
     fs-extra "^0.26.7"
     istanbul "^0.4.3"
+    node-dir "^0.1.16"
     source-map "0.5.6"
     string.prototype.startswith "^0.2.0"
 
@@ -4786,6 +4787,12 @@ natural-compare@^1.4.0:
 negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
+
+node-dir@^0.1.16:
+  version "0.1.16"
+  resolved "https://registry.yarnpkg.com/node-dir/-/node-dir-0.1.16.tgz#d2ef583aa50b90d93db8cdd26fcea58353957fe4"
+  dependencies:
+    minimatch "^3.0.2"
 
 node-emoji@^1.4.1:
   version "1.5.1"


### PR DESCRIPTION
Greenkeeper has been turned off so we're back to periodic dependency update roll-ups, fortunately `yarn` makes this *much* quicker and more convenient than `npm` ever did 😁 

- ember-cli@2.10.1
- ember-cli-chai@0.3.2
- ember-cli-code-coverage@0.3.10
- ember-power-select@1.2.0
- ember-route-action-helper@2.0.2
- password-generator@2.1.0