### PR TITLE
don't auto-save posts if there are no changes

### DIFF
--- a/app/mixins/editor-base-controller.js
+++ b/app/mixins/editor-base-controller.js
@@ -391,6 +391,15 @@ export default Mixin.create({
             let promise, status;
 
             options = options || {};
+
+            // don't auto-save save if nothing has changed, this prevents
+            // unnecessary collision errors when reading a post that another
+            // user is editing
+            if (options.backgroundSave && !this.get('hasDirtyAttributes')) {
+                this.send('cancelTimers');
+                return;
+            }
+
             this.toggleProperty('submitting');
             if (options.backgroundSave) {
                 // do not allow a post's status to be set to published by a background save

--- a/tests/acceptance/editor-test.js
+++ b/tests/acceptance/editor-test.js
@@ -343,12 +343,11 @@ describe('Acceptance: Editor', function() {
             let saveCount = 0;
 
             server.put('/posts/:id/', function (db, request) {
-                // we have three saves occurring here :-(
-                // 1. Auto-save of draft
-                // 2. Change of publish time
-                // 3. Pressing the Schedule button
+                // we have two saves occurring here :-(
+                // 1. Change of publish time
+                // 2. Pressing the Schedule button
                 saveCount++;
-                if (saveCount === 3) {
+                if (saveCount === 2) {
                     return new Mirage.Response(422, {}, {
                         errors: [{
                             errorType: 'ValidationError',


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/8331, https://github.com/TryGhost/Ghost/pull/8328
- prevents auto-save save if nothing has changed, this avoides unnecessary collision errors when reading a post that another user is editing