### PR TITLE
🐜  🎊  Fix firefox drag and drop support in markdown cards.

### DIFF
--- a/lib/gh-koenig/addon/components/gh-koenig.js
+++ b/lib/gh-koenig/addon/components/gh-koenig.js
@@ -152,17 +152,6 @@ export default Component.extend({
         };
     },
 
-    // drag and drop images onto the editor
-    drop(event) {
-        if (event.dataTransfer.files.length) {
-            event.preventDefault();
-            for (let i = 0; i < event.dataTransfer.files.length; i++) {
-                let file = [event.dataTransfer.files[i]];
-                this.editor.insertCard('card-image', {pos: 'top', file});
-            }
-        }
-    },
-
     // makes sure the cursor is on screen except when selection is happening in which case the browser mostly ensures it.
     // there is an issue with keyboard selection on some browsers though so the next step will be to record mouse and touch events.
     cursorMoved() {
@@ -385,6 +374,20 @@ export default Component.extend({
         },
         menuIsClosed() {
             this.sendAction('menuIsClosed');
+        },
+        // drag and drop images onto the editor
+        dropImage(event) {
+            if (event.dataTransfer.files.length) {
+                event.preventDefault();
+                for (let i = 0; i < event.dataTransfer.files.length; i++) {
+                    let file = [event.dataTransfer.files[i]];
+                    this.editor.insertCard('card-image', {pos: 'top', file});
+                }
+            }
+        },
+        dragOver(event) {
+            // required for drop events to fire on markdown cards in firefox.
+            event.preventDefault();
         }
     }
 

--- a/lib/gh-koenig/addon/templates/components/gh-koenig.hbs
+++ b/lib/gh-koenig/addon/templates/components/gh-koenig.hbs
@@ -16,7 +16,7 @@
     {{/ember-wormhole}}
 {{/each}}
 <div class='gh-koenig'>
-    <div class='surface needsclick' tabindex="{{tabindex}}"/>
+    <div class='surface needsclick' tabindex="{{tabindex}}" ondrop={{action "dropImage"}} ondragover={{action "dragOver"}} />
 </div>
 
 {{yield}}


### PR DESCRIPTION
Closes: https://github.com/TryGhost/Ghost/issues/8315

Previously you couldn't upload images in markdown cards in firefox. Moving the drop action off of the component and onto the root editor as well as having an dragover handler which does nothing fixed the issue 🤷
