### PR TITLE
🐛 clear date error when closing the PSM 

### DIFF
--- a/app/components/gh-post-settings-menu.js
+++ b/app/components/gh-post-settings-menu.js
@@ -24,9 +24,12 @@ export default Component.extend(SettingsMenuMixin, {
     session: injectService(),
     settings: injectService(),
 
+    model: null,
     slugValue: boundOneWay('model.slug'),
     metaTitleScratch: alias('model.metaTitleScratch'),
     metaDescriptionScratch: alias('model.metaDescriptionScratch'),
+
+    _showSettingsMenu: false,
 
     didReceiveAttrs() {
         this._super(...arguments);
@@ -38,6 +41,19 @@ export default Component.extend(SettingsMenuMixin, {
         this.get('model.author').then((author) => {
             this.set('selectedAuthor', author);
         });
+
+        // reset the publish date on close if it has an error
+        if (!this.get('showSettingsMenu') && this._showSettingsMenu) {
+            let post = this.get('model');
+            let errors = post.get('errors');
+
+            if (errors.has('publishedAtBlogDate') || errors.has('publishedAtBlogTime')) {
+                post.set('publishedAtBlogTZ', post.get('publishedAtUTC'));
+                post.validate({attribute: 'publishedAtBlog'});
+            }
+        }
+
+        this._showSettingsMenu = this.get('showSettingsMenu');
     },
 
     seoTitle: computed('model.titleScratch', 'metaTitleScratch', function () {

--- a/app/templates/components/gh-post-settings-menu.hbs
+++ b/app/templates/components/gh-post-settings-menu.hbs
@@ -3,7 +3,9 @@
     <div class="{{if isViewingSubview 'settings-menu-pane-out-left' 'settings-menu-pane-in'}} settings-menu settings-menu-pane">
         <div class="settings-menu-header">
             <h4>Post Settings</h4>
-            <button class="close settings-menu-header-action" {{action "closeMenus"}}>{{inline-svg "close"}}<span class="hidden">Close</span></button>
+            <button class="close settings-menu-header-action" {{action "closeMenus"}} data-test-close-settings-menu>
+                {{inline-svg "close"}}<span class="hidden">Close</span>
+            </button>
         </div>
         <div class="settings-menu-content">
             {{gh-image-uploader-with-preview


### PR DESCRIPTION
closes TryGhost/Ghost#8359
- if the date/time picker is in an error state when the PSM is closed, reset it to the currently saved time
- resolves the problem with the flash of an error as the publish menu is closed as it's no longer possible to be in a hidden error state