### PR TITLE
🐛  Use correct blog icon URL with subdirectory

### DIFF
--- a/app/components/gh-nav-menu.js
+++ b/app/components/gh-nav-menu.js
@@ -11,9 +11,15 @@ export default Component.extend({
 
     open: false,
 
-    navMenuIcon: computed('config.blogUrl', 'settings.icon', function () {
+    navMenuIcon: computed('config.blogUrl', 'settings.icon', 'ghostPaths.subdir', 'ghostPaths.url', function () {
+        let subdirRegExp = new RegExp(`^${this.get('ghostPaths.subdir')}`);
         let blogIcon = this.get('settings.icon') ? this.get('settings.icon') : 'favicon.ico';
-        let url = `${this.get('config.blogUrl')}/${blogIcon}`;
+        let url;
+
+        blogIcon = blogIcon.replace(subdirRegExp, '');
+
+        url = this.get('ghostPaths.url').join(this.get('config.blogUrl'), blogIcon).replace(/\/$/, '');
+        url += `?t=${(new Date()).valueOf()}`;
 
         return htmlSafe(`background-image: url(${url})`);
     }),


### PR DESCRIPTION
refs TryGhost/Ghost#7688

Fixes a bug in subdirectory setup where the blog icon URL would be concatenated with a double subdirectory in the URL.
Uses `RegExp` to strip it from `settings.icon` and concat it without trailing slash.