### PR TITLE
🎨 responsive editor header

### DIFF
--- a/app/components/gh-editor.js
+++ b/app/components/gh-editor.js
@@ -1,0 +1,56 @@
+import Component from 'ember-component';
+import run from 'ember-runloop';
+
+const {debounce} = run;
+
+export default Component.extend({
+
+    headerClass: '',
+
+    _navIsClosed: false,
+    _viewActionsWidth: 190,
+
+    init() {
+        this._super(...arguments);
+        this._onResizeHandler = (evt) => {
+            debounce(this, this._setHeaderClass, evt, 100);
+        };
+    },
+
+    didInsertElement() {
+        this._super(...arguments);
+        window.addEventListener('resize', this._onResizeHandler);
+        this._setHeaderClass();
+    },
+
+    didReceiveAttrs() {
+        let navIsClosed = this.get('navIsClosed');
+
+        if (navIsClosed !== this._navIsClosed) {
+            run.scheduleOnce('afterRender', this, this._setHeaderClass);
+        }
+
+        this._navIsClosed = navIsClosed;
+    },
+
+    willDestroyElement() {
+        this._super(...arguments);
+        window.removeEventListener('resize', this._onResizeHandler);
+    },
+
+    _setHeaderClass() {
+        let $editorInner = this.$('.gh-editor-inner');
+
+        if ($editorInner.length > 0) {
+            let boundingRect = $editorInner[0].getBoundingClientRect();
+            let maxRight = window.innerWidth - this._viewActionsWidth;
+
+            if (boundingRect.right >= maxRight) {
+                this.set('headerClass', 'gh-editor-header-small');
+                return;
+            }
+        }
+
+        this.set('headerClass', '');
+    }
+});

--- a/app/mixins/editor-base-controller.js
+++ b/app/mixins/editor-base-controller.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import Mixin from 'ember-metal/mixin';
 import RSVP from 'rsvp';
-import computed, {alias, mapBy} from 'ember-computed';
+import computed, {alias, mapBy, reads} from 'ember-computed';
 import injectService from 'ember-service/inject';
 import injectController from 'ember-controller/inject';
 import {htmlSafe} from 'ember-string';
@@ -48,15 +48,18 @@ export default Mixin.create({
     assetPath: ghostPaths().assetRoot,
     editor: null,
     editorMenuIsOpen: false,
+
+    shouldFocusTitle: alias('model.isNew'),
+    shouldFocusEditor: false,
+
+    navIsClosed: reads('application.autoNav'),
+
     init() {
         this._super(...arguments);
         window.onbeforeunload = () => {
             return this.get('hasDirtyAttributes') ? this.unloadDirtyMessage() : null;
         };
     },
-
-    shouldFocusTitle: alias('model.isNew'),
-    shouldFocusEditor: false,
 
     _canAutosave: computed('model.{isDraft,isNew}', function () {
         return !testing && this.get('model.isDraft') && !this.get('model.isNew');
@@ -564,9 +567,11 @@ export default Mixin.create({
         setEditor(editor) {
             this.set('editor', editor);
         },
+
         editorMenuIsOpen() {
             this.set('editorMenuIsOpen', true);
         },
+
         editorMenuIsClosed() {
             this.set('editorMenuIsOpen', false);
         }

--- a/app/styles/layouts/editor.css
+++ b/app/styles/layouts/editor.css
@@ -123,6 +123,7 @@
     padding: 15px;
     color: var(--midgrey);
     transition: all 0.15s ease-out 0s;
+    line-height: 0;
 }
 
 .post-settings:hover,
@@ -206,7 +207,7 @@
     top: 0;
     right: 0;
     left: 0;
-    z-index: 100;
+    z-index: 0;
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -234,4 +235,22 @@
     margin: 0 auto;
     max-width: 740px;
     height: 100%;
+}
+
+.gh-editor-header-small {
+    height: 43px;
+    padding: 0;
+    padding-left: 15px;
+    background: #fff;
+    border-bottom: 1px solid color(var(--lightgrey) l(+4%));
+    z-index: 100;
+}
+
+.gh-editor-header-small .gh-publishmenu {
+    line-height: 0;
+}
+
+
+.gh-editor-header-small .post-settings {
+    padding: 13px 15px;
 }

--- a/app/templates/components/gh-editor.hbs
+++ b/app/templates/components/gh-editor.hbs
@@ -1,0 +1,1 @@
+{{yield headerClass}}

--- a/app/templates/editor/edit.hbs
+++ b/app/templates/editor/edit.hbs
@@ -1,6 +1,5 @@
-<section class="gh-view">
-
-    <header class="gh-editor-header">
+{{#gh-editor tagName="section" class="gh-view" navIsClosed=navIsClosed as |headerClass|}}
+    <header class="gh-editor-header {{headerClass}}">
         <div class="gh-editor-status">
             {{gh-editor-post-status
                 post=model
@@ -25,6 +24,7 @@
             </button>
         </section>
     </header>
+
     <div class="gh-editor-container needsclick">
         <div class="gh-editor-inner">
             {{gh-editor-title
@@ -54,7 +54,7 @@
             }}
         </div>
     </div>
-</section>
+{{/gh-editor}}
 
 {{#if showDeletePostModal}}
     {{gh-fullscreen-modal "delete-post"


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8271
- adds `gh-editor` wrapper component that checks the editor position and will apply a `.gh-editor-header-small` class if the editor content will overlap the view actions
- adds `.gh-editor-header-small` class that minifies the header and applies a solid background so that there's no conflict between editor content and header elements
- modifies `.gh-editor-header` z-index so that there's no hidden non-selectable area at the top of the screen

![responsive-editor-header](https://cloud.githubusercontent.com/assets/415/25144365/62f54856-2465-11e7-96f1-65152c313492.gif)
