### PR TITLE
🐛 fix "More" link in mobile nav

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -17,7 +17,7 @@
 
         {{gh-content-cover onClick="closeMenus" onMouseEnter="closeAutoNav"}}
 
-        {{gh-mobile-nav-bar}}
+        {{gh-mobile-nav-bar openMobileMenu="openMobileMenu"}}
     </div>{{!gh-viewport}}
 {{/gh-app}}
 


### PR DESCRIPTION
no issue
- pass in the action string so that the mobile menu trigger works