### PR TITLE
Update ember-one-way-controls to version 2.0.0

### DIFF
--- a/app/components/gh-trim-focus-input.js
+++ b/app/components/gh-trim-focus-input.js
@@ -31,12 +31,16 @@ const TrimFocusInputComponent = GhostInput.extend({
         this._focus();
     },
 
-    sanitizeInput(input) {
-        if (input && typeof input.trim === 'function') {
-            return input.trim();
-        } else {
-            return input;
+    focusOut(event) {
+        this._trimInput(event.target.value);
+    },
+
+    _trimInput(value) {
+        if (value && typeof value.trim === 'function') {
+            value = value.trim();
         }
+
+        this._processNewValue(value);
     },
 
     _focus() {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "ember-light-table": "0.1.9",
     "ember-load-initializers": "0.5.1",
     "ember-myth": "0.1.1",
-    "ember-one-way-controls": "0.9.2",
+    "ember-one-way-controls": "2.0.0",
     "ember-power-select": "0.10.11",
     "ember-resolver": "2.1.0",
     "ember-route-action-helper": "1.0.0",


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/7886
- deps: ember-one-way-controls@2.0.0
- adjust `gh-trim-focus-input` for the removal of `sanitizeInput` method and to trim value only on focus-out to avoid trailing spaces being removed whilst using backspace

Backport of https://github.com/TryGhost/Ghost-Admin/pull/475 for LTS