### PR TITLE
[WIP] allow auto-login via token on setup/three

### DIFF
--- a/app/routes/setup.js
+++ b/app/routes/setup.js
@@ -1,6 +1,7 @@
 import Route from 'ember-route';
 import injectService from 'ember-service/inject';
 import styleBody from 'ghost-admin/mixins/style-body';
+import {isBlank} from 'ember-utils';
 
 export default Route.extend(styleBody, {
     titleToken: 'Setup',
@@ -22,6 +23,42 @@ export default Route.extend(styleBody, {
         if (!this.get('config.ghostOAuth') && this.get('session.isAuthenticated')) {
             this.transitionTo('posts');
             return;
+        }
+
+        // After ghost.org signup we get redirected to setup/three with a
+        // one-time, short expiry token in order to finish the signup flow.
+        // Grab the token here, exchange it for a full token set and allow
+        // setup to continue
+        let [, token] = window.location.search.match(/token=(.*)/) || [];
+
+        if (!isBlank(token)) {
+            let tokenExchangeUrl = this.get('ghostPaths.url')
+                .api('authentication', 'setup', 'three');
+
+            // simulate a completed step 2 and skip other setup bits
+            this.controllerFor('setup.two').set('blogCreated', true);
+
+            /* eslint-disable camelcase */
+            return this.get('ajax')
+                .post(tokenExchangeUrl, {data: {
+                    token,
+                    client_id: this.get('config.clientId'),
+                    client_secret: this.get('config.clientSecret')
+                }}).then((data) => {
+                    let now = (new Date()).getTime();
+
+                    delete data.errors;
+                    data.authenticator = 'authenticator:oauth2';
+                    data.token_type = 'Bearer';
+                    // server returns seconds, ESA stores expiry in ms
+                    data.expires_at = new Date(now + data.expires_in * 1000).getTime();
+
+                    this.get('session.session.store').persist({authenticated: data});
+                    this.get('session.session').restore();
+                }).catch(() => {
+                    return this.transitionTo('signin');
+                });
+            /* eslint-enable camelcase */
         }
 
         let authUrl = this.get('ghostPaths.url').api('authentication', 'setup');


### PR DESCRIPTION
no issue
- ports the functionality added in the LTS branch that allows for smoother signup via ghost.org

TODO:
- [ ] review any changes necessary for alpha vs LTS
- [ ] implement token exchange endpoint in Ghost
- [ ] test integration with Ghost