### PR TITLE
🐛 fix double slashes in URLs

### DIFF
--- a/app/services/config.js
+++ b/app/services/config.js
@@ -17,6 +17,10 @@ export default Service.extend(_ProxyMixin, {
         let configUrl = this.get('ghostPaths.url').api('configuration');
 
         return this.get('ajax').request(configUrl).then((config) => {
+            // normalize blogUrl to non-trailing-slash
+            let [{blogUrl}] = config.configuration;
+            config.configuration[0].blogUrl = blogUrl.replace(/\/$/, '');
+
             this.set('content', config.configuration[0]);
         });
     },


### PR DESCRIPTION
no issue
- update `config` service normalise blogUrl to non-trailing slash to match previous API behaviour
- fixes double slashes appearing in places around the app
- fixes "Redirect URI Mismatch" errors when using Ghost OAuth due to the double slashes