### PR TITLE
Fix gh-search-input highlighting

### DIFF
--- a/app/templates/components/gh-search-input.hbs
+++ b/app/templates/components/gh-search-input.hbs
@@ -8,6 +8,6 @@
     triggerComponent="gh-search-input/trigger"
     renderInPlace=true
     loadingMessage="Loading"
-    as |name term|}}
-    {{highlighted-text name.title term}}
+    as |name select|}}
+    {{highlighted-text name.title select.searchText}}
 {{/power-select}}


### PR DESCRIPTION
closes TryGhost/Ghost#8013
- ember-power-select yields the select public api object instead of just
the searchterm

Probably during the 1.0 update, the yield of `power-select` changed from `searchText` to the entire select object. Because we were converting that object to a regex, it was matching based on `/[object Object]/` which is why the highlighting styles were off.