### PR TITLE
🎨  simplify travis test setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,22 +24,18 @@ addons:
   apt:
     sources:
       - google-chrome
+      - sourceline: 'deb https://dl.yarnpkg.com/debian/ stable main'
+        key_url: 'https://dl.yarnpkg.com/debian/pubkey.gpg'
     packages:
       - google-chrome-stable
-
-install:
-  - npm i -g yarn
-  - yarn global add bower
-  - yarn
-  - bower install
+      - yarn
 
 before_script:
+  - yarn run bower
   - yarn add --force node-sass # temporary, workaround for https://github.com/yarnpkg/yarn/issues/1981
   - export DISPLAY=:99; sh -e /etc/init.d/xvfb start; sleep 3;
   - export BROCCOLI_PERSISTENT_FILTER_CACHE_ROOT=/home/travis/build/TryGhost/Ghost-Admin/broccoli-persistent-cache
-
-script:
-  - COVERAGE=true npm test
+  - export COVERAGE=true
 
 after_success:
   - npm run coverage

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "build": "ember build",
     "test": "ember test",
     "lint": "ember test --launch phantomjs -f 'ESLint'",
-    "coverage": "cat ./coverage/lcov.info | coveralls"
+    "coverage": "cat ./coverage/lcov.info | coveralls",
+    "bower": "bower install"
   },
   "engines": {
     "node": "~0.12.0 || ^4.2.0"


### PR DESCRIPTION
no issue
- travis will install yarn by default, we don't need to install it
- we can also rely upon the local installation of bower