### PR TITLE
🔥 Remove handlebars from serving admin

### DIFF
--- a/lib/asset-delivery/index.js
+++ b/lib/asset-delivery/index.js
@@ -37,9 +37,9 @@ module.exports = {
         fs.ensureDirSync(assetsOut);
 
         if (fs.existsSync(results.directory + '/index.min.html')) {
-            fs.copySync(results.directory + '/index.min.html', `${templateOutDir}/default-prod.hbs`, {overwrite: true});
+            fs.copySync(results.directory + '/index.min.html', `${templateOutDir}/default-prod.html`, {overwrite: true});
         } else {
-            fs.copySync(results.directory + '/index.html', `${templateOutDir}/default.hbs`, {overwrite: true});
+            fs.copySync(results.directory + '/index.html', `${templateOutDir}/default.html`, {overwrite: true});
         }
 
         assets.forEach(function (relativePath) {


### PR DESCRIPTION
This requires TryGhost/Ghost#8184

refs TryGhost/Ghost#8140

- now that the admin index page is just html, we don't need handlebars anymore
- this changes the template be called .html to reflect this