### PR TITLE
Fix tests when run via http://localhost:4200/tests

### DIFF
--- a/mirage/fixtures/configurations.js
+++ b/mirage/fixtures/configurations.js
@@ -1,6 +1,6 @@
 export default [{
     blogTitle: 'Test Blog',
-    blogUrl: 'http://localhost:7357/',
+    blogUrl: `${window.location.origin}/`,
     clientId: 'ghost-admin',
     clientSecret: '1234ClientSecret',
     fileStorage: 'true',

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "ember-cli-inject-live-reload": "1.6.1",
     "ember-cli-mirage": "0.2.8",
     "ember-cli-mocha": "0.13.2",
-    "ember-cli-node-assets": "0.1.6",
+    "ember-cli-node-assets": "0.2.2",
     "ember-cli-postcss": "3.2.0",
     "ember-cli-pretender": "1.0.1",
     "ember-cli-selectize": "0.5.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2438,7 +2438,18 @@ ember-cli-mocha@0.13.2:
     mocha "^2.5.3"
     resolve "^1.1.7"
 
-ember-cli-node-assets@0.1.6, ember-cli-node-assets@^0.1.4:
+ember-cli-node-assets@0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/ember-cli-node-assets/-/ember-cli-node-assets-0.2.2.tgz#d2d55626e7cc6619f882d7fe55751f9266022708"
+  dependencies:
+    broccoli-funnel "^1.0.1"
+    broccoli-merge-trees "^1.1.1"
+    broccoli-source "^1.1.0"
+    debug "^2.2.0"
+    lodash "^4.5.1"
+    resolve "^1.1.7"
+
+ember-cli-node-assets@^0.1.4:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/ember-cli-node-assets/-/ember-cli-node-assets-0.1.6.tgz#6488a2949048c801ad6d9e33753c7bce32fc1146"
   dependencies:


### PR DESCRIPTION
no issue
- `blogUrl` in the mocked config was hardcoded, switching to using the current origin fixed the navigation tests
- we were only pulling jquery drag simulator library in on test builds but we also need it added to `test-support.js` in development builds
- lazy loading is disabled in the test env which previously worked fine as all of the codemirror assets are bundled into the test build, now that we also run tests using the development build we needed to update the config to import codemirror assets into the `test-support.js` file - this ensures that we have normal lazy-loading behaviour when developing locally and that accessing via http://localhost:4200/tests doesn't die horribly due to missing dependencies