### PR TITLE
🎨 remove usage of ghost's {{asset}} helper in index.html

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -19,20 +19,19 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
     <meta name="apple-mobile-web-app-title" content="Ghost" />
 
-    <link rel="shortcut icon" href="{{asset "favicon.ico"}}" />
-    <link rel="apple-touch-icon-precomposed" href="{{asset "img/touch-icon-iphone.png" ghost="true"}}" />
-    <link rel="apple-touch-icon-precomposed" sizes="76x76" href="{{asset "img/touch-icon-ipad.png" ghost="true"}}" />
-    <link rel="apple-touch-icon-precomposed" sizes="120x120" href="{{asset "img/small.png" ghost="true"}}" />
-    <link rel="apple-touch-icon-precomposed" sizes="152x152" href="{{asset "img/medium.png" ghost="true"}}" />
+    <link rel="shortcut icon" href="../favicon.ico" />
+    <link rel="apple-touch-icon-precomposed" href="assets/img/touch-icon-iphone.png" />
+    <link rel="apple-touch-icon-precomposed" sizes="76x76" href="assets/img/touch-icon-ipad.png" />
+    <link rel="apple-touch-icon-precomposed" sizes="120x120" href="assets/img/small.png" />
+    <link rel="apple-touch-icon-precomposed" sizes="152x152" href="assets/img/medium.png" />
 
     <meta name="application-name" content="Ghost" />
     <meta name="msapplication-TileColor" content="#ffffff" />
-    <meta name="msapplication-square70x70logo" content="{{asset "img/small.png" ghost="true"}}" />
-    <meta name="msapplication-square150x150logo" content="{{asset "img/medium.png" ghost="true"}}" />
-    <meta name="msapplication-square310x310logo" content="{{asset "img/large.png" ghost="true"}}" />
+    <meta name="msapplication-square70x70logo" content="assets/img/small.png" />
+    <meta name="msapplication-square150x150logo" content="assets/img/medium.png" />
+    <meta name="msapplication-square310x310logo" content="assets/img/large.png" />
 
-    <link rel="stylesheet" href="{{asset "vendor.css" ghost="true" minifyInProduction="true"}}" />
-    <link rel="stylesheet" href="{{asset "ghost.css" ghost="true" minifyInProduction="true"}}" title="light" />
+    {{content-for "minifiedInProductionCss"}}
 
     {{content-for "head-footer"}}
 </head>
@@ -48,8 +47,6 @@
 
 {{content-for "body-footer"}}
 
-{{! Dem scripts }}
-<script src="{{asset "vendor.js" ghost="true" minifyInProduction="true"}}"></script>
-<script src="{{asset "ghost.js" ghost="true" minifyInProduction="true"}}"></script>
+{{content-for "minifiedInProductionJs"}}
 </body>
 </html>

--- a/app/initializers/trailing-hash.js
+++ b/app/initializers/trailing-hash.js
@@ -1,6 +1,6 @@
-import HistoryLocation from 'ember-locations/history';
+import HashLocation from 'ember-locations/hash';
 
