### PR TITLE
🐛 fix night-mode in production build

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -105,7 +105,8 @@ module.exports = function (defaults) {
                 js: assetLocation('ghost.js'),
                 css: {
                     app: assetLocation('ghost.css'),
-                    'app-dark': assetLocation('ghost-dark.css')
+                    // TODO: find a way to use the .min file with the lazyLoader
+                    'app-dark': 'assets/ghost-dark.css'
                 }
             },
             vendor: {


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8213
- quick-fix by not adding the `.min` to the production `ghost-dark.css` file, the asset rename breaks the asset rewriting resulting in the lazy loader attempting to load a non-fingerprinted file