### PR TITLE
Don't destroy codemirror editor if it doesn't exist

### DIFF
--- a/app/components/gh-cm-editor.js
+++ b/app/components/gh-cm-editor.js
@@ -55,9 +55,14 @@ const CmEditorComponent =  Component.extend(InvokeActionMixin, {
     willDestroyElement() {
         this._super(...arguments);
 
-        let editor = this._editor.getWrapperElement();
-        editor.parentNode.removeChild(editor);
-        this._editor = null;
+        // Ensure the editor exists before trying to destroy it. This fixes
+        // an error that occurs if codemirror hasn't finished loading before
+        // the component is destroyed.
+        if (this._editor) {
+            let editor = this._editor.getWrapperElement();
+            editor.parentNode.removeChild(editor);
+            this._editor = null;
+        }
     }
 });
 


### PR DESCRIPTION
closes TryGhost/Ghost#7855
- check if codemirror has been initialized before trying to destroy it

note - the codemirror initialization happens inside a `scheduleOnce`, so I'm fairly certain that if the component is destroyed before the codemirror script finishes loading, then the scheduleOnce won't be called and we won't have to worry about extraneous objects.