### PR TITLE
🐝 🐜 '+' button double click bug.

### DIFF
--- a/lib/gh-koenig/addon/components/koenig-plus-menu.js
+++ b/lib/gh-koenig/addon/components/koenig-plus-menu.js
@@ -69,7 +69,7 @@ export default Component.extend({
 
         input.blur(() => {
             window.setTimeout(() => {
-                this.send('closeMenu');
+                this.send('closeMenuKeepButton');
             }, 200);
         });
 
@@ -165,8 +165,11 @@ export default Component.extend({
             this.set('isOpen', false);
             this.set('isButton', false);
         },
+        closeMenuKeepButton: function () { // eslint-disable-line
+            this.set('isOpen', false);
+        },
         updateSelection: function (event) { // eslint-disable-line
-            alert(event);
+            // alert(event);
         }
     }
 });


### PR DESCRIPTION
When a user clicks on the plus button it opens the card menu, when they click on it twice the card menu input field loses focus and the card menu closes, because the Range object of the document is no longer within the editor the '+' button also disappears. This has the effect of making the '+' button disapear when double clicking.

Now when the input field to search cards loses focus the card menu disapears but the '+' button remains, we rely on the cursorDidChange event to also hide the button.

Refs: https://github.com/TryGhost/Ghost/issues/8106
