### PR TITLE
✨ success/failure state spinner buttons

### DIFF
--- a/app/components/modals/new-subscriber.js
+++ b/app/components/modals/new-subscriber.js
@@ -11,8 +11,7 @@ export default ModalComponent.extend({
             this.send('closeModal');
         } catch (error) {
             // TODO: server-side validation errors should be serialized
-            // properly so that errors are added to the model's errors
-            // property
+            // properly so that errors are added to model.errors automatically
             if (error && isInvalidError(error)) {
                 let [firstError] = error.errors;
                 let {message} = firstError;
@@ -24,9 +23,10 @@ export default ModalComponent.extend({
                 }
             }
 
-            // this is a route action so it should bubble up to the global
-            // error handler
-            throw error;
+            // route action so it should bubble up to the global error handler
+            if (error) {
+                throw error;
+            }
         }
     }).drop(),
 

--- a/app/styles/patterns/buttons.css
+++ b/app/styles/patterns/buttons.css
@@ -45,6 +45,10 @@ fieldset[disabled] .gh-btn {
     pointer-events: none;
 }
 
+/* TODO: replace with svg icons */
+.gh-btn i {
+    display: inline-block;
+}
 
 /* Button highlights
 /* ---------------------------------------------------------- */

--- a/app/templates/components/gh-modal-dialog.hbs
+++ b/app/templates/components/gh-modal-dialog.hbs
@@ -9,7 +9,7 @@
             {{#if confirm}}
             <footer class="modal-footer">
                 {{! Buttons must be on one line to prevent white-space errors }}
-                <button type="button" class="{{rejectButtonClass}} btn-minor js-button-reject" {{action "confirm" "reject"}}>{{confirm.reject.text}}</button><button type="button" class="{{acceptButtonClass}} js-button-accept" {{action "confirm" "accept"}}>{{confirm.accept.text}}</button>
+                <button type="button" class="{{rejectButtonClass}} btn-minor" {{action "confirm" "reject"}} data-test-modal-reject-button>{{confirm.reject.text}}</button><button type="button" class="{{acceptButtonClass}}" {{action "confirm" "accept"}} data-test-modal-accept-button>{{confirm.accept.text}}</button>
             </footer>
             {{/if}}
         </section>

--- a/app/templates/components/gh-task-button.hbs
+++ b/app/templates/components/gh-task-button.hbs
@@ -1,9 +1,15 @@
-{{#if isRunning}}
-    <span class="spinner"></span>
+{{#if hasBlock}}
+    {{yield (hash
+        isIdle=isIdle
+        isRunning=isRunning
+        isSuccess=isSuccess
+        isFailure=isFailure
+    )}}
 {{else}}
-    {{#if buttonText}}
-        {{buttonText}}
-    {{else}}
-        {{{yield}}}
-    {{/if}}
+    <span>
+    {{#if isRunning}}<span class="spinner"></span>{{/if}}
+    {{if (or isIdle isRunning) buttonText}}
+    {{#if isSuccess}}<i class="icon-check"></i> {{successText}}{{/if}}
+    {{#if isFailure}}<i class="icon-x"></i> {{failureText}}{{/if}}
+    </span>
 {{/if}}

--- a/app/templates/components/modals/delete-all.hbs
+++ b/app/templates/components/modals/delete-all.hbs
@@ -9,5 +9,5 @@
 
 <div class="modal-footer">
     <button {{action "closeModal"}} class="gh-btn"><span>Cancel</span></button>
-    {{#gh-task-button task=deleteAll class="gh-btn gh-btn-red"}}<span>Delete</span>{{/gh-task-button}}
+    {{gh-task-button "Delete" successText="Deleted" task=deleteAll class="gh-btn gh-btn-red"}}
 </div>

--- a/app/templates/components/modals/delete-post.hbs
+++ b/app/templates/components/modals/delete-post.hbs
@@ -11,5 +11,5 @@
 
 <div class="modal-footer">
     <button {{action "closeModal"}} class="gh-btn"><span>Cancel</span></button>
-    {{#gh-task-button task=deletePost class="gh-btn gh-btn-red"}}<span>Delete</span>{{/gh-task-button}}
+    {{gh-task-button "Delete" successText="Deleted" task=deletePost class="gh-btn gh-btn-red"}}
 </div>

--- a/app/templates/components/modals/delete-subscriber.hbs
+++ b/app/templates/components/modals/delete-subscriber.hbs
@@ -9,5 +9,5 @@
 
 <div class="modal-footer">
     <button {{action "closeModal"}} class="gh-btn"><span>Cancel</span></button>
-    {{#gh-task-button task=deleteSubscriber class="gh-btn gh-btn-red"}}<span>Delete</span>{{/gh-task-button}}
+    {{gh-task-button "Delete" successText="Deleted" task=deleteSubscriber class="gh-btn gh-btn-red"}}
 </div>

--- a/app/templates/components/modals/delete-tag.hbs
+++ b/app/templates/components/modals/delete-tag.hbs
@@ -12,5 +12,5 @@
 
 <div class="modal-footer">
     <button {{action "closeModal"}} class="gh-btn"><span>Cancel</span></button>
-    {{#gh-task-button task=deleteTag class="gh-btn gh-btn-red"}}<span>Delete</span>{{/gh-task-button}}
+    {{gh-task-button "Delete" successText="Deleted" task=deleteTag class="gh-btn gh-btn-red"}}
 </div>

--- a/app/templates/components/modals/delete-theme.hbs
+++ b/app/templates/components/modals/delete-theme.hbs
@@ -9,5 +9,5 @@
 
 <div class="modal-footer">
     <button {{action "closeModal"}} class="gh-btn" data-test-cancel-button><span>Cancel</span></button>
-    {{#gh-task-button task=deleteTheme class="gh-btn gh-btn-red" data-test-delete-button=true}}<span>Delete</span>{{/gh-task-button}}
+    {{gh-task-button "Delete" successText="Deleted" task=deleteTheme class="gh-btn gh-btn-red" data-test-delete-button=true}}
 </div>

--- a/app/templates/components/modals/delete-user.hbs
+++ b/app/templates/components/modals/delete-user.hbs
@@ -13,5 +13,5 @@
 
 <div class="modal-footer">
     <button {{action "closeModal"}} class="gh-btn"><span>Cancel</span></button>
-    {{#gh-task-button task=deleteUser class="gh-btn gh-btn-red"}}<span>Delete</span>{{/gh-task-button}}
+    {{gh-task-button "Delete" successText="Deleted" task=deleteUser class="gh-btn gh-btn-red"}}
 </div>

--- a/app/templates/components/modals/invite-new-user.hbs
+++ b/app/templates/components/modals/invite-new-user.hbs
@@ -42,5 +42,5 @@
 </div>
 
 <div class="modal-footer">
-    {{#gh-task-button task=sendInvitation class="gh-btn gh-btn-green"}}<span>Send invitation now</span>{{/gh-task-button}}
+    {{gh-task-button "Send invitation now" successText="Sent" task=sendInvitation class="gh-btn gh-btn-green"}}
 </div>

--- a/app/templates/components/modals/new-subscriber.hbs
+++ b/app/templates/components/modals/new-subscriber.hbs
@@ -25,5 +25,5 @@
 
 <div class="modal-footer">
     <button {{action "closeModal"}} class="gh-btn"><span>Cancel</span></button>
-    {{#gh-task-button task=addSubscriber class="gh-btn gh-btn-green"}}<span>Add</span>{{/gh-task-button}}
+    {{gh-task-button "Add" successText="Added" task=addSubscriber class="gh-btn gh-btn-green"}}
 </div>

--- a/app/templates/components/modals/re-authenticate.hbs
+++ b/app/templates/components/modals/re-authenticate.hbs
@@ -6,13 +6,13 @@
 <div class="modal-body {{if authenticationError 'error'}}">
 
     {{#if config.ghostOAuth}}
-        {{#gh-task-button task=reauthenticate class="login gh-btn gh-btn-blue gh-btn-block" tabindex="3" autoWidth="false"}}<span>Sign in with Ghost</span>{{/gh-task-button}}
+        {{gh-task-button "Sign in with Ghost" task=reauthenticate class="login gh-btn gh-btn-blue gh-btn-block" tabindex="3" autoWidth="false"}}
     {{else}}
         <form id="login" class="login-form" method="post" novalidate="novalidate" {{action "confirm" on="submit"}}>
             {{#gh-validation-status-container class="password-wrap" errors=errors property="password" hasValidated=hasValidated}}
                 {{gh-input password class="password" type="password" placeholder="Password" name="password" update=(action (mut password))}}
             {{/gh-validation-status-container}}
-            {{#gh-task-button task=reauthenticate class="gh-btn gh-btn-blue" type="submit"}}<span>Log in</span>{{/gh-task-button}}
+            {{gh-task-button "Log in" task=reauthenticate class="gh-btn gh-btn-blue" type="submit"}}
         </form>
     {{/if}}
 

--- a/app/templates/components/modals/transfer-owner.hbs
+++ b/app/templates/components/modals/transfer-owner.hbs
@@ -12,5 +12,5 @@
 
 <div class="modal-footer">
     <button {{action "closeModal"}} class="gh-btn"><span>Cancel</span></button>
-    {{#gh-task-button task=transferOwnership class="gh-btn gh-btn-red"}}<span>Yep - I'm sure</span>{{/gh-task-button}}
+    {{gh-task-button "Yep - I'm sure" task=transferOwnership class="gh-btn gh-btn-red"}}
 </div>

--- a/app/templates/components/modals/upload-image.hbs
+++ b/app/templates/components/modals/upload-image.hbs
@@ -20,5 +20,5 @@
 
 <div class="modal-footer">
     <button {{action "closeModal"}} class="gh-btn"><span>Cancel</span></button>
-    {{#gh-task-button task=uploadImage class="gh-btn gh-btn-blue right js-button-accept"}}<span>Save</span>{{/gh-task-button}}
+    {{gh-task-button task=uploadImage class="gh-btn gh-btn-blue right" data-test-modal-accept-button=true}}
 </div>

--- a/app/templates/reset.hbs
+++ b/app/templates/reset.hbs
@@ -9,7 +9,7 @@
                     {{gh-input ne2Password type="password" name="ne2password" placeholder="Confirm Password" class="password" autocorrect="off" autofocus="autofocus" update=(action (mut ne2Password))}}
                 {{/gh-form-group}}
 
-                {{#gh-task-button task=resetPassword class="gh-btn gh-btn-blue gh-btn-block" type="submit" autoWidth="false"}}<span>Reset Password</span>{{/gh-task-button}}
+                {{gh-task-button "Reset Password" task=resetPassword class="gh-btn gh-btn-blue gh-btn-block" type="submit" autoWidth="false"}}
             </form>
 
             <p class="main-error">{{{flowErrors}}}</p>

--- a/app/templates/team/user.hbs
+++ b/app/templates/team/user.hbs
@@ -45,7 +45,7 @@
                 </span>
             {{/if}}
 
-            {{#gh-task-button class="gh-btn gh-btn-blue" task=save}}<span>Save</span>{{/gh-task-button}}
+            {{gh-task-button class="gh-btn gh-btn-blue" task=save}}
         </section>
     </header>
 
@@ -199,7 +199,7 @@
                     {{/gh-form-group}}
 
                     <div class="form-group">
-                        {{#gh-task-button class="gh-btn gh-btn-red button-change-password" task=user.saveNewPassword}}<span>Change Password</span>{{/gh-task-button}}
+                        {{gh-task-button "Change Password" class="gh-btn gh-btn-red button-change-password" task=user.saveNewPassword}}
                     </div>
                 </fieldset>
             </form> {{! change password form }}

--- a/tests/acceptance/settings/general-test.js
+++ b/tests/acceptance/settings/general-test.js
@@ -135,7 +135,7 @@ describe('Acceptance: Settings - General', function () {
                 expect(find('.fullscreen-modal .modal-content .gh-image-uploader').length, 'modal selector').to.equal(1);
             });
 
-            click('.fullscreen-modal .modal-footer .js-button-accept');
+            click(testSelector('modal-accept-button'));
 
             andThen(() => {
                 expect(find('.fullscreen-modal').length).to.equal(0);

--- a/tests/integration/components/gh-task-button-test.js
+++ b/tests/integration/components/gh-task-button-test.js
@@ -13,21 +13,29 @@ describe('Integration: Component: gh-task-button', function() {
     });
 
     it('renders', function () {
-        this.render(hbs`{{#gh-task-button}}Test{{/gh-task-button}}`);
+        // sets button text using positional param
+        this.render(hbs`{{gh-task-button "Test"}}`);
         expect(this.$('button')).to.exist;
         expect(this.$('button')).to.contain('Test');
         expect(this.$('button')).to.have.prop('disabled', false);
 
-        this.render(hbs`{{#gh-task-button class="testing"}}Test{{/gh-task-button}}`);
+        this.render(hbs`{{gh-task-button class="testing"}}`);
         expect(this.$('button')).to.have.class('testing');
+        // default button text is "Save"
+        expect(this.$('button')).to.contain('Save');
 
-        this.render(hbs`{{#gh-task-button disabled=true}}Test{{/gh-task-button}}`);
+        // passes disabled attr
+        this.render(hbs`{{gh-task-button disabled=true buttonText="Test"}}`);
         expect(this.$('button')).to.have.prop('disabled', true);
+        // allows button text to be set via hash param
+        expect(this.$('button')).to.contain('Test');
 
-        this.render(hbs`{{#gh-task-button type="submit"}}Test{{/gh-task-button}}`);
+        // passes type attr
+        this.render(hbs`{{gh-task-button type="submit"}}`);
         expect(this.$('button')).to.have.attr('type', 'submit');
 
-        this.render(hbs`{{#gh-task-button tabindex="-1"}}Test{{/gh-task-button}}`);
+        // passes tabindex attr
+        this.render(hbs`{{gh-task-button tabindex="-1"}}`);
         expect(this.$('button')).to.have.attr('tabindex', '-1');
     });
 
@@ -36,7 +44,7 @@ describe('Integration: Component: gh-task-button', function() {
             yield timeout(50);
         }));
 
-        this.render(hbs`{{#gh-task-button task=myTask}}Test{{/gh-task-button}}`);
+        this.render(hbs`{{gh-task-button task=myTask}}`);
 
         this.get('myTask').perform();
 
@@ -52,7 +60,7 @@ describe('Integration: Component: gh-task-button', function() {
             yield timeout(50);
         }));
 
-        this.render(hbs`{{#gh-task-button task=myTask}}Test{{/gh-task-button}}`);
+        this.render(hbs`{{gh-task-button task=myTask}}`);
         expect(this.$('button'), 'initial class').to.not.have.class('appear-disabled');
 
         this.get('myTask').perform();
@@ -68,6 +76,64 @@ describe('Integration: Component: gh-task-button', function() {
         wait().then(done);
     });
 
+    it('shows success on success', function (done) {
+        this.set('myTask', task(function* () {
+            yield timeout(50);
+            return true;
+        }));
+
+        this.render(hbs`{{gh-task-button task=myTask}}`);
+
+        this.get('myTask').perform();
+
+        run.later(this, function () {
+            expect(this.$('button')).to.have.class('gh-btn-green');
+            expect(this.$('button')).to.contain('Saved');
+        }, 70);
+
+        wait().then(done);
+    });
+
+    it('shows failure when task errors', function (done) {
+        this.set('myTask', task(function* () {
+            try {
+                yield timeout(50);
+                throw new ReferenceError('test error');
+            } catch (error) {
+                // noop, prevent mocha triggering unhandled error assert
+            }
+        }));
+
+        this.render(hbs`{{gh-task-button task=myTask}}`);
+
+        this.get('myTask').perform();
+
+        run.later(this, function () {
+            expect(this.$('button')).to.have.class('gh-btn-red');
+            expect(this.$('button')).to.contain('Retry');
+        }, 70);
+
+        wait().then(done);
+    });
+
+    it('shows failure on falsy response', function (done) {
+        this.set('myTask', task(function* () {
+            yield timeout(50);
+            return false;
+        }));
+
+        this.render(hbs`{{gh-task-button task=myTask}}`);
+
+        this.get('myTask').perform();
+
+        run.later(this, function () {
+            expect(this.$('button')).to.have.class('gh-btn-red');
+            expect(this.$('button')).to.contain('Retry');
+        }, 70);
+
+        wait().then(done);
+    });
+
     it('performs task on click', function (done) {
         let taskCount = 0;
 
@@ -76,7 +142,7 @@ describe('Integration: Component: gh-task-button', function() {
             taskCount = taskCount + 1;
         }));
 
-        this.render(hbs`{{#gh-task-button task=myTask}}Test{{/gh-task-button}}`);
+        this.render(hbs`{{gh-task-button task=myTask}}`);
         this.$('button').click();
 
         wait().then(() => {
@@ -90,7 +156,7 @@ describe('Integration: Component: gh-task-button', function() {
             yield timeout(50);
         }));
 
-        this.render(hbs`{{#gh-task-button task=myTask}}Test{{/gh-task-button}}`);
+        this.render(hbs`{{gh-task-button task=myTask}}`);
         let width = this.$('button').width();
         let height = this.$('button').height();
         expect(this.$('button')).to.not.have.attr('style');


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/7515
- changes to `gh-task-button`:
  - can take `buttonText` (default: "Save"), `runningText` ("Saving"), `successText` ("Saved"), and `failureText` ("Retry") params
  - positional param for `buttonText`
  - default button display can be overridden by passing in a block, in that scenario the component will yield a hash containing all states to be used in this fashion:
    ```
    {{#gh-task-button task=myTask as |task|}}
        {{if task.isIdle "Save me"}}
        {{if task.isRunning "Saving"}}
        {{if task.isSuccess "Thank you!"}}
        {{if task.isFailure "Nooooooo!"}}
    {{/gh-task-button}}
    ```
- update existing uses of `gh-task-button` to match new component signature

This PR only introduces the basics so that initial testing can be done and further `ember-concurrency` refactors can be made against the almost-final state.

![gh-task-button](https://cloud.githubusercontent.com/assets/415/23655652/c0e5550e-032d-11e7-8d2a-9674d131f7a1.gif)

To be added in later PRs:
- proper styling and icons
- improvements to fixed width handling
