### PR TITLE
🚫 hide ds.errors related warnings that fill the test logs

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -22,6 +22,22 @@ let App = Application.extend({
     }
 });
 
+// TODO: remove once the validations refactor is complete
+// eslint-disable-next-line
+Ember.Debug.registerWarnHandler((message, options, next) => {
+    let skip = [
+        'ds.errors.add',
+        'ds.errors.remove',
+        'ds.errors.clear'
+    ];
+
+    if (skip.includes(options.id)) {
+        return;
+    }
+
+    next(message, options);
+});
+
 loadInitializers(App, config.modulePrefix);
 
 export default App;


### PR DESCRIPTION
no issue
- our custom validation engine makes extensive use of `DS.Errors` which fills the console and especially the test logs with a ton of warnings, this change adds a handler to skip the warnings that we don't care about at the moment
- should be removed when we merge the validations refactor