### PR TITLE
🐛 fix jumping "Invite User" button when modal is opened

### DIFF
--- a/app/templates/team/index.hbs
+++ b/app/templates/team/index.hbs
@@ -6,14 +6,14 @@
             <section class="view-actions">
                 <button class="btn btn-green" {{action "toggleInviteUserModal"}} >Invite People</button>
             </section>
-
-            {{#if showInviteUserModal}}
-                {{gh-fullscreen-modal "invite-new-user"
-                                      close=(action "toggleInviteUserModal")
-                                      modifier="action"}}
-            {{/if}}
         {{/unless}}
     </header>
+
+    {{#if showInviteUserModal}}
+        {{gh-fullscreen-modal "invite-new-user"
+                              close=(action "toggleInviteUserModal")
+                              modifier="action"}}
+    {{/if}}
 
     {{#gh-infinite-scroll
         fetch="loadNextPage"


### PR DESCRIPTION
closes TryGhost/Ghost#7890
- moved the modal outside of the `<header>` tag to avoid triggering unexpected flexbox justification