### PR TITLE
✨ suspend user feature

### DIFF
--- a/app/authenticators/oauth2-ghost.js
+++ b/app/authenticators/oauth2-ghost.js
@@ -32,8 +32,8 @@ export default Oauth2Authenticator.extend({
                     }
                     resolve(response);
                 });
-            }, (xhr) => {
-                run(null, reject, xhr.responseJSON || xhr.responseText);
+            }, (error) => {
+                reject(error);
             });
         });
     }

--- a/app/components/modals/suspend-user.js
+++ b/app/components/modals/suspend-user.js
@@ -1,0 +1,23 @@
+import ModalComponent from 'ghost-admin/components/modals/base';
+import {invokeAction} from 'ember-invoke-action';
+import {alias} from 'ember-computed';
+import {task} from 'ember-concurrency';
+
+export default ModalComponent.extend({
+
+    user: alias('model'),
+
+    suspendUser: task(function* () {
+        try {
+            yield invokeAction(this, 'confirm');
+        } finally {
+            this.send('closeModal');
+        }
+    }).drop(),
+
+    actions: {
+        confirm() {
+            return this.get('suspendUser').perform();
+        }
+    }
+});

--- a/app/components/modals/unsuspend-user.js
+++ b/app/components/modals/unsuspend-user.js
@@ -1,0 +1,23 @@
+import ModalComponent from 'ghost-admin/components/modals/base';
+import {invokeAction} from 'ember-invoke-action';
+import {alias} from 'ember-computed';
+import {task} from 'ember-concurrency';
+
+export default ModalComponent.extend({
+
+    user: alias('model'),
+
+    unsuspendUser: task(function* () {
+        try {
+            yield invokeAction(this, 'confirm');
+        } finally {
+            this.send('closeModal');
+        }
+    }).drop(),
+
+    actions: {
+        confirm() {
+            return this.get('unsuspendUser').perform();
+        }
+    }
+});

