### PR TITLE
Add workaround for yarn node-sass bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ install:
   - bower install
 
 before_script:
+  - yarn add --force node-sass # temporary, workaround for https://github.com/yarnpkg/yarn/issues/1981
   - export DISPLAY=:99; sh -e /etc/init.d/xvfb start; sleep 3;
 
 script:


### PR DESCRIPTION
Workaround for yarnpkg/yarn#1981

Found in this commit: https://github.com/tjgrathwell/ng-picross/commit/22d55c04b236f0b7647e8c8a7813047ac183009a
