### PR TITLE
🐛 fix sticky dropdown links

### DIFF
--- a/app/components/gh-basic-dropdown.js
+++ b/app/components/gh-basic-dropdown.js
@@ -1,0 +1,19 @@
+import BasicDropdown from 'ember-basic-dropdown/components/basic-dropdown';
+import layout from 'ember-basic-dropdown/templates/components/basic-dropdown';
+import injectService from 'ember-service/inject';
+
+export default BasicDropdown.extend({
+    dropdown: injectService(),
+
+    layout,
+
+    didInsertElement() {
+        this._super(...arguments);
+        this.get('dropdown').on('close', this, this.close);
+    },
+
+    willDestroyElement() {
+        this._super(...arguments);
+        this.get('dropdown').off('close');
+    }
+});

--- a/app/components/gh-nav-menu.js
+++ b/app/components/gh-nav-menu.js
@@ -2,6 +2,7 @@ import Component from 'ember-component';
 import {htmlSafe} from 'ember-string';
 import injectService from 'ember-service/inject';
 import computed from 'ember-computed';
+import calculatePosition from 'ember-basic-dropdown/utils/calculate-position';
 
 export default Component.extend({
     tagName: 'nav',
@@ -24,6 +25,17 @@ export default Component.extend({
 
     mouseEnter() {
         this.sendAction('onMouseEnter');
+    },
+
+    // equivalent to "left: auto; right: -20px"
+    userDropdownPosition(trigger, dropdown) {
+        let {horizontalPosition, verticalPosition, style} = calculatePosition(...arguments);
+        let {width: dropdownWidth} = dropdown.firstElementChild.getBoundingClientRect();
+
+        style.right += (dropdownWidth - 20);
+        style['z-index'] = 1100;
+
+        return {horizontalPosition, verticalPosition, style};
     },
 
     actions: {

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -49,6 +49,9 @@ export default Controller.extend({
         },
 
         closeAutoNav() {
+            if (this.get('autoNavOpen')) {
+                this.get('dropdown').closeDropdowns();
+            }
             this.set('autoNavOpen', false);
         },
 

--- a/app/mixins/body-event-listener.js
+++ b/app/mixins/body-event-listener.js
@@ -30,8 +30,8 @@ export default Mixin.create({
             return;
         }
 
-        this._clickHandler = () => {
-            return this.bodyClick();
+        this._clickHandler = (event) => {
+            return this.bodyClick(event);
         };
 
         return $(this.get('bodyElementSelector')).on('click', this._clickHandler);

--- a/app/services/dropdown.js
+++ b/app/services/dropdown.js
@@ -2,10 +2,15 @@ import Service from 'ember-service';
 import Evented from 'ember-evented';
 // This is used by the dropdown initializer (and subsequently popovers) to manage closing & toggling
 import BodyEventListener from 'ghost-admin/mixins/body-event-listener';
+import $ from 'jquery';
 
 export default Service.extend(Evented, BodyEventListener, {
-    bodyClick() {
-        this.closeDropdowns();
+    bodyClick(event) {
+        let dropdownSelector = '.ember-basic-dropdown-trigger, .ember-basic-dropdown-content';
+
+        if ($(event.target).closest(dropdownSelector).length <= 0) {
+            this.closeDropdowns();
+        }
     },
 
     closeDropdowns() {

--- a/app/styles/components/dropdowns.css
+++ b/app/styles/components/dropdowns.css
@@ -1,9 +1,13 @@
 /* Dropdowns
 /* ---------------------------------------------------------- */
 
+.ember-basic-dropdown-content {
+    z-index: 1100;
+}
+
 .dropdown {
     position: relative;
-    z-index: 1000;
+    z-index: 1100;
 }
 
 .dropdown-toggle:focus {

--- a/app/styles/layouts/main.css
+++ b/app/styles/layouts/main.css
@@ -65,6 +65,17 @@ body > .ember-view:not(.default-liquid-destination) {
     align-items: center;
     padding: 25px;
     cursor: pointer;
+    outline: none;
+}
+
+.gh-nav-menu-dropdown.ember-basic-dropdown--transitioning-in {
+    animation: fade-in-scale 0.2s;
+    animation-fill-mode: forwards;
+}
+
+.gh-nav-menu-dropdown.ember-basic-dropdown--transitioning-out {
+    animation: fade-out 0.5s;
+    animation-fill-mode: forwards;
 }
 
 .gh-nav-menu i {

--- a/app/templates/components/gh-nav-menu.hbs
+++ b/app/templates/components/gh-nav-menu.hbs
@@ -1,27 +1,29 @@
 {{gh-menu-toggle desktopAction="toggleAutoNav" mobileAction="closeMobileMenu"}}
-{{#gh-dropdown-button tagName="header" class="gh-nav-menu" dropdownName="user-menu"}}
-    <div class="gh-nav-menu-icon" style={{navMenuIcon}}></div>
-    <div class="gh-nav-menu-details">
-        <div class="gh-nav-menu-details-blog">{{config.blogTitle}}</div>
-        <div class="gh-nav-menu-details-user">{{session.user.name}}</div>
-    </div>
-    <i class="icon-arrow"></i>
-{{/gh-dropdown-button}}
-{{#gh-dropdown tagName="div" name="user-menu" closeOnClick="true"}}
-    <ul class="dropdown-menu dropdown-triangle-top js-user-menu-dropdown-menu" role="menu" style="right:-20px;left:auto;">
-        <li role="presentation"><a href="{{config.blogUrl}}/" target="_blank">View site</a></li>
-        <li role="presentation">{{#link-to "about" classNames="gh-nav-menu-about dropdown-item js-nav-item" role="menuitem" tabindex="-1"}}<i class="icon-shop"></i> About Ghost{{/link-to}}</li>
-        <li class="divider"></li>
-        <li role="presentation">{{#link-to "team.user" session.user.slug classNames="dropdown-item user-menu-profile js-nav-item" role="menuitem" tabindex="-1"}}<i class="icon-user"></i> Your Profile{{/link-to}}</li>
-        <li role="presentation"><a class="dropdown-item help-menu-support" role="menuitem" tabindex="-1" href="http://support.ghost.org/" target="_blank"><i class="icon-ambulance"></i> Support Center</a></li>
-        <li role="presentation"><a class="dropdown-item help-menu-tweet" role="menuitem" tabindex="-1" href="https://twitter.com/intent/tweet?text=%40TryGhost+Hi%21+Can+you+help+me+with+&related=TryGhost" target="_blank" onclick="window.open(this.href, 'twitter-share', 'width=550,height=235');return false;"><i class="icon-twitter"></i> Tweet @TryGhost!</a></li>
-        <li class="divider"></li>
-        <li role="presentation"><a class="dropdown-item help-menu-how-to" role="menuitem" tabindex="-1" href="http://support.ghost.org/how-to-use-ghost/" target="_blank"><i class="icon-book"></i> How to Use Ghost</a></li>
-        <li role="presentation"><a class="dropdown-item help-menu-wishlist" role="menuitem" tabindex="-1" href="http://ideas.ghost.org/" target="_blank"><i class="icon-idea"></i> Wishlist</a></li>
-        <li class="divider"></li>
-        <li role="presentation">{{#link-to "signout" classNames="dropdown-item user-menu-signout" role="menuitem" tabindex="-1"}}<i class="icon-signout"></i> Sign Out{{/link-to}}</li>
-    </ul>
-{{/gh-dropdown}}
+{{#gh-basic-dropdown horizontalPosition="right" calculatePosition=userDropdownPosition as |dropdown|}}
+    {{#dropdown.trigger tagName="header" class="gh-nav-menu"}}
+        <div class="gh-nav-menu-icon" style={{navMenuIcon}}></div>
+        <div class="gh-nav-menu-details">
+            <div class="gh-nav-menu-details-blog">{{config.blogTitle}}</div>
+            <div class="gh-nav-menu-details-user">{{session.user.name}}</div>
+        </div>
+        <i class="icon-arrow"></i>
+    {{/dropdown.trigger}}
+    {{#dropdown.content class="gh-nav-menu-dropdown"}}
+        <ul class="dropdown-menu dropdown-triangle-top" role="menu" {{action dropdown.actions.close on="click" preventDefault=false}}>
+            <li role="presentation"><a href="{{config.blogUrl}}/" target="_blank">View site</a></li>
+            <li role="presentation">{{#link-to "about" classNames="gh-nav-menu-about dropdown-item js-nav-item" role="menuitem" tabindex="-1"}}<i class="icon-shop"></i> About Ghost{{/link-to}}</li>
+            <li class="divider"></li>
+            <li role="presentation">{{#link-to "team.user" session.user.slug classNames="dropdown-item user-menu-profile js-nav-item" role="menuitem" tabindex="-1"}}<i class="icon-user"></i> Your Profile{{/link-to}}</li>
+            <li role="presentation"><a class="dropdown-item help-menu-support" role="menuitem" tabindex="-1" href="http://support.ghost.org/" target="_blank"><i class="icon-ambulance"></i> Support Center</a></li>
+            <li role="presentation"><a class="dropdown-item help-menu-tweet" role="menuitem" tabindex="-1" href="https://twitter.com/intent/tweet?text=%40TryGhost+Hi%21+Can+you+help+me+with+&related=TryGhost" target="_blank" onclick="window.open(this.href, 'twitter-share', 'width=550,height=235');return false;"><i class="icon-twitter"></i> Tweet @TryGhost!</a></li>
+            <li class="divider"></li>
+            <li role="presentation"><a class="dropdown-item help-menu-how-to" role="menuitem" tabindex="-1" href="http://support.ghost.org/how-to-use-ghost/" target="_blank"><i class="icon-book"></i> How to Use Ghost</a></li>
+            <li role="presentation"><a class="dropdown-item help-menu-wishlist" role="menuitem" tabindex="-1" href="http://ideas.ghost.org/" target="_blank"><i class="icon-idea"></i> Wishlist</a></li>
+            <li class="divider"></li>
+            <li role="presentation">{{#link-to "signout" classNames="dropdown-item user-menu-signout" role="menuitem" tabindex="-1"}}<i class="icon-signout"></i> Sign Out{{/link-to}}</li>
+        </ul>
+    {{/dropdown.content}}
+{{/gh-basic-dropdown}}
 <section class="gh-nav-body">
     <section class="gh-nav-search">
         {{gh-search-input class="gh-nav-search-input"}}

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "ember-light-table": "1.8.4",
     "ember-load": "0.0.11",
     "ember-load-initializers": "1.0.0",
+    "ember-native-dom-helpers": "0.3.5",
     "ember-one-way-controls": "2.0.0",
     "ember-power-select": "1.6.1",
     "ember-resolver": "4.1.0",

--- a/tests/integration/components/gh-basic-dropdown-test.js
+++ b/tests/integration/components/gh-basic-dropdown-test.js
@@ -1,0 +1,36 @@
+import {expect} from 'chai';
+import {describe, it} from 'mocha';
+import {setupComponentTest} from 'ember-mocha';
+import hbs from 'htmlbars-inline-precompile';
+import {clickTrigger} from '../../helpers/ember-basic-dropdown';
+import {find} from 'ember-native-dom-helpers';
+import $ from 'jquery';
+import run from 'ember-runloop';
+
+describe('Integration: Component: gh-basic-dropdown', function() {
+    setupComponentTest('gh-basic-dropdown', {
+        integration: true
+    });
+
+    it('closes when dropdown service fires close event', function() {
+        let dropdownService = this.container.lookup('service:dropdown');
+
+        this.render(hbs`
+            {{#gh-basic-dropdown as |dropdown|}}
+                <button class="ember-basic-dropdown-trigger" onclick={{dropdown.actions.toggle}}></button>
+                {{#if dropdown.isOpen}}
+                    <div id="dropdown-is-opened"></div>
+                {{/if}}
+            {{/gh-basic-dropdown}}
+        `);
+
+        clickTrigger();
+        expect($(find('#dropdown-is-opened'))).to.exist;
+
+        run(() => {
+            dropdownService.closeDropdowns();
+        });
+
+        expect($(find('#dropdown-is-opened'))).to.not.exist;
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -220,10 +220,6 @@ ast-types@0.8.12:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.12.tgz#a0d90e4351bb887716c83fd637ebf818af4adfcc"
 
-ast-types@0.8.15:
-  version "0.8.15"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.15.tgz#8eef0827f04dff0ec8857ba925abe3fea6194e52"
-
 ast-types@0.9.6:
   version "0.9.6"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.6.tgz#102c9e9e9005d3e7e3829bf0c4fa24ee862ee9b9"
@@ -2888,7 +2884,7 @@ ember-mocha@^0.11.0:
   dependencies:
     ember-test-helpers "^0.6.0-beta.1"
 
-ember-native-dom-helpers@^0.3.4:
+ember-native-dom-helpers@0.3.5, ember-native-dom-helpers@^0.3.4:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/ember-native-dom-helpers/-/ember-native-dom-helpers-0.3.5.tgz#df492bc34f6b277f0c9d2adcacb3fd8a3e11defa"
   dependencies:
@@ -4568,14 +4564,14 @@ js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
-js-yaml@3.6.1, js-yaml@3.x, js-yaml@^3.6.1, js-yaml@~3.6.0:
+js-yaml@3.6.1, js-yaml@3.x, js-yaml@^3.2.5, js-yaml@^3.6.1, js-yaml@~3.6.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.6.1.tgz#6e5fe67d8b205ce4d22fad05b7781e8dadcc4b30"
   dependencies:
     argparse "^1.0.7"
     esprima "^2.6.0"
 
-js-yaml@^3.2.5, js-yaml@^3.2.7, js-yaml@^3.5.1, js-yaml@~3.7.0:
+js-yaml@^3.2.7, js-yaml@^3.5.1, js-yaml@~3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
   dependencies:
@@ -6138,20 +6134,11 @@ readline2@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     mute-stream "0.0.5"
 
-recast@0.10.33:
+recast@0.10.33, recast@^0.10.10:
   version "0.10.33"
   resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.33.tgz#942808f7aa016f1fa7142c461d7e5704aaa8d697"
   dependencies:
     ast-types "0.8.12"
-    esprima-fb "~15001.1001.0-dev-harmony-fb"
-    private "~0.1.5"
-    source-map "~0.5.0"
-
-recast@^0.10.10:
-  version "0.10.43"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.43.tgz#b95d50f6d60761a5f6252e15d80678168491ce7f"
-  dependencies:
-    ast-types "0.8.15"
     esprima-fb "~15001.1001.0-dev-harmony-fb"
     private "~0.1.5"
     source-map "~0.5.0"


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8269
- swaps the usage of our custom `gh-dropdown` component in the user menu dropdown for the `ember-wormhole` based `ember-basic-dropdown` that is used elsewhere in the app and will fully replace `gh-dropdown` in the future
- adds `gh-basic-dropdown` component that extends from `ember-basic-dropdown` and hooks into our `dropdown` service so that we can programatically close dropdowns from disparate areas of the app
- modifies the `body-event-listener` mixin to pass the click event through to it's consumers
- modifies the `bodyClick` handler in the `dropdown` service to check if the click actually originated from an ember-basic-dropdown element - this body click handler will go away once we've fully switched to `gh-basic-dropdown`
- adds `ember-native-dom-helpers` to provide consistency between acceptance and integration tests (this is the start of another refactor, eventually this addon will disappear as part of ember's [grand testing unification project](https://github.com/rwjblue/rfcs/blob/42/text/0000-grand-testing-unification.md))

Note that `ember-native-dom-helpers` was already included in the app as it's used by other addons, this PR just makes it's usage explicit.