### PR TITLE
🛠 switch to using yarn in our Grunt tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,7 +34,7 @@ module.exports = function(grunt) {
 
         shell: {
             'npm-install': {
-                command: 'npm install'
+                command: 'yarn install'
             },
 
             'bower-install': {


### PR DESCRIPTION
requires https://github.com/TryGhost/Ghost/pull/8261
- use `yarn install` instead of `npm install` in our `grunt init` task (used in Ghost's `grunt init` via subgrunt)