### PR TITLE
fix(tag): ensure tag property exists before trying to trim it

### DIFF
--- a/app/controllers/settings/tags/tag.js
+++ b/app/controllers/settings/tags/tag.js
@@ -18,7 +18,9 @@ export default Controller.extend({
         let tag = this.get('tag');
         let currentValue = tag.get(propKey);
 
-        newValue = newValue.trim();
+        if (newValue) {
+            newValue = newValue.trim();
+        }
 
         // Quit if there was no change
         if (newValue === currentValue) {


### PR DESCRIPTION
no issue
- fixes error thrown when you focus in/focus out of a field in the tags
editor without entering anything