### PR TITLE
🎨  Don't scroll to top after toggle checkbox

### DIFF
--- a/app/styles/patterns/forms.css
+++ b/app/styles/patterns/forms.css
@@ -192,7 +192,7 @@ textarea {
     top: 0;
     right: 0;
     bottom: 0;
-    left: -9999px;
+    display:none;
 }
 
 .for-radio .input-toggle-component,


### PR DESCRIPTION
closes TryGhost/Ghost#8335

Use `display: none` instead of positioning it out of the viewport.
