### PR TITLE
🐛 fix broken assets

### DIFF
--- a/app/helpers/gh-path.js
+++ b/app/helpers/gh-path.js
@@ -7,6 +7,9 @@ import ghostPaths from 'ghost-admin/utils/ghost-paths';
 // {{gh-path}} or {{gh-path 'blog'}} for Ghost's root (/myblog/)
 // {{gh-path 'admin'}} for Ghost's admin root (/myblog/ghost/)
 // {{gh-path 'api'}} for Ghost's api root (/myblog/ghost/api/v0.1/)
+//
+// DO NOT USE - admin asset paths are now relative because we are using hash urls
+//              and the gh-path helper can get in the way of asset rewriting
 // {{gh-path 'asset' '/img/hi.png'}} for resolved url (/myblog/ghost/assets/img/hi.png)
 
 export default helper(function (params) {

--- a/app/templates/-contributors.hbs
+++ b/app/templates/-contributors.hbs
@@ -1,100 +1,100 @@
 <article>
     <a href="https://github.com/JohnONolan" title="JohnONolan">
-        <img src="{{gh-path "asset" "/img/contributors"}}/JohnONolan.jpeg" alt="JohnONolan" />
+        <img src="assets/img/contributors/JohnONolan.jpeg" alt="JohnONolan" />
     </a>
 </article>
 <article>
     <a href="https://github.com/ErisDS" title="ErisDS">
-        <img src="{{gh-path "asset" "/img/contributors"}}/ErisDS.jpeg" alt="ErisDS" />
+        <img src="assets/img/contributors/ErisDS.jpeg" alt="ErisDS" />
     </a>
 </article>
 <article>
     <a href="https://github.com/sebgie" title="sebgie">
-        <img src="{{gh-path "asset" "/img/contributors"}}/sebgie.png" alt="sebgie" />
+        <img src="assets/img/contributors/sebgie.png" alt="sebgie" />
     </a>
 </article>
 <article>
     <a href="https://github.com/frantzypants" title="frantzypants">
-        <img src="{{gh-path "asset" "/img/contributors"}}/frantzypants.jpeg" alt="frantzypants" />
+        <img src="assets/img/contributors/frantzypants.jpeg" alt="frantzypants" />
     </a>
 </article>
 <article>
     <a href="https://github.com/cobbspur" title="cobbspur">
-        <img src="{{gh-path "asset" "/img/contributors"}}/cobbspur.jpeg" alt="cobbspur" />
+        <img src="assets/img/contributors/cobbspur.jpeg" alt="cobbspur" />
     </a>
 </article>
 <article>
     <a href="https://github.com/kevinansfield" title="kevinansfield">
-        <img src="{{gh-path "asset" "/img/contributors"}}/kevinansfield.jpeg" alt="kevinansfield" />
+        <img src="assets/img/contributors/kevinansfield.jpeg" alt="kevinansfield" />
     </a>
 </article>
 <article>
     <a href="https://github.com/GeorginaLusby" title="GeorginaLusby">
-        <img src="{{gh-path "asset" "/img/contributors"}}/GeorginaLusby.jpeg" alt="GeorginaLusby" />
+        <img src="assets/img/contributors/GeorginaLusby.jpeg" alt="GeorginaLusby" />
     </a>
 </article>
 <article>
     <a href="https://github.com/AileenCGN" title="AileenCGN">
-        <img src="{{gh-path "asset" "/img/contributors"}}/AileenCGN.jpeg" alt="AileenCGN" />
+        <img src="assets/img/contributors/AileenCGN.jpeg" alt="AileenCGN" />
     </a>
 </article>
 <article>
     <a href="https://github.com/kirrg001" title="kirrg001">
-        <img src="{{gh-path "asset" "/img/contributors"}}/kirrg001.jpeg" alt="kirrg001" />
+        <img src="assets/img/contributors/kirrg001.jpeg" alt="kirrg001" />
     </a>
 </article>
 <article>
     <a href="https://github.com/disordinary" title="disordinary">
-        <img src="{{gh-path "asset" "/img/contributors"}}/disordinary.jpeg" alt="disordinary" />
+        <img src="assets/img/contributors/disordinary.jpeg" alt="disordinary" />
     </a>
 </article>
 <article>
     <a href="https://github.com/acburdine" title="acburdine">
-        <img src="{{gh-path "asset" "/img/contributors"}}/acburdine.jpeg" alt="acburdine" />
+        <img src="assets/img/contributors/acburdine.jpeg" alt="acburdine" />
     </a>
 </article>
 <article>
     <a href="https://github.com/dbalders" title="dbalders">
-        <img src="{{gh-path "asset" "/img/contributors"}}/dbalders.jpeg" alt="dbalders" />
+        <img src="assets/img/contributors/dbalders.jpeg" alt="dbalders" />
     </a>
 </article>
 <article>
     <a href="https://github.com/felixrieseberg" title="felixrieseberg">
-        <img src="{{gh-path "asset" "/img/contributors"}}/felixrieseberg.jpeg" alt="felixrieseberg" />
+        <img src="assets/img/contributors/felixrieseberg.jpeg" alt="felixrieseberg" />
     </a>
 </article>
 <article>
     <a href="https://github.com/jaswilli" title="jaswilli">
-        <img src="{{gh-path "asset" "/img/contributors"}}/jaswilli.jpeg" alt="jaswilli" />
+        <img src="assets/img/contributors/jaswilli.jpeg" alt="jaswilli" />
     </a>
 </article>
 <article>
     <a href="https://github.com/halfdan" title="halfdan">
-        <img src="{{gh-path "asset" "/img/contributors"}}/halfdan.jpeg" alt="halfdan" />
+        <img src="assets/img/contributors/halfdan.jpeg" alt="halfdan" />
     </a>
 </article>
 <article>
     <a href="https://github.com/kevinkucharczyk" title="kevinkucharczyk">
-        <img src="{{gh-path "asset" "/img/contributors"}}/kevinkucharczyk.jpeg" alt="kevinkucharczyk" />
+        <img src="assets/img/contributors/kevinkucharczyk.jpeg" alt="kevinkucharczyk" />
     </a>
 </article>
 <article>
     <a href="https://github.com/mixonic" title="mixonic">
-        <img src="{{gh-path "asset" "/img/contributors"}}/mixonic.png" alt="mixonic" />
+        <img src="assets/img/contributors/mixonic.png" alt="mixonic" />
     </a>
 </article>
 <article>
     <a href="https://github.com/rwjblue" title="rwjblue">
-        <img src="{{gh-path "asset" "/img/contributors"}}/rwjblue.jpeg" alt="rwjblue" />
+        <img src="assets/img/contributors/rwjblue.jpeg" alt="rwjblue" />
     </a>
 </article>
 <article>
     <a href="https://github.com/tgriesser" title="tgriesser">
-        <img src="{{gh-path "asset" "/img/contributors"}}/tgriesser.png" alt="tgriesser" />
+        <img src="assets/img/contributors/tgriesser.png" alt="tgriesser" />
     </a>
 </article>
 <article>
     <a href="https://github.com/bnookala" title="bnookala">
-        <img src="{{gh-path "asset" "/img/contributors"}}/bnookala.jpeg" alt="bnookala" />
+        <img src="assets/img/contributors/bnookala.jpeg" alt="bnookala" />
     </a>
 </article>

--- a/app/templates/about.hbs
+++ b/app/templates/about.hbs
@@ -4,7 +4,7 @@
     </header>
     <section class="view-content">
         <header class="gh-about-header">
-            <img class="gh-logo" src="{{gh-path 'asset' '/img/ghost-logo.png'}}" alt="Ghost" />
+            <img class="gh-logo" src="assets/img/ghost-logo.png" alt="Ghost" />
         </header>
 
         {{gh-upgrade-notification}}

--- a/app/templates/error.hbs
+++ b/app/templates/error.hbs
@@ -1,7 +1,7 @@
 <div class="gh-view">
     <section class="error-content error-404 js-error-container">
         <section class="error-details">
-             <img class="error-ghost" src="{{gh-path 'asset' '/img/404-ghost@2x.png'}}" srcset="{{gh-path 'asset' '/img/404-ghost.png'}} 1x, {{gh-path 'asset' '/img/404-ghost@2x.png'}} 2x" />
+             <img class="error-ghost" src="assets/img/404-ghost@2x.png" srcset="assets/img/404-ghost.png 1x, assets/img/404-ghost@2x.png 2x" />
              <section class="error-message">
                  <h1 class="error-code">{{code}}</h1>
                  <h2 class="error-description">{{message}}</h2>

--- a/app/templates/settings/apps/amp.hbs
+++ b/app/templates/settings/apps/amp.hbs
@@ -8,7 +8,7 @@
     <section class="view-content">
         <section class="app-grid">
             <div class="app-cell">
-                <img class="app-icon" src="{{gh-path 'asset' '/img/ampicon.png'}}" />
+                <img class="app-icon" src="assets/img/ampicon.png" />
             </div>
             <div class="app-cell">
                 <h3>AMP</h3>

--- a/app/templates/settings/apps/index.hbs
+++ b/app/templates/settings/apps/index.hbs
@@ -9,7 +9,7 @@
             {{#link-to "settings.apps.slack" id="slack-link"}}
             <article class="apps-card-app">
                 <div class="apps-card-left">
-                    <figure class="apps-card-app-icon" style="background-image:url({{gh-path 'asset' '/img/slackicon.png'}})"></figure>
+                    <figure class="apps-card-app-icon" style="background-image:url(assets/img/slackicon.png)"></figure>
                     <div class="apps-card-meta">
                         <h3 class="apps-card-app-title">Slack</h3>
                         <p class="apps-card-app-desc">A team communication tool</p>
@@ -33,7 +33,7 @@
             {{#link-to "settings.apps.amp" id="amp-link"}}
             <article class="apps-card-app">
                 <div class="apps-card-left">
-                    <figure class="apps-card-app-icon" style="background-image:url({{gh-path 'asset' '/img/ampicon.png'}})"></figure>
+                    <figure class="apps-card-app-icon" style="background-image:url(assets/img/ampicon.png)"></figure>
                     <div class="apps-card-meta">
                         <h3 class="apps-card-app-title">AMP</h3>
                         <p class="apps-card-app-desc">Google Accelerated Mobile Pages</p>

--- a/app/templates/settings/apps/slack.hbs
+++ b/app/templates/settings/apps/slack.hbs
@@ -8,7 +8,7 @@
     <section class="view-content">
         <section class="app-grid">
             <div class="app-cell">
-                <img class="app-icon" src="{{gh-path 'asset' '/img/slackicon.png'}}" />
+                <img class="app-icon" src="assets/img/slackicon.png" />
             </div>
             <div class="app-cell">
                 <h3>Slack</h3>

--- a/app/templates/setup/one.hbs
+++ b/app/templates/setup/one.hbs
@@ -4,7 +4,7 @@
 </header>
 
 <figure class="gh-flow-screenshot">
-    <img src="{{gh-path 'asset' 'img/install-welcome.png'}}" alt="Ghost screenshot" />
+    <img src="assets/img/install-welcome.png" alt="Ghost screenshot" />
 </figure>
 
 {{#link-to "setup.two" classNames="gh-btn gh-btn-green gh-btn-lg"}}

--- a/app/templates/setup/three.hbs
+++ b/app/templates/setup/three.hbs
@@ -3,7 +3,7 @@
     <p>Ghost works best when shared with others. Collaborate, get feedback on your posts &amp; work together on ideas.</p>
 </header>
 
-<div><img class="gh-flow-faces" src="{{gh-path 'asset' 'img/users.png'}}" alt="" /></div>
+<div><img class="gh-flow-faces" src="assets/img/users.png" alt="" /></div>
 
 <form class="gh-flow-invite">
     {{#gh-form-group errors=errors hasValidated=hasValidated property="users"}}

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -119,7 +119,10 @@ module.exports = function (defaults) {
                 plugins: postcssPlugins()
             }
         },
-        fingerprint: {enabled: true},
+        fingerprint: {
+            enabled: true,
+            extensions: ['js', 'css', 'png', 'jpg', 'jpeg', 'gif', 'map']
+        },
         nodeAssets: {
             'blueimp-md5': {
                 import: ['js/md5.js']


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8270
- add `.jpeg` to the list of asset extensions that get fingerprinted
- remove the use of the `{{gh-path "asset" ...}}` helper - since switching to hash-location URLs all assets can now be referenced relatively and removing usage of the helper prevents it getting in the way of ember-cli's asset fingerprinting/rewriting mechanism