### PR TITLE
🔥 remove settings.postsPerPage

### DIFF
--- a/app/models/setting.js
+++ b/app/models/setting.js
@@ -12,7 +12,6 @@ export default Model.extend(ValidationEngine, {
     cover: attr('string'),
     icon: attr('string'),
     defaultLang: attr('string'),
-    postsPerPage: attr('number'),
     forceI18n: attr('boolean'),
     permalinks: attr('string'),
     activeTimezone: attr('string', {defaultValue: 'Etc/UTC'}),

--- a/app/validators/setting.js
+++ b/app/validators/setting.js
@@ -1,7 +1,7 @@
 import BaseValidator from './base';
 
 export default BaseValidator.create({
-    properties: ['title', 'description', 'password', 'postsPerPage'],
+    properties: ['title', 'description', 'password'],
     title(model) {
         let title = model.get('title');
 
@@ -26,21 +26,6 @@ export default BaseValidator.create({
 
         if (isPrivate && password === '') {
             model.get('errors').add('password', 'Password must be supplied');
-            this.invalidate();
-        }
-    },
-
-    postsPerPage(model) {
-        let postsPerPage = model.get('postsPerPage');
-
-        if (!validator.isInt(postsPerPage)) {
-            model.get('errors').add('postsPerPage', 'Posts per page must be a number');
-            this.invalidate();
-        } else if (postsPerPage > 1000) {
-            model.get('errors').add('postsPerPage', 'The maximum number of posts per page is 1000');
-            this.invalidate();
-        } else if (postsPerPage < 1) {
-            model.get('errors').add('postsPerPage', 'The minimum number of posts per page is 1');
             this.invalidate();
         }
     }

--- a/mirage/fixtures/settings.js
+++ b/mirage/fixtures/settings.js
@@ -51,16 +51,6 @@ export default [
         updated_by: 1
     },
     {
-        id: 6,
-        created_at: '2015-09-11T09:44:30.809Z',
-        created_by: 1,
-        key: 'postsPerPage',
-        type: 'blog',
-        updated_at: '2015-10-04T16:26:05.211Z',
-        updated_by: 1,
-        value: '5'
-    },
-    {
         id: 7,
         key: 'forceI18n',
         value: 'true',

--- a/tests/integration/services/feature-test.js
+++ b/tests/integration/services/feature-test.js
@@ -8,7 +8,7 @@ import run from 'ember-runloop';
 
 const {Error: EmberError} = Ember;
 
-function stubSettings(server, labs, validSave = true, validSettings = true) {
+function stubSettings(server, labs, validSave = true) {
     let settings = [
         {
             id: '1',
@@ -17,15 +17,6 @@ function stubSettings(server, labs, validSave = true, validSettings = true) {
             value: JSON.stringify(labs)
         }
     ];
-
-    if (validSettings) {
-        settings.push({
-            id: '2',
-            type: 'blog',
-            key: 'postsPerPage',
-            value: 1
-        });
-    }
 
     server.get('/ghost/api/v0.1/settings/', function () {
         return [200, {'Content-Type': 'application/json'}, JSON.stringify({settings})];


### PR DESCRIPTION
requires https://github.com/TryGhost/Ghost/pull/8149
- "posts per page" is now a theme-level concern
- UI has already been removed, this finishes the cleanup by removing `settings.postsPerPage` and related validation/test support