### PR TITLE
Permit Facebook usernames with less than 5 chars. 

### DIFF
--- a/app/controllers/settings/general.js
+++ b/app/controllers/settings/general.js
@@ -134,8 +134,8 @@ export default Controller.extend({
                     // we got a page url, now save the username without the / in the beginning
 
                     [, username] = username.match(/^(?:\/)?(pages?\/\S+)/mi);
-                } else if (username.match(/^(http|www)|(\/)/) || !username.match(/^([a-z\d\.]{5,50})$/mi)) {
-                    errMessage = !username.match(/^([a-z\d\.]{5,50})$/mi) ? 'Your Page name is not a valid Facebook Page name' : 'The URL must be in a format like https://www.facebook.com/yourPage';
+                } else if (username.match(/^(http|www)|(\/)/) || !username.match(/^([a-z\d\.]{1,50})$/mi)) {
+                    errMessage = !username.match(/^([a-z\d\.]{1,50})$/mi) ? 'Your Page name is not a valid Facebook Page name' : 'The URL must be in a format like https://www.facebook.com/yourPage';
 
                     this.get('model.errors').add('facebook', errMessage);
                     this.get('model.hasValidated').pushObject('facebook');

--- a/app/controllers/team/user.js
+++ b/app/controllers/team/user.js
@@ -282,8 +282,8 @@ export default Controller.extend({
                     // we got a page url, now save the username without the / in the beginning
 
                     [, username] = username.match(/^(?:\/)?(pages?\/\S+)/mi);
-                } else if (username.match(/^(http|www)|(\/)/) || !username.match(/^([a-z\d\.]{5,50})$/mi)) {
-                    errMessage = !username.match(/^([a-z\d\.]{5,50})$/mi) ? 'Your Username is not a valid Facebook Username' : 'The URL must be in a format like https://www.facebook.com/yourUsername';
+                } else if (username.match(/^(http|www)|(\/)/) || !username.match(/^([a-z\d\.]{1,50})$/mi)) {
+                    errMessage = !username.match(/^([a-z\d\.]{1,50})$/mi) ? 'Your Username is not a valid Facebook Username' : 'The URL must be in a format like https://www.facebook.com/yourUsername';
 
                     this.get('user.errors').add('facebook', errMessage);
                     this.get('user.hasValidated').pushObject('facebook');

--- a/tests/acceptance/settings/general-test.js
+++ b/tests/acceptance/settings/general-test.js
@@ -208,8 +208,9 @@ describe('Acceptance: Settings - General', function () {
             await fillIn(testSelector('facebook-input'), 'ab99');
             await triggerEvent(testSelector('facebook-input'), 'blur');
 
+            expect(find(testSelector('facebook-input')).val()).to.be.equal('https://www.facebook.com/ab99');
             expect(find(testSelector('facebook-error')).text().trim(), 'inline validation response')
-                .to.equal('Your Page name is not a valid Facebook Page name');
+                .to.equal('');
 
             await fillIn(testSelector('facebook-input'), 'page/ab99');
             await triggerEvent(testSelector('facebook-input'), 'blur');

--- a/tests/acceptance/team-test.js
+++ b/tests/acceptance/team-test.js
@@ -560,7 +560,8 @@ describe('Acceptance: Team', function () {
                 await fillIn('#user-facebook', 'test');
                 await triggerEvent('#user-facebook', 'blur');
 
-                expect(find('#user-facebook').closest('.form-group').hasClass('error'), 'facebook input should be in error state').to.be.true;
+                expect(find('#user-facebook').val()).to.be.equal('https://www.facebook.com/test');
+                expect(find('#user-facebook').closest('.form-group').hasClass('error'), 'facebook input should be in error state').to.be.false;
 
                 await fillIn('#user-facebook', '');
                 await fillIn('#user-facebook', 'http://twitter.com/testuser');


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8296
- permit Facebook usernames with less than 5 chars
    - brands are allowed to have Page names with less than 5 chars (ex: facebook.com/nike)
    - current/former employees are allowed to have usernames with less than 5 chars (ex: facebook.com/zuck)
