### PR TITLE
🐛 fix non-clickable editor header actions with wide screens

### DIFF
--- a/app/styles/layouts/editor.css
+++ b/app/styles/layouts/editor.css
@@ -125,6 +125,7 @@
     color: var(--midgrey);
     transition: all 0.15s ease-out 0s;
     line-height: 0;
+    z-index: 1000;
 }
 
 .post-settings:hover,
@@ -208,7 +209,6 @@
     top: 0;
     right: 0;
     left: 0;
-    z-index: 0;
     display: flex;
     justify-content: space-between;
     align-items: center;


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8366
- ensure that header actions are layered above the editor so that they are still clickable
- editor content is still selectable in the header area