### PR TITLE
🎨  Make blog icon backround transparent

### DIFF
--- a/app/styles/layouts/main.css
+++ b/app/styles/layouts/main.css
@@ -92,7 +92,7 @@ body > .ember-view:not(.default-liquid-destination) {
     margin-right: 10px;
     width: 34px;
     height: 34px;
-    background-color: #222;
+    background-color: transparent;
     background-size: 34px;
     border-radius: 4px;
 }


### PR DESCRIPTION
refs TryGhost/Ghost#7688

Instead of having a dark background (which was ok, when we were **only** using the default Ghost icon), we're changing it to be transparent, so custom icons look like this:

![image](https://cloud.githubusercontent.com/assets/8037602/24801259/a649ae58-1bcd-11e7-99eb-6727aa1470b4.png)

instead of

![image](https://cloud.githubusercontent.com/assets/8037602/24801278/b7a90f04-1bcd-11e7-8f9a-bebe10e1f534.png)

