### PR TITLE
🐝  Ghost Image Preview in Markdown.

### DIFF
--- a/lib/gh-koenig/addon/lib/format-markdown.js
+++ b/lib/gh-koenig/addon/lib/format-markdown.js
@@ -4,7 +4,7 @@ import {htmlSafe} from 'ember-string';
 import cajaSanitizers from './caja-sanitizers';
 
 // eslint-disable-next-line new-cap
-let showdown = new Showdown.converter({extensions: ['ghostimagepreview', 'ghostgfm', 'footnotes', 'highlight']});
+let showdown = new Showdown.converter({extensions: ['ghostgfm', 'footnotes', 'highlight']});
 
 export function formatMarkdown(params) {
     if (!params || !params.length) {


### PR DESCRIPTION
Removes the upload image button in the markdown preview.

Refs: https://github.com/TryGhost/Ghost/issues/8248