-let trailingHistory = HistoryLocation.extend({
+let trailingHash = HashLocation.extend({
     formatURL() {
         let url = this._super(...arguments);
 
@@ -13,9 +13,9 @@ let trailingHistory = HistoryLocation.extend({
 });
 
 export default {
-    name: 'registerTrailingLocationHistory',
+    name: 'registerTrailingHashLocation',
 
     initialize(application) {
-        application.register('location:trailing-history', trailingHistory);
+        application.register('location:trailing-hash', trailingHash);
     }
 };

--- a/app/mixins/unauthenticated-route-mixin.js
+++ b/app/mixins/unauthenticated-route-mixin.js
@@ -1,0 +1,35 @@
+import Mixin from 'ember-metal/mixin';
+import injectService from 'ember-service/inject';
+
+export default Mixin.create({
+
+    ajax: injectService(),
+    ghostPaths: injectService(),
+    session: injectService(),
+
+    routeIfAlreadyAuthenticated: 'posts',
+
+    beforeModel() {
+        let authUrl = this.get('ghostPaths.url').api('authentication', 'setup');
+
+        // check the state of the setup process via the API
+        return this.get('ajax').request(authUrl).then((result) => {
+            let [setup] = result.setup;
+
+            if (setup.status !== true) {
+                this.transitionTo('setup');
+            } else {
+                // NOTE: this is the same as ESA's UnauthenticatedRouteMixin,
+                // adding that mixin to this and calling _super wasn't calling
+                // the ESA mixin's beforeModel method
+                if (this.get('session').get('isAuthenticated')) {
+                    let routeIfAlreadyAuthenticated = this.get('routeIfAlreadyAuthenticated');
+
+                    return this.transitionTo(routeIfAlreadyAuthenticated);
+                } else {
+                    return this._super(...arguments);
+                }
+            }
+        });
+    }
+});

--- a/app/routes/reset.js
+++ b/app/routes/reset.js
@@ -1,6 +1,6 @@
 import Route from 'ember-route';
 import injectService from 'ember-service/inject';
-import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
+import UnauthenticatedRouteMixin from 'ghost-admin/mixins/unauthenticated-route-mixin';
 import styleBody from 'ghost-admin/mixins/style-body';
 
 export default Route.extend(styleBody, UnauthenticatedRouteMixin, {

--- a/app/routes/signin.js
+++ b/app/routes/signin.js
@@ -1,9 +1,8 @@
 import Route from 'ember-route';
-import injectService from 'ember-service/inject';
 import EmberObject from 'ember-object';
 import styleBody from 'ghost-admin/mixins/style-body';
 import DS from 'ember-data';
-import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
+import UnauthenticatedRouteMixin from 'ghost-admin/mixins/unauthenticated-route-mixin';
 
 const {Errors} = DS;
 
@@ -11,11 +10,6 @@ export default Route.extend(UnauthenticatedRouteMixin, styleBody, {
     titleToken: 'Sign In',
 
     classNames: ['ghost-login'],
-
-    session: injectService(),
-    notifications: injectService(),
-
-    routeIfAlreadyAuthenticated: 'posts',
 
     model() {
         return EmberObject.create({

--- a/app/routes/signup.js
+++ b/app/routes/signup.js
@@ -9,7 +9,7 @@ import {
 } from 'ghost-admin/services/ajax';
 
 import DS from 'ember-data';
-import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
+import UnauthenticatedRouteMixin from 'ghost-admin/mixins/unauthenticated-route-mixin';
 import styleBody from 'ghost-admin/mixins/style-body';
 
 const {Promise} = RSVP;

--- a/config/environment.js
+++ b/config/environment.js
@@ -5,7 +5,7 @@ module.exports = function (environment) {
         modulePrefix: 'ghost-admin',
         environment: environment,
         rootURL: '/',
-        locationType: 'trailing-history',
+        locationType: 'trailing-hash',
         EmberENV: {
             FEATURES: {
                 // Here you can enable experimental features on an ember canary build

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -95,6 +95,7 @@ module.exports = function (defaults) {
         },
         outputPaths: {
             app: {
+                html: isProduction ? 'index.min.html' : 'index.html',
                 js: assetLocation('ghost.js'),
                 css: {
                     app: assetLocation('ghost.css'),
@@ -112,7 +113,7 @@ module.exports = function (defaults) {
                 plugins: postcssPlugins()
             }
         },
-        fingerprint: disabled,
+        fingerprint: {enabled: true},
         nodeAssets: {
             'blueimp-md5': {
                 import: ['js/md5.js']

--- a/lib/asset-delivery/index.js
+++ b/lib/asset-delivery/index.js
@@ -1,17 +1,46 @@
 /* eslint-disable */
+'use strict';
+
 module.exports = {
     name: 'asset-delivery',
+
+    isDevelopingAddon() {
+        return true;
+    },
+
+    contentFor(type, config) {
+        let min = config.environment === 'production' ? '.min' : '';
+
+        if (type === 'minifiedInProductionCss') {
+            return `
+                <link rel="stylesheet" href="assets/vendor${min}.css">
+                <link rel="stylesheet" href="assets/ghost${min}.css" title="light">
+            `;
+        }
+
+        if (type === 'minifiedInProductionJs') {
+            return `
+                <script src="assets/vendor${min}.js"></script>
+                <script src="assets/ghost${min}.js"></script>
+            `;
+        }
+    },
+
     postBuild: function (results) {
         var fs = this.project.require('fs-extra'),
             walkSync = this.project.require('walk-sync'),
             assetsIn = results.directory + '/assets',
-            templateOut = '../server/views/default.hbs',
+            templateOutDir = '../server/admin/views',
             assetsOut = '../built/assets',
             assets = walkSync(assetsIn);
 
         fs.ensureDirSync(assetsOut);
 
-        fs.copySync(results.directory + '/index.html', templateOut, {overwrite: true});
+        if (fs.existsSync(results.directory + '/index.min.html')) {
+            fs.copySync(results.directory + '/index.min.html', `${templateOutDir}/default-prod.hbs`, {overwrite: true});
+        } else {
+            fs.copySync(results.directory + '/index.html', `${templateOutDir}/default.hbs`, {overwrite: true});
+        }
 
         assets.forEach(function (relativePath) {
             if (relativePath.slice(-1) === '/') { return; }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "ember-cli-pretender": "1.0.1",
     "ember-cli-selectize": "0.5.12",
     "ember-cli-shims": "1.0.2",
-    "ember-cli-sri": "2.1.1",
     "ember-cli-test-loader": "1.1.1",
     "ember-cli-uglify": "1.2.0",
     "ember-composable-helpers": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "ember-cli-fastclick": "1.3.0",
     "ember-cli-htmlbars": "1.1.1",
     "ember-cli-htmlbars-inline-precompile": "0.3.6",
+    "ember-cli-inject-live-reload": "1.6.1",
     "ember-cli-mirage": "0.2.8",
     "ember-cli-mocha": "0.13.2",
     "ember-cli-node-assets": "0.1.6",

--- a/tests/acceptance/authentication-test.js
+++ b/tests/acceptance/authentication-test.js
@@ -30,6 +30,22 @@ describe('Acceptance: Authentication', function () {
         destroyApp(application);
     });
 
+    describe('setup redirect', function () {
+        beforeEach(function () {
+            server.get('authentication/setup', function () {
+                return {setup: [{status: false}]};
+            });
+        });
+
+        it('redirects to setup when setup isn\'t complete', function () {
+            visit('settings/labs');
+
+            andThen(() => {
+                expect(currentURL()).to.equal('/setup/one');
+            });
+        });
+    });
+
     describe('token handling', function () {
         beforeEach(function () {
             // replace the default test authenticator with our own authenticator
@@ -93,6 +109,11 @@ describe('Acceptance: Authentication', function () {
 
             authenticateSession(application);
             visit('/team');
+
+            andThen(() => {
+                // NOTE: seems to be a test issue where this is running
+                // mid transition
+            });
 
             andThen(() => {
                 expect(currentURL(), 'url after 401').to.equal('/signin');

--- a/yarn.lock
+++ b/yarn.lock
@@ -675,7 +675,7 @@ broccoli-caching-writer@^0.5.5:
     rsvp "^3.0.14"
     symlink-or-copy "^1.0.0"
 
-broccoli-caching-writer@^2.0.4, broccoli-caching-writer@^2.2.0, broccoli-caching-writer@^2.3.1:
+broccoli-caching-writer@^2.0.4, broccoli-caching-writer@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/broccoli-caching-writer/-/broccoli-caching-writer-2.3.1.tgz#b93cf58f9264f003075868db05774f4e7f25bd07"
   dependencies:
@@ -980,16 +980,6 @@ broccoli-source@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/broccoli-source/-/broccoli-source-1.1.0.tgz#54f0e82c8b73f46580cbbc4f578f0b32fca8f809"
 
-broccoli-sri-hash@^2.1.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/broccoli-sri-hash/-/broccoli-sri-hash-2.1.2.tgz#bc69905ed7a381ad325cc0d02ded071328ebf3f3"
-  dependencies:
-    broccoli-caching-writer "^2.2.0"
-    mkdirp "^0.5.1"
-    rsvp "^3.1.0"
-    sri-toolbox "^0.2.0"
-    symlink-or-copy "^1.0.1"
-
 broccoli-stew@^1.0.4, broccoli-stew@^1.2.0, broccoli-stew@^1.3.3:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/broccoli-stew/-/broccoli-stew-1.4.0.tgz#1bdb0a1804d62a419d190abc26acb3c91878154d"
@@ -1145,8 +1135,8 @@ caniuse-api@^1.5.2:
     lodash.uniq "^4.3.0"
 
 caniuse-db@^1.0.30000346, caniuse-db@^1.0.30000631, caniuse-db@^1.0.30000634:
-  version "1.0.30000634"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000634.tgz#439f4b95e715b1fd105196d40c681edd7122e622"
+  version "1.0.30000635"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000635.tgz#ea159dfa062e00f25f97af3791baef93f17904a1"
 
 capture-exit@^1.0.7:
   version "1.2.0"
@@ -2015,6 +2005,10 @@ ember-cli-import-polyfill@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/ember-cli-import-polyfill/-/ember-cli-import-polyfill-0.2.0.tgz#c1a08a8affb45c97b675926272fe78cf4ca166f2"
 
+ember-cli-inject-live-reload@1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-inject-live-reload/-/ember-cli-inject-live-reload-1.6.1.tgz#82b8f5be454815a75e7f6d42c9ce0bc883a914a3"
+
 ember-cli-is-package-missing@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-is-package-missing/-/ember-cli-is-package-missing-1.0.0.tgz#6e6184cafb92635dd93ca6c946b104292d4e3390"
@@ -2148,12 +2142,6 @@ ember-cli-shims@1.0.2:
     ember-cli-babel "^5.2.1"
     ember-cli-version-checker "^1.2.0"
     silent-error "^1.0.1"
-
-ember-cli-sri@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ember-cli-sri/-/ember-cli-sri-2.1.1.tgz#971620934a4b9183cf7923cc03e178b83aa907fd"
-  dependencies:
-    broccoli-sri-hash "^2.1.0"
 
 ember-cli-string-utils@^1.0.0:
   version "1.1.0"
@@ -4883,13 +4871,7 @@ minimatch@0.3:
     lru-cache "2"
     sigmund "~1.0.0"
 
-"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@~3.0.0:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
-  dependencies:
-    brace-expansion "^1.0.0"
-
-minimatch@3.0.2:
+"minimatch@2 || 3", minimatch@3.0.2, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@~3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.2.tgz#0f398a7300ea441e9c348c83d98ab8c9dbf9c40a"
   dependencies:
@@ -4898,6 +4880,12 @@ minimatch@3.0.2:
 minimatch@^2.0.3:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-2.0.10.tgz#8d087c39c6b38c001b97fca7ce6d0e1e80afbac7"
+  dependencies:
+    brace-expansion "^1.0.0"
+
+minimatch@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
   dependencies:
     brace-expansion "^1.0.0"
 
@@ -6328,7 +6316,7 @@ route-recognizer@^0.2.3:
   version "0.2.10"
   resolved "https://registry.yarnpkg.com/route-recognizer/-/route-recognizer-0.2.10.tgz#024b2283c2e68d13a7c7f5173a5924645e8902df"
 
-rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.6, rsvp@^3.1.0, rsvp@^3.2.1, rsvp@^3.3.3:
+rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.6, rsvp@^3.2.1, rsvp@^3.3.3:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.4.0.tgz#96f397d9c7e294351b3c1456a74b3d0e7542988d"
 
@@ -6643,10 +6631,6 @@ spdx-license-ids@^1.0.2:
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
-
-sri-toolbox@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/sri-toolbox/-/sri-toolbox-0.2.0.tgz#a7fea5c3fde55e675cf1c8c06f3ebb5c2935835e"
 
 sshpk@^1.7.0:
   version "1.11.0"


### PR DESCRIPTION
requires https://github.com/TryGhost/Ghost/pull/8142
- switch to hash-location rather than history-location
- remove usage of Ghost's `{{asset}}` helper in index.html
- add `content-for` helpers to `asset-delivery` addon that switch asset urls in index.html to `.min` files in production
- update the `asset-delivery` addon to copy the production `index.min.html` to `default-prod.hbs` so Ghost can serve production assets when in production mode
- enable asset fingerprinting
- add `ember-cli-inject-live-reload` dependency
- remove `ember-cli-sri` dependency - we weren't using it but now that ember is handling assets it was used automatically and could potentially create issues if users have proxy servers that attempt to compress or otherwise modify asset files

This cuts the final tie that requires Ghost to render+parse the index.html as a handlebars file which means that `ember serve` will finally be usable and the associated livereload functionality can be re-enabled.

To use ember serve and livereload:
1. In first tab, run `npm start` in Ghost root
2. In second tab, `cd core/client` then run `ember serve --proxy=http://localhost:2368`
3. Admin area is now available on http://localhost:4200 with livereload enabled (necessary to use password auth at the moment due to mismatch between ember URL and registered ghost url in auth server)

TODO:
- [x] server-side component that switches between default.hbs and default-prod.hbs depending on environment
- [x] `favicon.ico` handling - ghost-admin doesn't have a favicon.ico
- [ ] look into how the `core/built` folder can be kept clean - asset files now have hashes in the filename so old files will be kept around rather than being overwritten - add a gulp/grunt task and ensure any release task calls it so releases have a clean built/assets folder?
- [x] remove `minified-in-production` and combine with the `asset-delivery` addon
- [x] check whether `ghost-dark.css` is rewritten correctly to match the hashed asset
- [ ] if using `ember serve --proxy`, how should Ghost OAuth be handled? (redirect URI mismatch)