### PR TITLE
✨ `grunt dev` admin livereload

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,5 +1,6 @@
 /* eslint-env node */
 /* eslint-disable object-shorthand */
+'use strict';
 
 module.exports = function(grunt) {
 
@@ -42,18 +43,15 @@ module.exports = function(grunt) {
 
             ember: {
                 command: function (mode) {
+                    let liveReloadBaseUrl = grunt.option('live-reload-base-url') || '/ghost/';
+
                     switch (mode) {
                     case 'prod':
                         return 'npm run build -- --environment=production --silent';
                     case 'dev':
                         return 'npm run build';
                     case 'watch':
-                        return 'npm run build -- --watch';
-                    }
-                },
-                options: {
-                    execOptions: {
-                        stdout: false
+                        return `npm run start -- --live-reload-base-url=${liveReloadBaseUrl} --live-reload-port=4201`;
                     }
                 }
             },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "ember-cli-babel": "5.2.4",
     "ember-cli-chai": "0.3.2",
     "ember-cli-code-coverage": "0.3.11",
-    "ember-cli-content-security-policy": "0.6.0",
     "ember-cli-dependency-checker": "1.3.0",
     "ember-cli-eslint": "3.0.3",
     "ember-cli-fastclick": "1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -220,10 +220,6 @@ ast-types@0.8.12:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.12.tgz#a0d90e4351bb887716c83fd637ebf818af4adfcc"
 
-ast-types@0.8.15:
-  version "0.8.15"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.15.tgz#8eef0827f04dff0ec8857ba925abe3fea6194e52"
-
 ast-types@0.9.6:
   version "0.9.6"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.6.tgz#102c9e9e9005d3e7e3829bf0c4fa24ee862ee9b9"
@@ -955,7 +951,7 @@ blueimp-md5@2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/blueimp-md5/-/blueimp-md5-2.7.0.tgz#7f518e0dd70467fefe28ecba398916092f2a02a9"
 
-body-parser@^1.12.3, body-parser@^1.15.0:
+body-parser@^1.15.0:
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.17.1.tgz#75b3bc98ddd6e7e0d8ffe750dfaca5c66993fa47"
   dependencies:
@@ -2317,14 +2313,6 @@ ember-cli-code-coverage@0.3.11:
     rsvp "^3.2.1"
     source-map "0.5.6"
     string.prototype.startswith "^0.2.0"
-
-ember-cli-content-security-policy@0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-content-security-policy/-/ember-cli-content-security-policy-0.6.0.tgz#5c8fb9f2a721574a296318ada01d1b5771d44411"
-  dependencies:
-    body-parser "^1.12.3"
-    chalk "^1.0.0"
-    ember-cli-babel "^5.0.0"
 
 ember-cli-dependency-checker@1.3.0:
   version "1.3.0"
@@ -4566,14 +4554,14 @@ js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
-js-yaml@3.6.1, js-yaml@3.x, js-yaml@^3.6.1, js-yaml@~3.6.0:
+js-yaml@3.6.1, js-yaml@3.x, js-yaml@^3.2.5, js-yaml@^3.6.1, js-yaml@~3.6.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.6.1.tgz#6e5fe67d8b205ce4d22fad05b7781e8dadcc4b30"
   dependencies:
     argparse "^1.0.7"
     esprima "^2.6.0"
 
-js-yaml@^3.2.5, js-yaml@^3.2.7, js-yaml@^3.5.1, js-yaml@~3.7.0:
+js-yaml@^3.2.7, js-yaml@^3.5.1, js-yaml@~3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
   dependencies:
@@ -5203,7 +5191,13 @@ minimatch@0.3:
     lru-cache "2"
     sigmund "~1.0.0"
 
-"minimatch@2 || 3", minimatch@3.0.2, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@~3.0.0:
+"minimatch@2 || 3", minimatch@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
+  dependencies:
+    brace-expansion "^1.0.0"
+
+minimatch@3.0.2, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@~3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.2.tgz#0f398a7300ea441e9c348c83d98ab8c9dbf9c40a"
   dependencies:
@@ -5212,12 +5206,6 @@ minimatch@0.3:
 minimatch@^2.0.3:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-2.0.10.tgz#8d087c39c6b38c001b97fca7ce6d0e1e80afbac7"
-  dependencies:
-    brace-expansion "^1.0.0"
-
-minimatch@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
   dependencies:
     brace-expansion "^1.0.0"
 
@@ -6134,20 +6122,11 @@ readline2@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     mute-stream "0.0.5"
 
-recast@0.10.33:
+recast@0.10.33, recast@^0.10.10:
   version "0.10.33"
   resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.33.tgz#942808f7aa016f1fa7142c461d7e5704aaa8d697"
   dependencies:
     ast-types "0.8.12"
-    esprima-fb "~15001.1001.0-dev-harmony-fb"
-    private "~0.1.5"
-    source-map "~0.5.0"
-
-recast@^0.10.10:
-  version "0.10.43"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.43.tgz#b95d50f6d60761a5f6252e15d80678168491ce7f"
-  dependencies:
-    ast-types "0.8.15"
     esprima-fb "~15001.1001.0-dev-harmony-fb"
     private "~0.1.5"
     source-map "~0.5.0"


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/8161, requires https://github.com/TryGhost/Ghost/pull/8176
- updates the `ember:watch` grunt task to use `ember serve`, passing in the required `--live-reload-base-url` parameter
    - forces live reload port to `4201` for now as there's a [bug on touchbar macs](https://github.com/ember-cli/ember-cli/issues/6513)
- removes the unused `ember-cli-content-security-policy` dependency to remove console log noise from x-domain warnings

With this and the required Ghost PR, when using `grunt dev` the admin screen will refresh any time a file is changed. It will also allow tests to be run simultaneously by visiting http://localhost:4200/tests