### PR TITLE
🗑  Get the trash icon back in card

### DIFF
--- a/app/styles/addons/gh-koenig/gh-koenig.css
+++ b/app/styles/addons/gh-koenig/gh-koenig.css
@@ -163,13 +163,13 @@
     border-radius:5px;
 }
 .kg-card .kg-card-toolbar button.kg-card-delete {
-    text-transform: none !important;
-    /*font-family: "ghosticons" !important;*/
-    font-size: 1rem;
     line-height: 1;
-    font-weight: normal !important;
-    font-style: normal !important;
-    font-variant: normal !important;
+}
+
+.kg-card .kg-card-toolbar button.kg-card-delete svg {
+    height: 1.4rem;
+    width: auto;
+    fill: color(var(--lightgrey) l(-10%));
 }
 
 .kg-card textarea {

--- a/lib/gh-koenig/addon/templates/components/koenig-card.hbs
+++ b/lib/gh-koenig/addon/templates/components/koenig-card.hbs
@@ -20,7 +20,7 @@
                         Cancel
             </button>--}}
             <button {{action "stopEdit"}} class='kg-card-button kg-card-button-save'>
-                Done            
+                Done
             </button>
         {{else}}
             {{#if card.card.buttons.edit}}
@@ -28,7 +28,7 @@
                         Edit
                 </button>
             {{/if}}
-            <button class='kg-card-button kg-card-delete' {{action "delete"}}></button>
+            <button class='kg-card-button kg-card-delete' {{action "delete"}}>{{inline-svg "trash"}}</button>
         {{/if}}
     </div>
 </div>


### PR DESCRIPTION
closes TryGhost/Ghost#8340

Use `{{inline-svg}}` helper instead of icon font

![image](https://cloud.githubusercontent.com/assets/8037602/25087725/37c2e2d0-239b-11e7-8265-a6fa2fb869dd.png)