### PR TITLE
match 0.11.x's auto-save behaviour

### DIFF
--- a/app/components/gh-publishmenu.js
+++ b/app/components/gh-publishmenu.js
@@ -92,7 +92,9 @@ export default Component.extend({
         open() {
             this._cachePublishedAtBlogTZ();
             this.get('post.errors').clear();
-            this.get('onOpen')();
+            if (this.get('onOpen')) {
+                this.get('onOpen')();
+            }
         },
 
         close(dropdown, e) {
@@ -108,7 +110,9 @@ export default Component.extend({
             post.set('statusScratch', null);
             post.validate();
 
-            this.get('onClose')();
+            if (this.get('onClose')) {
+                this.get('onClose')();
+            }
             return true;
         }
     }

--- a/app/mixins/editor-base-controller.js
+++ b/app/mixins/editor-base-controller.js
@@ -71,7 +71,7 @@ export default Mixin.create({
         }
     }).restartable(),
 
-    // save every 60 seconds so we still save even if the user doesn't stop typing
+    // save at 60 seconds even if the user doesn't stop typing
     _timedSave: task(function* () {
         // eslint-disable-next-line no-constant-condition
         while (!testing && true) {
@@ -81,7 +81,7 @@ export default Mixin.create({
                 yield this.get('autosave').perform();
             }
         }
-    }).drop().on('init'),
+    }).drop(),
 
     // separate task for autosave so that it doesn't override a manual save
     autosave: task(function* () {
@@ -93,15 +93,11 @@ export default Mixin.create({
         }
     }).drop(),
 
-    // save tasks cancels autosave before running, although the _xSave tasks
-    // are the ones being cancelled that will also cancel the autosave task
+    // save tasks cancels autosave before running, although this cancels the
+    // _xSave tasks  that will also cancel the autosave task
     save: task(function* (options) {
-        try {
-            this.send('cancelAutosave');
-            return yield this._savePromise(options);
-        } finally {
-            this.send('restartAutosave');
-        }
+        this.send('cancelAutosave');
+        return yield this._savePromise(options);
     }),
 
     // TODO: convert this into a more ember-concurrency flavour
@@ -111,6 +107,10 @@ export default Mixin.create({
         let promise, status;
 
         options = options || {};
+
+        if (options.backgroundSave && !this.get('hasDirtyAttributes')) {
+            return RSVP.resolve();
+        }
 
         if (options.backgroundSave) {
             // do not allow a post's status to be set to published by a background save
@@ -461,10 +461,9 @@ export default Mixin.create({
     actions: {
         updateScratch(value) {
             this.set('model.scratch', value);
+            // save 3 seconds after last edit
             this.get('_autosave').perform();
-        },
-
-        restartAutosave() {
+            // force save at 60 seconds
             this.get('_timedSave').perform();
         },
 

--- a/app/templates/editor/edit.hbs
+++ b/app/templates/editor/edit.hbs
@@ -17,8 +17,7 @@
                 post=model
                 saveTask=save
                 setSaveType=(action "setSaveType")
-                onOpen=(action "cancelAutosave")
-                onClose=(action "restartAutosave")}}
+                onOpen=(action "cancelAutosave")}}
 
             <button type="button" class="post-settings" title="Settings" {{action "openSettingsMenu"}} data-test-psm-trigger>
                 {{inline-svg "settings"}}


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/8331
- rather than always saving every 60 seconds, the 60 seconds timer is a fallback for when the user has made changes to the post content for 60 seconds without triggering the 3 second debounced timer
- don't perform a save if there have been no changes to the post - this should prevent unnecessary collision errors when multiple people are viewing a post
- adds guards to `gh-publishmenu` so that we don't try to call actions that weren't passed in