### PR TITLE
🐜  Bulk selecting

### DIFF
--- a/lib/gh-koenig/addon/components/gh-koenig.js
+++ b/lib/gh-koenig/addon/components/gh-koenig.js
@@ -130,17 +130,20 @@ export default Component.extend({
         }
     },
 
-    // makes sure the cursor is on screen.
+    // makes sure the cursor is on screen except when selection is happening in which case the browser mostly ensures it.
+    // there is an issue with keyboard selection on some browsers though so the next step will be to record mouse and touch events.
     cursorMoved() {
-        let scrollBuffer = 33; // the extra buffer to scroll.
-        let range = window.getSelection().getRangeAt(0); // get the actual range within the DOM.
-        let position =  range.getBoundingClientRect();
-        let windowHeight = window.innerHeight;
+        if (this.get('editor').range.isCollapsed) {
+            let scrollBuffer = 33; // the extra buffer to scroll.
+            let range = window.getSelection().getRangeAt(0); // get the actual range within the DOM.
+            let position =  range.getBoundingClientRect();
+            let windowHeight = window.innerHeight;
 
-        if (position.bottom > windowHeight) {
-            this.domContainer.scrollTop += position.bottom - windowHeight + scrollBuffer;
-        } else if (position.top < 0) {
-            this.domContainer.scrollTop += position.top - scrollBuffer;
+            if (position.bottom > windowHeight) {
+                this.domContainer.scrollTop += position.bottom - windowHeight + scrollBuffer;
+            } else if (position.top < 0) {
+                this.domContainer.scrollTop += position.top - scrollBuffer;
+            }
         }
     },
 


### PR DESCRIPTION
Previously when selecting text in the editor the screen will jump as it tries to scroll so that the cursor is always on it.

This update means it will no longer happen when selecting the text with either the mouse or in a mobile browser. Unfortunately when selecting text with the keyboard the editor will no longer scroll with the cursor.

Closes: https://github.com/TryGhost/Ghost/issues/8153