### PR TITLE
🎨 fix settings menu delete button styles 

### DIFF
--- a/app/styles/components/settings-menu.css
+++ b/app/styles/components/settings-menu.css
@@ -134,36 +134,6 @@
     height: 108px;
 }
 
-.settings-menu-content .tag-delete-button {
-    padding-left: 0;
-    color: var(--red);
-}
-
-.settings-menu-content .tag-delete-button span {
-    flex-direction: column;
-    justify-content: space-between;
-}
-
-.settings-menu-content .tag-delete-button svg {
-    fill: var(--red);
-    height: 13px;
-    width: auto;
-    margin-bottom: 12px;
-    flex: 1 0 13px;
-}
-
-.settings-menu-content .tag-delete-button svg path {
-    stroke: var(--red);
-}
-
-.settings-menu-content .tag-delete-button:hover,
-.settings-menu-content .tag-delete-button svg:hover,
-.settings-menu-content .tag-delete-button svg path:hover {
-    color: color(var(--red) lightness(-10%));
-    fill: color(var(--red) lightness(-10%));
-    stroke: color(var(--red) lightness(-10%));
-}
-
 .settings-menu-content .nav-list {
     margin-top: 3rem;
 }
@@ -178,6 +148,35 @@
     width: 98%;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+
+.settings-menu-delete-button {
+    padding-left: 0;
+    color: var(--red);
+    font-size: 1rem;
+    text-transform: uppercase;
+}
+
+.settings-menu-delete-button span {
+    padding: 0;
+    font-size: inherit;
+}
+
+.settings-menu-delete-button svg {
+    margin-bottom: 1px;
+}
+
+.settings-menu-delete-button svg path {
+    fill: var(--red);
+    stroke: var(--red);
+    stroke-width: 1px;
+}
+
+.settings-menu-delete-button:hover,
+.settings-menu-delete-button:hover svg path {
+    color: color(var(--red) lightness(-10%));
+    fill: color(var(--red) lightness(-10%));
+    stroke: color(var(--red) lightness(-10%));
 }
 
 

--- a/app/templates/components/gh-post-settings-menu.hbs
+++ b/app/templates/components/gh-post-settings-menu.hbs
@@ -114,7 +114,7 @@
             </div>
 
             {{#unless model.isNew}}
-                <button type="button" class="gh-btn gh-btn-link gh-btn-sm gh-btn-icon tag-delete-button" {{action "deletePost"}}><span>{{inline-svg "trash"}} Delete Post</span></button>
+                <button type="button" class="gh-btn gh-btn-link gh-btn-sm gh-btn-icon settings-menu-delete-button" {{action "deletePost"}}><span>{{inline-svg "trash"}} Delete Post</span></button>
             {{/unless}}
 
             </form>

--- a/app/templates/components/gh-tag-settings-form.hbs
+++ b/app/templates/components/gh-tag-settings-form.hbs
@@ -46,7 +46,7 @@
             </ul>
 
             {{#unless tag.isNew}}
-                <button type="button" class="gh-btn gh-btn-link gh-btn-sm gh-btn-icon tag-delete-button" {{action "deleteTag"}}><span>{{inline-svg "trash"}} Delete Tag</span></button>
+                <button type="button" class="gh-btn gh-btn-link gh-btn-sm gh-btn-icon settings-menu-delete-button" {{action "deleteTag"}}><span>{{inline-svg "trash"}} Delete Tag</span></button>
             {{/unless}}
         </form>
     </div>

--- a/tests/acceptance/settings/tags-test.js
+++ b/tests/acceptance/settings/tags-test.js
@@ -213,7 +213,7 @@ describe('Acceptance: Settings - Tags', function () {
             });
 
             // delete tag
-            click('.tag-delete-button');
+            click('.settings-menu-delete-button');
             click('.fullscreen-modal .gh-btn-red');
 
             andThen(() => {

--- a/tests/integration/components/gh-tag-settings-form-test.js
+++ b/tests/integration/components/gh-tag-settings-form-test.js
@@ -306,7 +306,7 @@ describe('Integration: Component: gh-tag-settings-form', function () {
         `);
 
         run(() => {
-            this.$('.tag-delete-button').click();
+            this.$('.settings-menu-delete-button').click();
         });
     });
 


### PR DESCRIPTION
closes TryGhost/Ghost#8345
- renames `.tag-delete-button` to `.settings-menu-delete-button` to match it's more generic purpose
- match styles as close to 0.11.x as possible, it was necessary to add both stroke and fill to the trashcan SVG for it not to be washed out

<img width="353" alt="screen shot 2017-04-18 at 11 20 37" src="https://cloud.githubusercontent.com/assets/415/25126327/cf08a6be-2429-11e7-8978-296586608360.png">
<img width="352" alt="screen shot 2017-04-18 at 11 21 07" src="https://cloud.githubusercontent.com/assets/415/25126328/cf260970-2429-11e7-8b1f-1823be734824.png">

0.11.x style for reference:
<img width="319" alt="screen shot 2017-04-17 at 18 17 44" src="https://cloud.githubusercontent.com/assets/415/25126344/e6a83c4e-2429-11e7-83d3-81594938be5d.png">
