### PR TITLE
🐜  Navigating from the title to a card.

### DIFF
--- a/app/components/gh-editor-title.js
+++ b/app/components/gh-editor-title.js
@@ -1,5 +1,7 @@
 import Component from 'ember-component';
 import computed from 'ember-computed';
+import run from 'ember-runloop';
+import $ from 'jquery';
 
 export default Component.extend({
     val: '',
@@ -88,13 +90,26 @@ export default Component.extend({
             // if we're within ten pixels of the bottom of this element then we try and figure out where to position
             // the cursor in the editor.
             if (event.keyCode === 40) {
+                if (!window.getSelection().rangeCount) {
+                    return;
+                }
                 let range = window.getSelection().getRangeAt(0); // get the actual range within the DOM.
-                let cursorPositionOnScreen =  range.getBoundingClientRect();
+                let cursorPositionOnScreen = range.getBoundingClientRect();
                 let offset = title.offset();
                 let bottomOfHeading =  offset.top + title.height();
                 if (cursorPositionOnScreen.bottom > bottomOfHeading - 13) {
                     let editor = this.get('editor');
                     let loc = editor.element.getBoundingClientRect();
+
+                    // if the first element is a card then that is always going to be selected.
+                    if (editor.post.sections.head && editor.post.sections.head.isCardSection) {
+                        run.next(() => {
+                            window.getSelection().removeAllRanges();
+                            $(editor.post.sections.head.renderNode.element).children('div').click();
+                        });
+
+                        return;
+                    }
 
                     let cursorPositionInEditor = editor.positionAtPoint(cursorPositionOnScreen.left, loc.top);
 
@@ -106,7 +121,6 @@ export default Component.extend({
                     return false;
                 }
             }
-            // title.removeClass('no-content');
         };
 
         // setup mutation observer

--- a/app/styles/addons/gh-koenig/koenig-toolbar.css
+++ b/app/styles/addons/gh-koenig/koenig-toolbar.css
@@ -58,6 +58,15 @@
     border: none;
     padding:5px;
 }
+.gh-toolbar.is-touch {
+    position: fixed !important;
+    top: 70px;
+    right: 40px;
+}
+
+.gh-toolbar.is-touch:after {
+    border: none;
+}
 
 .gh-toolbar-btn {
     display: flex;

--- a/app/styles/addons/ghost-editor/cardmenu.css
+++ b/app/styles/addons/ghost-editor/cardmenu.css
@@ -28,6 +28,7 @@
     border: var(--midgrey) 1px solid;
     background: #fff;
     border-radius: 100%;
+    margin-left: -40px;
 }
 
 .gh-cardmenu-button svg {
@@ -38,6 +39,12 @@
 .gh-cardmenu-button svg path {
     stroke: var(--midgrey);
     stroke-width: 2px;
+}
+
+@media (max-width: 1024px) {
+  .gh-cardmenu-button {
+        right:10px;
+  }
 }
 
 .gh-cardmenu-search {

--- a/app/templates/editor/edit.hbs
+++ b/app/templates/editor/edit.hbs
@@ -59,6 +59,7 @@
                 apiRoot=apiRoot
                 assetPath=assetPath
                 tabindex="2"
+                titleSelector=".gh-editor-title"
 		        containerSelector=".gh-editor-container"
                 setEditor=(action "setEditor")
                 menuIsOpen=(action "editorMenuIsOpen")

--- a/lib/gh-koenig/addon/components/gh-koenig.js
+++ b/lib/gh-koenig/addon/components/gh-koenig.js
@@ -69,12 +69,12 @@ export default Component.extend({
         this.set('isTouch', 'ontouchstart' in document.documentElement);
 
         // window resize handler - throttled
-        window.onresize = () => {
-            let now = Date.now();
-            if (now - 2000 > this.get('resizeEvent')) {
-                this.set('resizeEvent', now);
-            }
-        };
+        // window.onresize = () => {
+        //     let now = Date.now();
+        //     if (now - 2000 > this.get('resizeEvent')) {
+        //         this.set('resizeEvent', now);
+        //     }
+        // };
 
         run.next(() => {
             if (this.get('setEditor')) {
@@ -216,7 +216,7 @@ export default Component.extend({
         this.editor.destroy();
         this.send('deselectCard');
         document.onkeydown = null;
-        window.oresize = null;
+        // window.oresize = null;
     },
 
     actions: {

--- a/lib/gh-koenig/addon/components/gh-koenig.js
+++ b/lib/gh-koenig/addon/components/gh-koenig.js
@@ -25,6 +25,7 @@ export default Component.extend({
     selectedCard: null,
     editedCard: null,
     keyDownHandler: [],
+    resizeEvent: 0,
     init() {
         this._super(...arguments);
         let mobiledoc = this.get('value') || BLANK_DOC;
@@ -66,6 +67,14 @@ export default Component.extend({
         // to place the toolbar. Above the selected content on a mobile browser is the
         // cut | copy | paste menu so we need to place our toolbar below.
         this.set('isTouch', 'ontouchstart' in document.documentElement);
+
+        // window resize handler - throttled
+        window.onresize = () => {
+            let now = Date.now();
+            if (now - 2000 > this.get('resizeEvent')) {
+                this.set('resizeEvent', now);
+            }
+        };
 
         run.next(() => {
             if (this.get('setEditor')) {
@@ -111,7 +120,9 @@ export default Component.extend({
         editor.render(editorDom);
         this.set('_rendered', true);
 
+        // set global editor for debugging and testing.
         window.editor = editor;
+
         defaultCommands(editor); // initialise the custom text handlers for MD, etc.
         // shouldFocusEditor is only true when transitioning from new to edit, otherwise it's false or undefined.
         // therefore, if it's true it's after the first lot of content is entered and we expect the caret to be at the
@@ -139,7 +150,6 @@ export default Component.extend({
                 return returnType;
             }, true);
         };
-
     },
 
     // drag and drop images onto the editor
@@ -206,6 +216,7 @@ export default Component.extend({
         this.editor.destroy();
         this.send('deselectCard');
         document.onkeydown = null;
+        window.oresize = null;
     },
 
     actions: {

--- a/lib/gh-koenig/addon/components/gh-koenig.js
+++ b/lib/gh-koenig/addon/components/gh-koenig.js
@@ -287,7 +287,7 @@ export default Component.extend({
                                 range.tail.offset = 0;
                                 editor.selectRange(range);
                             } else {
-                                $(this.titleQuery).focus();
+                                $(this.get('titleSelector')).focus();
                                 this.send('deselectCard');
                             }
                         }
@@ -308,7 +308,7 @@ export default Component.extend({
                                 range.tail.offset = 0;
                                 editor.selectRange(range);
                             } else {
-                                $(this.titleQuery).focus();
+                                $(this.get('titleSelector')).focus();
                                 this.send('deselectCard');
                             }
                         }

--- a/lib/gh-koenig/addon/components/koenig-plus-menu.js
+++ b/lib/gh-koenig/addon/components/koenig-plus-menu.js
@@ -107,11 +107,12 @@ export default Component.extend({
             run.schedule('afterRender', this,
                 () => {
                     let button = this.$('.gh-cardmenu-button');
+
                     button.css('top', offset.top + $editor.scrollTop() - editorOffset.top - 2);
                     if (currentNode.tagName.toLowerCase() === 'li') {
-                        button.css('left', this.$(currentNode.parentNode).position().left + $editor.scrollLeft() - 90);
+                     //   button.css('left', this.$(currentNode.parentNode).position().left + $editor.scrollLeft());
                     } else {
-                        button.css('left', offset.left + $editor.scrollLeft() - 50);
+                     //   button.css('left', offset.left + $editor.scrollLeft() - 50);
                     }
                 });
         });

--- a/lib/gh-koenig/addon/components/koenig-slash-menu.js
+++ b/lib/gh-koenig/addon/components/koenig-slash-menu.js
@@ -215,6 +215,7 @@ export default Component.extend({
                     // calculate if parts of the menu that are hidden by the overflow.
                     let hiddenByOverflowY = ($editor.innerHeight() + $editor.scrollTop()) - (menu.height() + top);
                     // if the menu is off the bottom of the screen then place it above the cursor
+
                     if (hiddenByOverflowY < 0) {
                         menu.css('margin-top', -(menu.outerHeight() + 20));
                     }

--- a/lib/gh-koenig/addon/components/koenig-toolbar.js
+++ b/lib/gh-koenig/addon/components/koenig-toolbar.js
@@ -9,7 +9,7 @@ import Tools from '../options/default-tools';
 export default Component.extend({
     layout,
     classNames: ['gh-toolbar'],
-    classNameBindings: ['isVisible', 'isLink', 'tickFullLeft', 'tickHalfLeft', 'tickFullRight', 'tickHalfRight', 'tickAbove'],
+    classNameBindings: ['isVisible', 'isLink', 'tickFullLeft', 'tickHalfLeft', 'tickFullRight', 'tickHalfRight', 'tickAbove', 'isTouch'],
     isVisible: false,
     tools: [],
     hasRendered: false,
@@ -162,6 +162,10 @@ function updateToolbarToRange(self, $holder, $editor, isMouseDown) {
         self.set('isVisible', true);
         run.schedule('afterRender', this,
             () => {
+                // if we're in touch mode we just use CSS to display the toolbar.
+                if (self.get('isTouch')) {
+                    return;
+                }
                 let width = $holder.width();
                 let height = $holder.height();
                 let top = position.top + $editor.scrollTop() - $holder.height() - 20;
@@ -201,7 +205,7 @@ function updateToolbarToRange(self, $holder, $editor, isMouseDown) {
                     self.set('tickHalfRight', false);
                 }
 
-                if (self.get('isTouch') || top - $editor.scrollTop() < 0) {
+                if (!self.get('isTouch') && top - $editor.scrollTop() < 0) {
                     top = top + height + 60;
                     self.set('tickAbove', true);
                 } else {

--- a/lib/gh-koenig/addon/options/default-commands.js
+++ b/lib/gh-koenig/addon/options/default-commands.js
@@ -154,6 +154,10 @@ export default function (editor) {
             editor.run((postEditor) => {
                 let card = postEditor.builder.createCardSection('card-image', {pos: 'top', img, alt});
                 postEditor.replaceSection(editor.range.headSection, card);
+                if (!editor.range.headSection.next) {
+                    let newSection = editor.builder.createMarkupSection('p');
+                    postEditor.insertSectionAtEnd(newSection);
+                }
             });
         }
     }
@@ -181,6 +185,10 @@ export default function (editor) {
             editor.run((postEditor) => {
                 let card = postEditor.builder.createCardSection('card-markdown', {pos: 'top', markdown: code});
                 postEditor.replaceSection(editor.range.headSection, card);
+                if (!editor.range.headSection.next) {
+                    let newSection = editor.builder.createMarkupSection('p');
+                    postEditor.insertSectionAtEnd(newSection);
+                }
             });
         }
     }

--- a/lib/gh-koenig/addon/templates/components/gh-koenig.hbs
+++ b/lib/gh-koenig/addon/templates/components/gh-koenig.hbs
@@ -1,16 +1,18 @@
 {{#each emberCards as |card index|}}
     {{#ember-wormhole to=card.id}}
         {{koenig-card 
-        tabindex=index 
-        card=card 
-        apiRoot=apiRoot 
-        assetPath=assetPath 
-        selectCard=(action "selectCard") 
-        selectCardHard=(action "selectCardHard") 
-        deselectCard=(action "deselectCard") 
-        edit=(action "editCard") 
-        stopEdit=(action "stopEditingCard") 
-        editedCard=editedCard}}
+            tabindex=index 
+            card=card 
+            apiRoot=apiRoot 
+            assetPath=assetPath 
+            selectCard=(action "selectCard") 
+            selectCardHard=(action "selectCardHard") 
+            deselectCard=(action "deselectCard") 
+            edit=(action "editCard") 
+            stopEdit=(action "stopEditingCard") 
+            editedCard=editedCard
+            resize=resizeEvent
+        }}
     {{/ember-wormhole}}
 {{/each}}
 <div class='gh-koenig'>
@@ -24,6 +26,7 @@
     assetPath=assetPath 
     containerSelector=containerSelector 
     isTouch=isTouch
+    resize=resizeEvent
 }}
 {{koenig-slash-menu 
     editor=editor 
@@ -32,6 +35,7 @@
     isTouch=isTouch
     menuIsOpen=(action "menuIsOpen")
     menuIsClosed=(action "menuIsClosed")
+    resize=resizeEvent
 }}
 {{koenig-plus-menu 
     editor=editor 
@@ -40,4 +44,6 @@
     isTouch=isTouch
     menuIsOpen=(action "menuIsOpen")
     menuIsClosed=(action "menuIsClosed")
+    isTouch=isTouch
+    resize=resizeEvent
 }}


### PR DESCRIPTION
Refs: https://github.com/TryGhost/Ghost/issues/8194

Previously if the title was selected and the first element was a card then the first element would be skipped on key down.

Previously if the first element was a card and the card was selected it wouldn't navigate into the title upon pressing the up key.

This update:
- Allows you to navigate to the title and body if the first element in the document is a card.
- Adds paragraphs underneath inline markdown cards if they are the last item in the document.
- Better optimises UI for mobile devices.