### PR TITLE
add "delete post" button to the PSM

### DIFF
--- a/app/components/gh-post-settings-menu.js
+++ b/app/components/gh-post-settings-menu.js
@@ -388,6 +388,12 @@ export default Component.extend(SettingsMenuMixin, {
             if (tag.get('isNew')) {
                 tag.destroyRecord();
             }
+        },
+
+        deletePost() {
+            if (this.get('deletePost')) {
+                this.get('deletePost')();
+            }
         }
     }
 });

--- a/app/controllers/editor/edit.js
+++ b/app/controllers/editor/edit.js
@@ -1,12 +1,4 @@
 import Controller from 'ember-controller';
 import EditorControllerMixin from 'ghost-admin/mixins/editor-base-controller';
 
-export default Controller.extend(EditorControllerMixin, {
-    showDeletePostModal: false,
-
-    actions: {
-        toggleDeletePostModal() {
-            this.toggleProperty('showDeletePostModal');
-        }
-    }
-});
+export default Controller.extend(EditorControllerMixin);

--- a/app/mixins/editor-base-controller.js
+++ b/app/mixins/editor-base-controller.js
@@ -35,6 +35,7 @@ export default Mixin.create({
 
     showLeaveEditorModal: false,
     showReAuthenticateModal: false,
+    showDeletePostModal: false,
 
     application: injectController(),
     notifications: injectService(),
@@ -539,8 +540,8 @@ export default Mixin.create({
         },
 
         updateTitle() {
-            let currentTitle = this.model.get('title');
-            let newTitle = this.model.get('titleScratch').trim();
+            let currentTitle = this.get('model.title');
+            let newTitle = this.get('model.titleScratch').trim();
 
             if (currentTitle === newTitle) {
                 return;
@@ -554,6 +555,12 @@ export default Mixin.create({
                     silent: true,
                     backgroundSave: true
                 });
+            }
+        },
+
+        toggleDeletePostModal() {
+            if (!this.get('model.isNew')) {
+                this.toggleProperty('showDeletePostModal');
             }
         },
 

--- a/app/templates/components/gh-post-settings-menu.hbs
+++ b/app/templates/components/gh-post-settings-menu.hbs
@@ -113,6 +113,10 @@
                 </label>
             </div>
 
+            {{#unless model.isNew}}
+                <button type="button" class="gh-btn gh-btn-link gh-btn-sm gh-btn-icon tag-delete-button" {{action "deletePost"}}><span>{{inline-svg "trash"}} Delete Post</span></button>
+            {{/unless}}
+
             </form>
         </div>{{! .settings-menu-content }}
     </div>{{! .post-settings-menu }}

--- a/app/templates/editor/edit.hbs
+++ b/app/templates/editor/edit.hbs
@@ -82,5 +82,6 @@
         showSettingsMenu=application.showSettingsMenu
         closeNavMenu=(action "closeNavMenu")
         closeMenus=(action "closeMenus")
+        deletePost=(action "toggleDeletePostModal")
     }}
 {{/liquid-wormhole}}


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8332
- moves `toggleDeletePostModal` action from the `edit` controller to the `editor-base-controller` mixin
- adds delete button to the bottom of the PSM unless it's a new post
- adds `deletePost` attribute to `gh-post-settings-menu` to allow a delete post action to be passed in

_Note:_ this PR adds the necessary functionality but the styling for settings menu delete buttons is currently broken (https://github.com/TryGhost/Ghost/issues/8345) and will be fixed in a separate PR