### PR TITLE
🐜  Card Menu Default State Enter Action

### DIFF
--- a/lib/gh-koenig/addon/components/koenig-plus-menu.js
+++ b/lib/gh-koenig/addon/components/koenig-plus-menu.js
@@ -52,8 +52,9 @@ export default Component.extend({
                 selectedTool.selected = true;
             }
         } else {
-            this.set('selectedTool', tools[0]); // even if the range is out of bounds (as in the starting state where the selection prompt is not shown) 
-                                                // we still need a selected item for the enter key.
+            // even if the range is out of bounds (as in the starting state where the selection prompt is not shown)
+            // we still need a selected item for the enter key.
+            this.set('selectedTool', tools[0]);
         }
         return tools;
     }),

--- a/lib/gh-koenig/addon/components/koenig-plus-menu.js
+++ b/lib/gh-koenig/addon/components/koenig-plus-menu.js
@@ -51,6 +51,9 @@ export default Component.extend({
                 this.set('selectedTool', selectedTool);
                 selectedTool.selected = true;
             }
+        } else {
+            this.set('selectedTool', tools[0]); // even if the range is out of bounds (as in the starting state where the selection prompt is not shown) 
+                                                // we still need a selected item for the enter key.
         }
         return tools;
     }),

--- a/lib/gh-koenig/addon/components/koenig-slash-menu.js
+++ b/lib/gh-koenig/addon/components/koenig-slash-menu.js
@@ -47,6 +47,9 @@ export default Component.extend({
                 this.set('selectedTool', selectedTool);
                 selectedTool.selected = true;
             }
+        } else {
+            this.set('selectedTool', tools[0]); // even if the range is out of bounds (as in the starting state where the selection prompt is not shown) 
+                                                // we still need a selected item for the enter key.
         }
 
         return tools;

--- a/lib/gh-koenig/addon/components/koenig-slash-menu.js
+++ b/lib/gh-koenig/addon/components/koenig-slash-menu.js
@@ -48,8 +48,9 @@ export default Component.extend({
                 selectedTool.selected = true;
             }
         } else {
-            this.set('selectedTool', tools[0]); // even if the range is out of bounds (as in the starting state where the selection prompt is not shown) 
-                                                // we still need a selected item for the enter key.
+            // even if the range is out of bounds (as in the starting state where the selection prompt is not shown)
+            // we still need a selected item for the enter key.
+            this.set('selectedTool', tools[0]);
         }
 
         return tools;


### PR DESCRIPTION
The default state of both the '/' and '+' card menus is a selection of -1, this ensure that the active tool prompt isn't shown until the user presses an arrow key for keyboard selection. However -1 isn't a valid tool id so when pressing enter without selecting a tool the user will cause an error.

This update ensures that the selected tool is the first tool available even if the selection is in fact -1.

Closes: https://github.com/TryGhost/Ghost/issues/8196