### PR TITLE
🐜  Key up to empty title.

### DIFF
--- a/app/components/gh-editor-title.js
+++ b/app/components/gh-editor-title.js
@@ -98,7 +98,7 @@ export default Component.extend({
 
                     let cursorPositionInEditor = editor.positionAtPoint(cursorPositionOnScreen.left, loc.top);
 
-                    if (cursorPositionInEditor.isBlank) {
+                    if (!cursorPositionInEditor || cursorPositionInEditor.isBlank) {
                         editor.element.focus();
                     } else {
                         editor.selectRange(cursorPositionInEditor.toRange());
@@ -172,6 +172,9 @@ export default Component.extend({
     // gets the character in the last line of the title that best matches the editor
     getOffsetAtPosition(horizontalOffset) {
         let [title] = this.$('.gh-editor-title')[0].childNodes;
+        if (!title || !title.textContent) {
+            return 0;
+        }
         let len = title.textContent.length;
         let range = document.createRange();
 

--- a/tests/acceptance/editor-test.js
+++ b/tests/acceptance/editor-test.js
@@ -425,6 +425,40 @@ describe('Acceptance: Editor', function() {
             });
         });
 
+        it('if title is blank it correctly shows the placeholder', function () {
+            server.createList('post', 1);
+
+            // post id 1 is a draft, checking for draft behaviour now
+            visit('/editor/1');
+
+            andThen(() => {
+                expect(currentURL(), 'currentURL')
+                    .to.equal('/editor/1');
+            });
+
+            andThen(() => {
+                titleRendered();
+            });
+
+            andThen(() => {
+                let title = find('#gh-editor-title div');
+                expect(title.data('placeholder')).to.equal('Your Post Title');
+                expect(title.hasClass('no-content')).to.be.false;
+                title.html('');
+            });
+
+            andThen(() => {
+                let title = find('#gh-editor-title div');
+                expect(title.hasClass('no-content')).to.be.true;
+                title.html('test');
+            });
+
+            andThen(() => {
+                let title = find('#gh-editor-title div');
+                expect(title.hasClass('no-content')).to.be.false;
+            });
+        });
+
         it('renders first countdown notification before scheduled time', function () {
             let clock = sinon.useFakeTimers(moment().valueOf());
             let compareDate = moment().tz('Etc/UTC').add(4, 'minutes').format('DD MMM YY @ HH:mm').toString();


### PR DESCRIPTION
When a title is empty it has no textnode to get a length of so we automatically put the horizontal offset of the cursor to 0.

Closes: https://github.com/TryGhost/Ghost/issues/8293
