### PR TITLE
🐛 fix posts screen infinite scroll

### DIFF
--- a/app/templates/posts/index.hbs
+++ b/app/templates/posts/index.hbs
@@ -23,7 +23,7 @@
 
     {{infinity-loader
         infinityModel=model
-        scrollable=".content-list"
+        scrollable=".gh-main"
         triggerOffset=1000}}
 </section>
 


### PR DESCRIPTION
no issue
- changes to layout meant that every page was automatically requested upon loading the content screen, this changes the infinite scroll trigger to match the new scrollable element