### PR TITLE
Editor 0.1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "emberx-file-input": "1.1.1",
     "eslint-plugin-ember-suave": "1.0.0",
     "fs-extra": "2.0.0",
-    "ghost-editor": "https://github.com/TryGhost/Ghost-Editor/tarball/dev-deps-test",
+    "ghost-editor": "0.1.9",
     "glob": "7.1.1",
     "grunt": "1.0.1",
     "grunt-bg-shell": "2.3.3",


### PR DESCRIPTION
Upgrades Ghost-Editor to 0.1.9
- Adds drag and drop image support within the markdown card.
- Adds drag and drop image support within the editor.
- The slash menu now renders in the next run-loop which means it should always be located at the correct place.
- The editor scrolls to follow the caret if it's off screen.