### PR TITLE
🐛 fix long text overflowing signin button on setup screen

### DIFF
--- a/app/styles/patterns/buttons.css
+++ b/app/styles/patterns/buttons.css
@@ -21,6 +21,7 @@
 /* ALL buttons must have a span for content */
 .gh-btn span {
     display: block;
+    overflow: hidden;
     padding: 0 12px;
     height: 33px;
     font-size: 1.3rem;
@@ -29,6 +30,8 @@
     text-align: center;
     letter-spacing: 0.2px;
     border-radius: 4px;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 }
 
 .gh-btn:hover {


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8029
- quick fix - works for the setup button but won't work for buttons that include spinners because the `display: flex` breaks the `text-overflow: ellipsis` style, this should be fine as I'm not aware of any other buttons where the text is user-defined

<img width="429" alt="screen shot 2017-04-11 at 11 44 28" src="https://cloud.githubusercontent.com/assets/415/24905735/d6a03158-1eac-11e7-88de-bb055fca2e12.png">
