### PR TITLE
🐛 fix password change button not showing success state

### DIFF
--- a/app/components/gh-task-button.js
+++ b/app/components/gh-task-button.js
@@ -18,13 +18,21 @@ import {task, timeout} from 'ember-concurrency';
  */
 const GhTaskButton = Component.extend({
     tagName: 'button',
-    classNameBindings: ['isRunning:appear-disabled', 'isSuccessClass', 'isFailureClass'],
+    classNameBindings: [
+        'isRunning:appear-disabled',
+        'isIdleClass',
+        'isRunningClass',
+        'isSuccessClass',
+        'isFailureClass'
+    ],
     attributeBindings: ['disabled', 'type', 'tabindex'],
 
     task: null,
     disabled: false,
     buttonText: 'Save',
     runningText: reads('buttonText'),
+    idleClass: '',
+    runningClass: '',
     successText: 'Saved',
     successClass: 'gh-btn-green',
     failureText: 'Retry',
@@ -34,6 +42,18 @@ const GhTaskButton = Component.extend({
     // state of the associated task
     hasRun: false,
     isRunning: reads('task.last.isRunning'),
+
+    isIdleClass: computed('isIdle', function () {
+        if (this.get('isIdle')) {
+            return this.get('idleClass');
+        }
+    }),
+
+    isRunningClass: computed('isRunning', function () {
+        if (this.get('isRunning')) {
+            return this.get('runningClass') || this.get('idleClass');
+        }
+    }),
 
     isSuccess: computed('hasRun', 'isRunning', 'task.last.value', function () {
         if (!this.get('hasRun') || this.get('isRunning')) {

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -109,6 +109,8 @@ export default Model.extend(ValidationEngine, {
             // engine only clears the "validated proeprty"
             // TODO: clean up once we have a better validations library
             this.get('errors').remove('ne2Password');
+
+            return true;
         } catch (error) {
             this.get('notifications').showAPIError(error, {key: 'user.change-password'});
         }

--- a/app/templates/team/user.hbs
+++ b/app/templates/team/user.hbs
@@ -235,7 +235,10 @@
                     {{/gh-form-group}}
 
                     <div class="form-group">
-                        {{gh-task-button "Change Password" class="gh-btn gh-btn-red gh-btn-icon button-change-password" task=user.saveNewPassword}}
+                        {{gh-task-button "Change Password"
+                            class="gh-btn gh-btn-icon button-change-password"
+                            idleClass="gh-btn-red"
+                            task=user.saveNewPassword}}
                     </div>
                 </fieldset>
             </form> {{! change password form }}


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8358
- the change password task was not returning a truthy value on success so you always saw the "X Retry" state
- adds option to pass `idleClass` and `runningClass` to `gh-task-button` - this is so that colour classes can be set in the "base" state without overriding the success/failure colors (some colours would have preference based on the order the colours are defined in the CSS file, eg. setting `gh-btn-red` as a base CSS class would override the `gh-btn-green` that is added after a successful save)