--- a/app/controllers/team/index.js
+++ b/app/controllers/team/index.js
@@ -6,13 +6,19 @@ export default Controller.extend({
 
     showInviteUserModal: false,
 
-    users: null,
+    activeUsers: null,
+    suspendedUsers: null,
     invites: null,
 
     session: injectService(),
 
     inviteOrder: ['email'],
     sortedInvites: sort('invites', 'inviteOrder'),
+
+    userOrder: ['name', 'email'],
+
+    sortedActiveUsers: sort('activeUsers', 'userOrder'),
+    sortedSuspendedUsers: sort('suspendedUsers', 'userOrder'),
 
     actions: {
         toggleInviteUserModal() {

--- a/app/controllers/team/user.js
+++ b/app/controllers/team/user.js
@@ -16,6 +16,7 @@ const {Handlebars} = Ember;
 
 export default Controller.extend({
     showDeleteUserModal: false,
+    showSuspendUserModal: false,
     showTransferOwnerModal: false,
     showUploadCoverModal: false,
     showUplaodImageModal: false,
@@ -190,7 +191,6 @@ export default Controller.extend({
                 window.history.replaceState({path: newPath}, '', newPath);
             }
 
-            this.toggleProperty('submitting');
             this.get('notifications').closeAlerts('user.update');
 
             return model;
@@ -219,6 +219,28 @@ export default Controller.extend({
         toggleDeleteUserModal() {
             if (this.get('deleteUserActionIsVisible')) {
                 this.toggleProperty('showDeleteUserModal');
+            }
+        },
+
+        suspendUser() {
+            this.get('model').set('status', 'inactive');
+            return this.get('save').perform();
+        },
+
+        toggleSuspendUserModal() {
+            if (this.get('deleteUserActionIsVisible')) {
+                this.toggleProperty('showSuspendUserModal');
+            }
+        },
+
+        unsuspendUser() {
+            this.get('model').set('status', 'active');
+            return this.get('save').perform();
+        },
+
+        toggleUnsuspendUserModal() {
+            if (this.get('deleteUserActionIsVisible')) {
+                this.toggleProperty('showUnsuspendUserModal');
             }
         },
 

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -53,9 +53,12 @@ export default Model.extend(ValidationEngine, {
         return this.get('id') === this.get('session.user.id');
     }),
 
-    active: computed('status', function () {
+    isActive: computed('status', function () {
+        // TODO: review "locked" as an "active" status
         return ['active', 'warn-1', 'warn-2', 'warn-3', 'warn-4', 'locked'].indexOf(this.get('status')) > -1;
     }),
+
+    isSuspended: equal('status', 'inactive'),
 
     role: computed('roles', {
         get() {

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -5,7 +5,7 @@ import run from 'ember-runloop';
 import {isEmberArray} from 'ember-array/utils';
 import observer from 'ember-metal/observer';
 import $ from 'jquery';
-
+import {isUnauthorizedError} from 'ember-ajax/errors';
 import AuthConfiguration from 'ember-simple-auth/configuration';
 import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
 import ShortcutsRoute from 'ghost-admin/mixins/shortcuts-route';
@@ -195,6 +195,11 @@ export default Route.extend(ApplicationRouteMixin, ShortcutsRoute, {
         save: K,
 
         error(error, transition) {
+            // unauthoirized errors are already handled in the ajax service
+            if (isUnauthorizedError(error)) {
+                return false;
+            }
+
             if (error && isEmberArray(error.errors)) {
                 switch (error.errors[0].errorType) {
                 case 'NotFoundError': {

--- a/app/templates/components/gh-nav-menu.hbs
+++ b/app/templates/components/gh-nav-menu.hbs
@@ -50,7 +50,6 @@
         <ul class="gh-nav-list gh-nav-settings">
             <li class="gh-nav-list-h">Settings</li>
             <li>{{#link-to "settings.general" classNames="gh-nav-settings-general"}}<i class="icon-settings"></i>General{{/link-to}}</li>
-            {{!<li><i class="icon-design"></i>Themes</li>}}
             <li>{{#link-to "settings.design" classNames="gh-nav-settings-navigation"}}<i class="icon-compass"></i>Design{{/link-to}}</li>
             <li>{{#link-to "settings.tags" classNames="gh-nav-settings-tags"}}<i class="icon-tag"></i>Tags{{/link-to}}</li>
             <li>{{#link-to "settings.code-injection" classNames="gh-nav-settings-code-injection"}}<i class="icon-code"></i>Code injection{{/link-to}}</li>

--- a/app/templates/components/modals/suspend-user.hbs
+++ b/app/templates/components/modals/suspend-user.hbs
@@ -1,0 +1,13 @@
+<header class="modal-header">
+    <h1>Are you sure you want to suspend this user?</h1>
+</header>
+<a class="close icon-x" href="" title="Close" {{action "closeModal"}}><span class="hidden">Close</span></a>
+
+<div class="modal-body">
+    <strong>WARNING:</strong> This user will no longer be able to log in but their posts will be kept.
+</div>
+
+<div class="modal-footer">
+    <button {{action "closeModal"}} class="gh-btn"><span>Cancel</span></button>
+    {{gh-task-button "Suspend" successText="Suspended" task=suspendUser class="gh-btn gh-btn-red" data-test-modal-confirm=true}}
+</div>

--- a/app/templates/components/modals/unsuspend-user.hbs
+++ b/app/templates/components/modals/unsuspend-user.hbs
@@ -1,0 +1,13 @@
+<header class="modal-header">
+    <h1>Are you sure you want to un-suspend this user?</h1>
+</header>
+<a class="close icon-x" href="" title="Close" {{action "closeModal"}}><span class="hidden">Close</span></a>
+
+<div class="modal-body">
+    <strong>WARNING:</strong> This user will be able to log in again and will have the same permissions they had previously.
+</div>
+
+<div class="modal-footer">
+    <button {{action "closeModal"}} class="gh-btn"><span>Cancel</span></button>
+    {{gh-task-button "Un-suspend" successText="Suspended" task=unsuspendUser class="gh-btn gh-btn-red" data-test-modal-confirm=true}}
+</div>

--- a/app/templates/team/index.hbs
+++ b/app/templates/team/index.hbs
@@ -25,7 +25,7 @@
     {{!-- Show invited users to everyone except authors --}}
     {{#unless session.user.isAuthor}}
         {{#if invites}}
-        <section class="apps-grid-container gh-invited-users">
+        <section class="apps-grid-container gh-invited-users" data-test-invited-users>
             <span class="apps-grid-title">Invited users</span>
             <div class="apps-grid">
 
@@ -77,10 +77,10 @@
         {{/if}}
     {{/unless}}
 
-    <section class="apps-grid-container gh-active-users">
+    <section class="apps-grid-container gh-active-users" data-test-active-users>
         <span class="apps-grid-title">Active users</span>
         <div class="apps-grid">
-            {{#each users key="id" as |user|}}
+            {{#each sortedActiveUsers key="id" as |user|}}
                 {{!-- For authors only shows users as a list, otherwise show users with links to user page --}}
                 {{#unless session.user.isAuthor}}
                     {{#gh-user-active user=user as |component|}}
@@ -96,4 +96,24 @@
     </section>
 
     {{/gh-infinite-scroll}}
+
+    {{#if suspendedUsers}}
+    <section class="apps-grid-container gh-active-users" data-test-suspended-users>
+        <span class="apps-grid-title">Suspended users</span>
+        <div class="apps-grid">
+            {{#each sortedSuspendedUsers key="id" as |user|}}
+                {{!-- For authors only shows users as a list, otherwise show users with links to user page --}}
+                {{#unless session.user.isAuthor}}
+                    {{#gh-user-active user=user as |component|}}
+                        {{partial 'user-list-item'}}
+                    {{/gh-user-active}}
+                {{else}}
+                    {{#gh-user-active user=user as |component|}}
+                        <li class="ember-view active user-list-item">{{partial 'user-list-item'}}</li>
+                    {{/gh-user-active}}
+                {{/unless}}
+            {{/each}}
+        </div>
+    </section>
+    {{/if}}
 </section>

--- a/app/templates/team/user.hbs
+++ b/app/templates/team/user.hbs
@@ -1,13 +1,17 @@
 <section class="gh-view">
     <header class="view-header">
         {{#gh-view-title openMobileMenu="openMobileMenu"}}
-            {{link-to "Team" "team"}}
+            {{link-to "Team" "team" data-test-team-link=true}}
             <i class="icon-arrow-right"></i> <span>{{user.name}}</span>
+
+            {{#if user.isSuspended}}
+            <i></i> <span class="gh-badge administrator" data-test-suspended-badge>Suspended</span>
+            {{/if}}
         {{/gh-view-title}}
         <section class="view-actions">
             {{#if userActionsAreVisible}}
                 <span class="dropdown">
-                    {{#gh-dropdown-button dropdownName="user-actions-menu" classNames="gh-btn gh-btn-default only-has-icon user-actions-cog" title="User Actions"}}
+                    {{#gh-dropdown-button dropdownName="user-actions-menu" classNames="gh-btn gh-btn-default only-has-icon user-actions-cog" title="User Actions" data-test-user-actions=true}}
                         <span>
                             <i class="icon-settings"></i>
                             <span class="hidden">User Settings</span>
@@ -29,23 +33,54 @@
                         {{/if}}
                         {{#if deleteUserActionIsVisible}}
                             <li>
-                                <button {{action "toggleDeleteUserModal"}} class="delete">
+                                <button {{action "toggleDeleteUserModal"}} class="delete" data-test-delete-button>
                                     Delete User
                                 </button>
-                                {{#if showDeleteUserModal}}
-                                    {{gh-fullscreen-modal "delete-user"
-                                                          model=user
-                                                          confirm=(action "deleteUser")
-                                                          close=(action "toggleDeleteUserModal")
-                                                          modifier="action wide"}}
-                                {{/if}}
                             </li>
+                            {{#if user.isActive}}
+                                <li>
+                                    <button {{action "toggleSuspendUserModal"}} class="suspend" data-test-suspend-button>
+                                        Suspend User
+                                    </button>
+                                </li>
+                            {{/if}}
+                            {{#if user.isSuspended}}
+                                <li>
+                                    <button {{action "toggleUnsuspendUserModal"}} class="unsuspend" data-test-unsuspend-button>
+                                        Un-suspend User
+                                    </button>
+                                </li>
+                            {{/if}}
                         {{/if}}
                     {{/gh-dropdown}}
                 </span>
             {{/if}}
 
             {{gh-task-button class="gh-btn gh-btn-blue" task=save}}
+
+            {{#if showDeleteUserModal}}
+                {{gh-fullscreen-modal "delete-user"
+                                      model=user
+                                      confirm=(action "deleteUser")
+                                      close=(action "toggleDeleteUserModal")
+                                      modifier="action wide"}}
+            {{/if}}
+
+            {{#if showSuspendUserModal}}
+                {{gh-fullscreen-modal "suspend-user"
+                                      model=user
+                                      confirm=(action "suspendUser")
+                                      close=(action "toggleSuspendUserModal")
+                                      modifier="action wide"}}
+            {{/if}}
+
+            {{#if showUnsuspendUserModal}}
+                {{gh-fullscreen-modal "unsuspend-user"
+                                      model=user
+                                      confirm=(action "unsuspendUser")
+                                      close=(action "toggleUnsuspendUserModal")
+                                      modifier="action wide"}}
+            {{/if}}
         </section>
     </header>
 

--- a/tests/integration/components/gh-task-button-test.js
+++ b/tests/integration/components/gh-task-button-test.js
@@ -71,7 +71,7 @@ describe('Integration: Component: gh-task-button', function() {
 
         run.later(this, function () {
             expect(this.$('button'), 'ended class').to.not.have.class('appear-disabled');
-        }, 70);
+        }, 100);
 
         wait().then(done);
     });
@@ -89,7 +89,7 @@ describe('Integration: Component: gh-task-button', function() {
         run.later(this, function () {
             expect(this.$('button')).to.have.class('gh-btn-green');
             expect(this.$('button')).to.contain('Saved');
-        }, 70);
+        }, 100);
 
         wait().then(done);
     });
@@ -108,7 +108,7 @@ describe('Integration: Component: gh-task-button', function() {
             expect(this.$('button')).to.not.have.class('gh-btn-green');
             expect(this.$('button')).to.have.class('im-a-success');
             expect(this.$('button')).to.contain('Saved');
-        }, 70);
+        }, 100);
 
         wait().then(done);
     });
@@ -130,7 +130,7 @@ describe('Integration: Component: gh-task-button', function() {
         run.later(this, function () {
             expect(this.$('button')).to.have.class('gh-btn-red');
             expect(this.$('button')).to.contain('Retry');
-        }, 70);
+        }, 100);
 
         wait().then(done);
     });
@@ -148,7 +148,7 @@ describe('Integration: Component: gh-task-button', function() {
         run.later(this, function () {
             expect(this.$('button')).to.have.class('gh-btn-red');
             expect(this.$('button')).to.contain('Retry');
-        }, 70);
+        }, 100);
 
         wait().then(done);
     });
@@ -167,7 +167,7 @@ describe('Integration: Component: gh-task-button', function() {
             expect(this.$('button')).to.not.have.class('gh-btn-red');
             expect(this.$('button')).to.have.class('im-a-failure');
             expect(this.$('button')).to.contain('Retry');
-        }, 70);
+        }, 100);
 
         wait().then(done);
     });
@@ -216,7 +216,7 @@ describe('Integration: Component: gh-task-button', function() {
             // chai-jquery test doesn't work because Firefox outputs blank string
             // expect(this.$('button')).to.not.have.attr('style');
             expect(this.$('button').attr('style')).to.be.blank;
-        }, 70);
+        }, 100);
 
         wait().then(done);
     });

--- a/tests/unit/models/user-test.js
+++ b/tests/unit/models/user-test.js
@@ -13,29 +13,27 @@ describe('Unit: Model: user', function () {
         expect(model.get('validationType')).to.equal('user');
     });
 
-    it('active property is correct', function () {
+    it('isActive/isSuspended properties are correct', function () {
         let model = this.subject({
             status: 'active'
         });
 
-        expect(model.get('active')).to.be.ok;
+        expect(model.get('isActive')).to.be.ok;
+        expect(model.get('isSuspended')).to.not.be.ok;
 
         ['warn-1', 'warn-2', 'warn-3', 'warn-4', 'locked'].forEach(function (status) {
             run(() => {
                 model.set('status', status);
             });
-            expect(model.get('status')).to.be.ok;
+            expect(model.get('isActive')).to.be.ok;
+            expect(model.get('isSuspended')).to.not.be.ok;
         });
 
         run(() => {
             model.set('status', 'inactive');
         });
-        expect(model.get('active')).to.not.be.ok;
-
-        run(() => {
-            model.set('status', 'invited');
-        });
-        expect(model.get('active')).to.not.be.ok;
+        expect(model.get('isSuspended')).to.be.ok;
+        expect(model.get('isActive')).to.not.be.ok;
     });
 
     it('role property is correct', function () {


### PR DESCRIPTION
requires https://github.com/TryGhost/Ghost/pull/8114
- adds "(Un-)Suspend User" options on user profile page with a modal confirmation screen
- separates team index into "active" and "suspended" users
- adds "suspended" badge to user profile when suspended
- updates `oauth2-ghost` authenticate method to handle an ember-ajax error object instead of an xhr (fixes "There was a problem on the server" message instead of "Your account has been suspended" when trying to log in)
- bumps `gh-task-button` test timeouts to avoid random test failures

<img width="824" alt="screen shot 2017-03-10 at 16 43 35" src="https://cloud.githubusercontent.com/assets/415/23805291/2f0be3fc-05b5-11e7-8358-25a3c39e7808.png">

<img width="359" alt="screen shot 2017-03-10 at 16 42 30" src="https://cloud.githubusercontent.com/assets/415/23805276/23f96f70-05b5-11e7-8cf0-cd5848bbceda.png">


TODO:
- [x] add "un-suspend user" option and confirmation modal
- [x] remove OAuth-only restriction
- [x] indicate which users are suspended on team index
- [x] indicate a user is suspended when viewing their profile
- [x] display useful error message when trying to log in as a suspended user
- [x] tests