### PR TITLE
use current URI instead of configured blog URI for OAuth redirectURI

### DIFF
--- a/app/torii-providers/ghost-oauth2.js
+++ b/app/torii-providers/ghost-oauth2.js
@@ -9,7 +9,7 @@ let GhostOauth2 = Oauth2.extend({
 
     name:    'ghost-oauth2',
     baseUrl: computed(function () {
-        return `${this.get('config.ghostAuthUrl')}/oauth2/authorize`;
+        return `${this.get('config.ghostAuthUrl')}/oauth2/authorize/`;
     }),
     apiKey: computed(function () {
         return this.get('config.ghostAuthId');

--- a/app/torii-providers/ghost-oauth2.js
+++ b/app/torii-providers/ghost-oauth2.js
@@ -1,6 +1,7 @@
 import Oauth2 from 'torii/providers/oauth2-code';
 import injectService from 'ember-service/inject';
 import computed from 'ember-computed';
+import ghostPaths from 'ghost-admin/utils/ghost-paths';
 
 let GhostOauth2 = Oauth2.extend({
 
@@ -21,7 +22,12 @@ let GhostOauth2 = Oauth2.extend({
     // we want to redirect to the ghost admin app by default
     init() {
         this._super(...arguments);
-        this.set('redirectUri', `${this.get('config.blogUrl')}/ghost/`);
+        let adminPath = ghostPaths().adminRoot;
+        let redirectUri = `${window.location.protocol}//${window.location.host}`;
+
+        redirectUri += adminPath;
+
+        this.set('redirectUri', redirectUri);
     },
 
     open(options) {


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/7907
- rather than forwarding the redirect URI as configured in Ghost we should use the URL that the admin client is currently loaded on when setting the Ghost OAuth `redirectUri` attribute
- fixes issue with the admin app loading inside of the OAuth popup window and not logging in when using https with a registered http redirect uri