### PR TITLE
Places no-content placeholder in the correct position in firefox.

### DIFF
--- a/app/styles/layouts/editor.css
+++ b/app/styles/layouts/editor.css
@@ -17,6 +17,7 @@
     font-weight: bold;
     font-size: 3.2rem;
     line-height: 1.3em;
+    min-height: 1.3em;
     z-index: 1;
 }
 
@@ -25,7 +26,7 @@
     content: attr(data-placeholder);
     color: color(var(--midgrey) l(+35%));
     cursor: text;
-    position: absolute;
+    position: relative;
     top: 0;
     font-size: 3.2rem;
     font-weight: bold;

--- a/app/templates/components/gh-editor-title.hbs
+++ b/app/templates/components/gh-editor-title.hbs
@@ -1,1 +1,1 @@
-<div contenteditable="true" data-placeholder="Your Post Title" class="gh-editor-title needsclick" tabindex={{tabindex}}></div>
+<div contenteditable="true" data-placeholder="Your Post Title" class="gh-editor-title" tabindex={{tabindex}}></div>


### PR DESCRIPTION
Closes: https://github.com/TryGhost/Ghost/issues/8322

Previously in firefox the `no-content` psuedo element was placed below the actual on first load (but not subsequent reloads), this update positions it in the correct place in both scenarios.

![posttitle](https://cloud.githubusercontent.com/assets/73181/25216926/f94533d6-25f8-11e7-9248-5e2aecd88f52.gif)
