### PR TITLE
🏃 persist broccoli cache + re-enable yarn on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ branches:
 cache:
   directories:
     - node_modules
+    - broccoli-persistent-cache
 
 addons:
   firefox: "latest"
@@ -36,6 +37,7 @@ install:
 
 before_script:
   - export DISPLAY=:99; sh -e /etc/init.d/xvfb start; sleep 3;
+  - export BROCCOLI_PERSISTENT_FILTER_CACHE_ROOT=/home/travis/build/TryGhost/Ghost-Admin/broccoli-persistent-cache
 
 script:
   - COVERAGE=true npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ branches:
     - /^greenkeeper-.+$/
 
 cache:
+  yarn: true
   directories:
     - node_modules
     - broccoli-persistent-cache
@@ -26,16 +27,14 @@ addons:
     packages:
       - google-chrome-stable
 
-before_install:
-  - npm config --global set spin false
-  - npm install -g npm@^2
-
 install:
-  - npm install -g bower
-  - npm install
+  - npm i -g yarn
+  - yarn global add bower
+  - yarn
   - bower install
 
 before_script:
+  - yarn add --force node-sass # temporary, workaround for https://github.com/yarnpkg/yarn/issues/1981
   - export DISPLAY=:99; sh -e /etc/init.d/xvfb start; sleep 3;
   - export BROCCOLI_PERSISTENT_FILTER_CACHE_ROOT=/home/travis/build/TryGhost/Ghost-Admin/broccoli-persistent-cache
 


### PR DESCRIPTION
no issue
- persisting the broccoli cache should dramatically speed up the client builds on Travis as it will only need to rebuild changed files and those that depend on them
- re-enable yarn on Travis