### PR TITLE
🐝  Refresh publication icon after upload

### DIFF
--- a/app/components/gh-nav-menu.js
+++ b/app/components/gh-nav-menu.js
@@ -11,13 +11,15 @@ export default Component.extend({
 
     open: false,
 
-    navMenuIcon: computed('config.blogUrl', function () {
-        let url = `${this.get('config.blogUrl')}/favicon.png`;
+    navMenuIcon: computed('config.blogUrl', 'settings.icon', function () {
+        let blogIcon = this.get('settings.icon') ? this.get('settings.icon') : 'favicon.ico';
+        let url = `${this.get('config.blogUrl')}/${blogIcon}`;
 
         return htmlSafe(`background-image: url(${url})`);
     }),
 
     config: injectService(),
+    settings: injectService(),
     session: injectService(),
     ghostPaths: injectService(),
     feature: injectService(),


### PR DESCRIPTION
refs TryGhost/Ghost#7688

Instead of using a hardcoded `favicon.ico` URL to request the blog/publication icon, we read the settings which get updated as soon as a icon is uploaded.