### PR TITLE
✨ show theme warnings/errors when activating a theme

### DIFF
--- a/app/adapters/theme.js
+++ b/app/adapters/theme.js
@@ -6,7 +6,8 @@ export default ApplicationAdapter.extend({
         let url = `${this.buildURL('theme', model.get('id'))}activate/`;
 
         return this.ajax(url, 'PUT', {data: {}}).then((data) => {
-            return this.store.pushPayload(data);
+            this.store.pushPayload(data);
+            return model;
         });
     }
 

--- a/app/components/gh-theme-error-li.js
+++ b/app/components/gh-theme-error-li.js
@@ -1,0 +1,6 @@
+import Component from 'ember-component';
+
+export default Component.extend({
+    tagName: '',
+    error: null
+});

--- a/app/components/modals/theme-warnings.js
+++ b/app/components/modals/theme-warnings.js
@@ -1,0 +1,10 @@
+import ModalComponent from 'ghost-admin/components/modals/base';
+import {reads} from 'ember-computed';
+
+export default ModalComponent.extend({
+    title: reads('model.title'),
+    message: reads('model.message'),
+    warnings: reads('model.warnings'),
+
+    'data-test-theme-warnings-modal': true
+});

--- a/app/models/theme.js
+++ b/app/models/theme.js
@@ -9,6 +9,25 @@ export default Model.extend({
 
     activate() {
         let adapter = this.store.adapterFor(this.constructor.modelName);
-        return adapter.activate(this);
+
+        return adapter.activate(this).then(() => {
+            // the server only gives us the newly active theme back so we need
+            // to manually mark other themes as inactive in the store
+            let activeThemes = this.store.peekAll('theme').filterBy('active', true);
+
+            activeThemes.forEach((theme) => {
+                if (theme !== this) {
+                    // store.push is necessary to avoid dirty records that cause
+                    // problems when we get new data back in subsequent requests
+                    this.store.push({data: {
+                        id: theme.id,
+                        type: 'theme',
+                        attributes: {active: false}
+                    }});
+                }
+            });
+
+            return this;
+        });
     }
 });

--- a/app/templates/components/gh-theme-error-li.hbs
+++ b/app/templates/components/gh-theme-error-li.hbs
@@ -1,0 +1,13 @@
+<li>
+    {{#if error.details}}
+        {{{error.details}}}
+    {{else}}
+        {{{error.rule}}}
+    {{/if}}
+
+    <ul>
+        {{#each error.failures as |failure|}}
+            <li><code>{{failure.ref}}</code>{{#if failure.message}}: {{failure.message}}{{/if}}</li>
+        {{/each}}
+    </ul>
+</li>

--- a/app/templates/components/modals/theme-warnings.hbs
+++ b/app/templates/components/modals/theme-warnings.hbs
@@ -1,0 +1,23 @@
+<header class="modal-header">
+    <h1 data-test-theme-warnings-title>{{title}}</h1>
+</header>
+<a class="close icon-x" href="#" title="Close" {{action "closeModal"}}><span class="hidden">Close</span></a>
+
+<div class="modal-body">
+    <ul class="theme-validation-errors" data-test-theme-warnings>
+        {{#if message}}
+            <li>
+                <p data-test-theme-warnings-message>{{message}}</p>
+            </li>
+        {{/if}}
+        {{#each warnings as |error|}}
+            {{gh-theme-error-li error=error}}
+        {{/each}}
+    </ul>
+</div>
+
+<div class="modal-footer">
+    <button {{action "closeModal"}} class="gh-btn" data-test-modal-close-button>
+        <span>Close</span>
+    </button>
+</div>

--- a/app/templates/components/modals/upload-theme.hbs
+++ b/app/templates/components/modals/upload-theme.hbs
@@ -25,19 +25,7 @@
                     </p>
                 </li>
                 {{#each validationWarnings as |error|}}
-                    <li>
-                        {{#if error.details}}
-                            {{{error.details}}}
-                        {{else}}
-                            {{{error.rule}}}
-                        {{/if}}
-
-                        <ul>
-                            {{#each error.failures as |failure|}}
-                                <li><code>{{failure.ref}}</code>{{#if failure.message}}: {{failure.message}}{{/if}}</li>
-                            {{/each}}
-                        </ul>
-                    </li>
+                    {{gh-theme-error-li error=error}}
                 {{/each}}
             </ul>
         {{else}}
@@ -53,19 +41,7 @@
     {{else if validationErrors}}
         <ul class="theme-validation-errors">
             {{#each validationErrors as |error|}}
-                <li>
-                    {{#if error.details}}
-                        {{{error.details}}}
-                    {{else}}
-                        {{{error.rule}}}
-                    {{/if}}
-
-                    <ul>
-                        {{#each error.failures as |failure|}}
-                            <li><code>{{failure.ref}}</code>{{#if failure.message}}: {{failure.message}}{{/if}}</li>
-                        {{/each}}
-                    </ul>
-                </li>
+                {{gh-theme-error-li error=error}}
             {{/each}}
         </ul>
     {{else}}

--- a/app/templates/settings/design.hbs
+++ b/app/templates/settings/design.hbs
@@ -42,6 +42,26 @@
                     confirm=(action "deleteTheme")
                     modifier="action wide"}}
             {{/if}}
+
+            {{#if showThemeWarningsModal}}
+                {{gh-fullscreen-modal "theme-warnings"
+                    model=(hash
+                        title="Theme activated with warnings"
+                        warnings=themeWarnings
+                    )
+                    close=(action "hideThemeWarningsModal")
+                    modifier="action wide"}}
+            {{/if}}
+
+            {{#if showThemeErrorsModal}}
+                {{gh-fullscreen-modal "theme-warnings"
+                    model=(hash
+                        title="Theme activation failed"
+                        warnings=themeWarnings
+                    )
+                    close=(action "hideThemeWarningsModal")
+                    modifier="action wide"}}
+            {{/if}}
         </div>
 
     </section>

--- a/mirage/config/themes.js
+++ b/mirage/config/themes.js
@@ -20,9 +20,7 @@ export default function mockThemes(server) {
 
         theme = themes.create(theme);
 
-        return {
-            themes: [theme]
-        };
+        return {themes: [theme]};
     });
 
     server.del('/themes/:theme/', function ({themes}, {params}) {
@@ -33,8 +31,8 @@ export default function mockThemes(server) {
 
     server.put('/themes/:theme/activate/', function ({themes}, {params}) {
         themes.all().update('active', false);
-        themes.findBy({name: params.theme}).update({active: true});
+        let theme = themes.findBy({name: params.theme}).update({active: true});
 
-        return themes.all();
+        return {themes: [theme]};
     });
 }


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8127
- update theme activation to manually set other themes to `active: false` in the store now that we only get the active theme back from `/themes/:name/activate` endpoint
- move theme warning list item rendering into `{{gh-theme-error-li error=x}}`
- add `theme-warnings` modal that accepts a warnings list, title, and optional message
- after activating a theme, check if the theme has any warnings or errors and display an appropriate modal informing the user

![theme-activation-warnings](https://cloud.githubusercontent.com/assets/415/23866268/34ac2026-0810-11e7-8159-94af90832ac6.gif)
