### PR TITLE
Make Ghost Editor compatible with showdown latest

### DIFF
--- a/app/helpers/gh-format-markdown.js
+++ b/app/helpers/gh-format-markdown.js
@@ -1,10 +1,27 @@
-/* global Showdown, html_sanitize */
+/* global showdown, html_sanitize */
 import {helper} from 'ember-helper';
 import {htmlSafe} from 'ember-string';
 import cajaSanitizers from 'ghost-admin/utils/caja-sanitizers';
 
 // eslint-disable-next-line new-cap
-let showdown = new Showdown.converter({extensions: ['ghostimagepreview', 'ghostgfm', 'footnotes', 'highlight']});
+let converter = new showdown.Converter({
+    extensions: ['ghostimagepreview', 'showdown-ghost-extra', 'footnotes', 'highlight'],
+    omitExtraWLInCodeBlocks: true,
+    parseImgDimensions: true,
+    simplifiedAutoLink: true,
+    excludeTrailingPunctuationFromURLs: true,
+    literalMidWordUnderscores: true,
+    strikethrough: true,
+    tables: true,
+    tablesHeaderId: true,
+    ghCodeBlocks: true,
+    tasklists: true,
+    smoothLivePreview: true,
+    simpleLineBreaks: true,
+    requireSpaceBeforeHeadingText: true,
+    ghMentions: false,
+    encodeEmails: true
+});
 
 export function formatMarkdown(params) {
     if (!params || !params.length) {
@@ -15,7 +32,7 @@ export function formatMarkdown(params) {
     let escapedhtml = '';
 
     // convert markdown to HTML
-    escapedhtml = showdown.makeHtml(markdown);
+    escapedhtml = converter.makeHtml(markdown);
 
     // replace script and iFrame
     escapedhtml = escapedhtml.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,

--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,11 @@
     "pretender": "1.1.0",
     "rangyinputs": "1.2.0",
     "selectize": "~0.12.1",
-    "showdown-ghost": "0.3.6",
+    "showdown": "^1.6.3",
+    "showdown-ghost-footnotes": "^0.0.x",
+    "showdown-ghost-extra": "^0.0.x",
+    "showdown-ghost-imagepreview": "^0.0.x",
+    "showdown-ghost-highlight": "^0.0.x",
     "validator-js": "3.39.0"
   }
 }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -113,11 +113,11 @@ module.exports = function (defaults) {
     // 'dem Scripts
     app.import('bower_components/validator-js/validator.js');
     app.import('bower_components/rangyinputs/rangyinputs-jquery-src.js');
-    app.import('bower_components/showdown-ghost/src/showdown.js');
-    app.import('bower_components/showdown-ghost/src/extensions/ghostgfm.js');
-    app.import('bower_components/showdown-ghost/src/extensions/ghostimagepreview.js');
-    app.import('bower_components/showdown-ghost/src/extensions/footnotes.js');
-    app.import('bower_components/showdown-ghost/src/extensions/highlight.js');
+    app.import('bower_components/showdown/dist/showdown.js');
+    app.import('bower_components/showdown-ghost-footnotes/dist/showdown-ghost-footnotes.js');
+    app.import('bower_components/showdown-ghost-extra/dist/showdown-ghost-extra.js');
+    app.import('bower_components/showdown-ghost-imagepreview/dist/showdown-ghost-imagepreview.js');
+    app.import('bower_components/showdown-ghost-highlight/dist/showdown-ghost-highlight.js');
     app.import('bower_components/keymaster/keymaster.js');
     app.import('bower_components/devicejs/lib/device.js');
 


### PR DESCRIPTION
 - turned a bunch of options on in showdown to set a "ghost" flavor markdown, similar to GFM
 - custom extensions live in their own repo, with proper tests against showdown
 - updated dependencies in package.json
 - should fix a number of issues and bugs in markdown parsing
