### PR TITLE
💄 refactor acceptance tests to use async/await

### DIFF
--- a/tests/acceptance/content-test.js
+++ b/tests/acceptance/content-test.js
@@ -19,13 +19,11 @@ describe('Acceptance: Content', function() {
         destroyApp(application);
     });
 
-    it('redirects to signin when not authenticated', function () {
+    it('redirects to signin when not authenticated', async function () {
         invalidateSession(application);
-        visit('/');
+        await visit('/');
 
-        andThen(function () {
-            expect(currentURL()).to.equal('/signin');
-        });
+        expect(currentURL()).to.equal('/signin');
     });
 
     describe('as admin', function () {
@@ -47,87 +45,73 @@ describe('Acceptance: Content', function() {
             return authenticateSession(application);
         });
 
-        it('displays and filters posts', function () {
-            visit('/');
+        it('displays and filters posts', async function () {
+            await visit('/');
 
-            andThen(() => {
-                // Not checking request here as it won't be the last request made
-                // Displays all posts + pages
-                expect(find(testSelector('post-id')).length, 'all posts count').to.equal(5);
-            });
+            // Not checking request here as it won't be the last request made
+            // Displays all posts + pages
+            expect(find(testSelector('post-id')).length, 'all posts count').to.equal(5);
 
-            selectChoose(testSelector('type-select'), 'Draft posts');
+            await selectChoose(testSelector('type-select'), 'Draft posts');
 
-            andThen(() => {
-                // API request is correct
-                let [lastRequest] = server.pretender.handledRequests.slice(-1);
-                expect(lastRequest.queryParams.status, '"drafts" request status param').to.equal('draft');
-                expect(lastRequest.queryParams.staticPages, '"drafts" request staticPages param').to.equal('false');
-                // Displays draft post
-                expect(find(testSelector('post-id')).length, 'drafts count').to.equal(1);
-                expect(find(testSelector('post-id', draftPost.id)), 'draft post').to.exist;
-            });
+            // API request is correct
+            let [lastRequest] = server.pretender.handledRequests.slice(-1);
+            expect(lastRequest.queryParams.status, '"drafts" request status param').to.equal('draft');
+            expect(lastRequest.queryParams.staticPages, '"drafts" request staticPages param').to.equal('false');
+            // Displays draft post
+            expect(find(testSelector('post-id')).length, 'drafts count').to.equal(1);
+            expect(find(testSelector('post-id', draftPost.id)), 'draft post').to.exist;
 
-            selectChoose(testSelector('type-select'), 'Published posts');
+            await selectChoose(testSelector('type-select'), 'Published posts');
 
-            andThen(() => {
-                // API request is correct
-                let [lastRequest] = server.pretender.handledRequests.slice(-1);
-                expect(lastRequest.queryParams.status, '"published" request status param').to.equal('published');
-                expect(lastRequest.queryParams.staticPages, '"published" request staticPages param').to.equal('false');
-                // Displays three published posts + pages
-                expect(find(testSelector('post-id')).length, 'published count').to.equal(2);
-                expect(find(testSelector('post-id', publishedPost.id)), 'admin published post').to.exist;
-                expect(find(testSelector('post-id', authorPost.id)), 'author published post').to.exist;
-            });
+            // API request is correct
+            [lastRequest] = server.pretender.handledRequests.slice(-1);
+            expect(lastRequest.queryParams.status, '"published" request status param').to.equal('published');
+            expect(lastRequest.queryParams.staticPages, '"published" request staticPages param').to.equal('false');
+            // Displays three published posts + pages
+            expect(find(testSelector('post-id')).length, 'published count').to.equal(2);
+            expect(find(testSelector('post-id', publishedPost.id)), 'admin published post').to.exist;
+            expect(find(testSelector('post-id', authorPost.id)), 'author published post').to.exist;
 
-            selectChoose(testSelector('type-select'), 'Scheduled posts');
+            await selectChoose(testSelector('type-select'), 'Scheduled posts');
 
-            andThen(() => {
-                // API request is correct
-                let [lastRequest] = server.pretender.handledRequests.slice(-1);
-                expect(lastRequest.queryParams.status, '"scheduled" request status param').to.equal('scheduled');
-                expect(lastRequest.queryParams.staticPages, '"scheduled" request staticPages param').to.equal('false');
-                // Displays scheduled post
-                expect(find(testSelector('post-id')).length, 'scheduled count').to.equal(1);
-                expect(find(testSelector('post-id', scheduledPost.id)), 'scheduled post').to.exist;
-            });
+            // API request is correct
+            [lastRequest] = server.pretender.handledRequests.slice(-1);
+            expect(lastRequest.queryParams.status, '"scheduled" request status param').to.equal('scheduled');
+            expect(lastRequest.queryParams.staticPages, '"scheduled" request staticPages param').to.equal('false');
+            // Displays scheduled post
+            expect(find(testSelector('post-id')).length, 'scheduled count').to.equal(1);
+            expect(find(testSelector('post-id', scheduledPost.id)), 'scheduled post').to.exist;
 
-            selectChoose(testSelector('type-select'), 'Pages');
+            await selectChoose(testSelector('type-select'), 'Pages');
 
-            andThen(() => {
-                // API request is correct
-                let [lastRequest] = server.pretender.handledRequests.slice(-1);
-                expect(lastRequest.queryParams.status, '"pages" request status param').to.equal('all');
-                expect(lastRequest.queryParams.staticPages, '"pages" request staticPages param').to.equal('true');
-                // Displays page
-                expect(find(testSelector('post-id')).length, 'pages count').to.equal(1);
-                expect(find(testSelector('post-id', publishedPage.id)), 'page post').to.exist;
-            });
+            // API request is correct
+            [lastRequest] = server.pretender.handledRequests.slice(-1);
+            expect(lastRequest.queryParams.status, '"pages" request status param').to.equal('all');
+            expect(lastRequest.queryParams.staticPages, '"pages" request staticPages param').to.equal('true');
+            // Displays page
+            expect(find(testSelector('post-id')).length, 'pages count').to.equal(1);
+            expect(find(testSelector('post-id', publishedPage.id)), 'page post').to.exist;
 
-            selectChoose(testSelector('type-select'), 'All posts');
+            await selectChoose(testSelector('type-select'), 'All posts');
 
-            andThen(() => {
-                // API request is correct
-                let [lastRequest] = server.pretender.handledRequests.slice(-1);
-                expect(lastRequest.queryParams.status, '"all" request status param').to.equal('all');
-                expect(lastRequest.queryParams.staticPages, '"all" request staticPages param').to.equal('all');
-            });
+            // API request is correct
+            [lastRequest] = server.pretender.handledRequests.slice(-1);
+            expect(lastRequest.queryParams.status, '"all" request status param').to.equal('all');
+            expect(lastRequest.queryParams.staticPages, '"all" request staticPages param').to.equal('all');
 
-            selectChoose(testSelector('author-select'), editor.name);
+            await selectChoose(testSelector('author-select'), editor.name);
 
-            andThen(() => {
-                // API request is correct
-                let [lastRequest] = server.pretender.handledRequests.slice(-1);
-                expect(lastRequest.queryParams.status, '"all" request status param').to.equal('all');
-                expect(lastRequest.queryParams.staticPages, '"all" request staticPages param').to.equal('all');
-                expect(lastRequest.queryParams.filter, '"editor" request filter param')
-                    .to.equal(`author:${editor.slug}`);
-                // Displays editor post
-                // TODO: implement "filter" param support and fix mirage post->author association
-                // expect(find(testSelector('post-id')).length, 'editor post count').to.equal(1);
-                // expect(find(testSelector('post-id', authorPost.id)), 'author post').to.exist;
-            });
+            // API request is correct
+            [lastRequest] = server.pretender.handledRequests.slice(-1);
+            expect(lastRequest.queryParams.status, '"all" request status param').to.equal('all');
+            expect(lastRequest.queryParams.staticPages, '"all" request staticPages param').to.equal('all');
+            expect(lastRequest.queryParams.filter, '"editor" request filter param')
+                .to.equal(`author:${editor.slug}`);
+            // Displays editor post
+            // TODO: implement "filter" param support and fix mirage post->author association
+            // expect(find(testSelector('post-id')).length, 'editor post count').to.equal(1);
+            // expect(find(testSelector('post-id', authorPost.id)), 'author post').to.exist;
 
             // TODO: test tags dropdown
         });
@@ -149,20 +133,18 @@ describe('Acceptance: Content', function() {
             return authenticateSession(application);
         });
 
-        it('only fetches the author\'s posts', function () {
-            visit('/');
+        it('only fetches the author\'s posts', async function () {
+            await visit('/');
             // trigger a filter request so we can grab the posts API request easily
-            selectChoose(testSelector('type-select'), 'Published posts');
+            await selectChoose(testSelector('type-select'), 'Published posts');
 
-            andThen(() => {
-                // API request includes author filter
-                let [lastRequest] = server.pretender.handledRequests.slice(-1);
-                expect(lastRequest.queryParams.filter).to.equal(`author:${author.slug}`);
+            // API request includes author filter
+            let [lastRequest] = server.pretender.handledRequests.slice(-1);
+            expect(lastRequest.queryParams.filter).to.equal(`author:${author.slug}`);
 
-                // only author's post is shown
-                expect(find(testSelector('post-id')).length, 'post count').to.equal(1);
-                expect(find(testSelector('post-id', authorPost.id)), 'author post').to.exist;
-            });
+            // only author's post is shown
+            expect(find(testSelector('post-id')).length, 'post count').to.equal(1);
+            expect(find(testSelector('post-id', authorPost.id)), 'author post').to.exist;
         });
     });
 });

--- a/tests/acceptance/editor-test.js
+++ b/tests/acceptance/editor-test.js
@@ -237,11 +237,9 @@ describe('Acceptance: Editor', function() {
                 'scheduled status text'
             ).to.equal('Scheduled');
 
-            andThen(() => {
-                // expect countdown to show warning, that post will be published in x minutes
-                expect(find(testSelector('schedule-countdown')).text().trim(), 'notification countdown')
-                    .to.contain('Post will be published in');
-            });
+            // expect countdown to show warning, that post will be published in x minutes
+            expect(find(testSelector('schedule-countdown')).text().trim(), 'notification countdown')
+                .to.contain('Post will be published in');
 
             // unschedule
             await click(testSelector('publishmenu-trigger'));

--- a/tests/acceptance/ghost-desktop-test.js
+++ b/tests/acceptance/ghost-desktop-test.js
@@ -56,27 +56,23 @@ describe('Acceptance: Ghost Desktop', function() {
             restoreUserAgent();
         });
 
-        it('displays alert for broken version', function() {
+        it('displays alert for broken version', async function() {
             setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) ghost-desktop/0.4.0 Chrome/51.0.2704.84 Electron/1.2.2 Safari/537.36');
 
-            visit('/');
+            await visit('/');
 
-            andThen(function () {
-                // has an alert with matching text
-                expect(find('.gh-alert-yellow').length, 'number of warning alerts').to.equal(1);
-                expect(find('.gh-alert-yellow').text().trim(), 'alert text').to.match(/Your version of Ghost Desktop needs to be manually updated/);
-            });
+            // has an alert with matching text
+            expect(find('.gh-alert-yellow').length, 'number of warning alerts').to.equal(1);
+            expect(find('.gh-alert-yellow').text().trim(), 'alert text').to.match(/Your version of Ghost Desktop needs to be manually updated/);
         });
 
-        it('doesn\'t display alert for working version', function () {
+        it('doesn\'t display alert for working version', async function () {
             setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) ghost-desktop/0.5.1 Chrome/51.0.2704.84 Electron/1.2.2 Safari/537.36');
 
-            visit('/');
+            await visit('/');
 
-            andThen(function () {
-                // no alerts
-                expect(find('.gh-alert').length, 'number of alerts').to.equal(0);
-            });
+            // no alerts
+            expect(find('.gh-alert').length, 'number of alerts').to.equal(0);
         });
     });
 });

--- a/tests/acceptance/password-reset-test.js
+++ b/tests/acceptance/password-reset-test.js
@@ -21,85 +21,77 @@ describe('Acceptance: Password Reset', function() {
     });
 
     describe('request reset', function () {
-        it('is successful with valid data', function () {
-            visit('/signin');
-            fillIn('input[name="identification"]', 'test@example.com');
-            click('.forgotten-link');
+        it('is successful with valid data', async function () {
+            await visit('/signin');
+            await fillIn('input[name="identification"]', 'test@example.com');
+            await click('.forgotten-link');
 
-            andThen(function () {
-                // an alert with instructions is displayed
-                expect(find('.gh-alert-blue').length, 'alert count')
-                    .to.equal(1);
-            });
+            // an alert with instructions is displayed
+            expect(find('.gh-alert-blue').length, 'alert count')
+                .to.equal(1);
         });
 
-        it('shows error messages with invalid data', function () {
-            visit('/signin');
+        it('shows error messages with invalid data', async function () {
+            await visit('/signin');
 
             // no email provided
-            click('.forgotten-link');
+            await click('.forgotten-link');
 
-            andThen(function () {
-                // email field is invalid
-                expect(
-                    find('input[name="identification"]').closest('.form-group').hasClass('error'),
-                    'email field has error class (no email)'
-                ).to.be.true;
+            // email field is invalid
+            expect(
+                find('input[name="identification"]').closest('.form-group').hasClass('error'),
+                'email field has error class (no email)'
+            ).to.be.true;
 
-                // password field is valid
-                expect(
-                    find('input[name="password"]').closest('.form-group').hasClass('error'),
-                    'password field has error class (no email)'
-                ).to.be.false;
+            // password field is valid
+            expect(
+                find('input[name="password"]').closest('.form-group').hasClass('error'),
+                'password field has error class (no email)'
+            ).to.be.false;
 
-                // error message shown
-                expect(find('p.main-error').text().trim(), 'error message')
-                    .to.equal('We need your email address to reset your password!');
-            });
+            // error message shown
+            expect(find('p.main-error').text().trim(), 'error message')
+                .to.equal('We need your email address to reset your password!');
 
             // invalid email provided
-            fillIn('input[name="identification"]', 'test');
-            click('.forgotten-link');
+            await fillIn('input[name="identification"]', 'test');
+            await click('.forgotten-link');
 
-            andThen(function () {
-                // email field is invalid
-                expect(
-                    find('input[name="identification"]').closest('.form-group').hasClass('error'),
-                    'email field has error class (invalid email)'
-                ).to.be.true;
+            // email field is invalid
+            expect(
+                find('input[name="identification"]').closest('.form-group').hasClass('error'),
+                'email field has error class (invalid email)'
+            ).to.be.true;
 
-                // password field is valid
-                expect(
-                    find('input[name="password"]').closest('.form-group').hasClass('error'),
-                    'password field has error class (invalid email)'
-                ).to.be.false;
+            // password field is valid
+            expect(
+                find('input[name="password"]').closest('.form-group').hasClass('error'),
+                'password field has error class (invalid email)'
+            ).to.be.false;
 
-                // error message
-                expect(find('p.main-error').text().trim(), 'error message')
-                    .to.equal('We need your email address to reset your password!');
-            });
+            // error message
+            expect(find('p.main-error').text().trim(), 'error message')
+                .to.equal('We need your email address to reset your password!');
 
             // unknown email provided
-            fillIn('input[name="identification"]', 'unknown@example.com');
-            click('.forgotten-link');
+            await fillIn('input[name="identification"]', 'unknown@example.com');
+            await click('.forgotten-link');
 
-            andThen(function () {
-                // email field is invalid
-                expect(
-                    find('input[name="identification"]').closest('.form-group').hasClass('error'),
-                    'email field has error class (unknown email)'
-                ).to.be.true;
+            // email field is invalid
+            expect(
+                find('input[name="identification"]').closest('.form-group').hasClass('error'),
+                'email field has error class (unknown email)'
+            ).to.be.true;
 
-                // password field is valid
-                expect(
-                    find('input[name="password"]').closest('.form-group').hasClass('error'),
-                    'password field has error class (unknown email)'
-                ).to.be.false;
+            // password field is valid
+            expect(
+                find('input[name="password"]').closest('.form-group').hasClass('error'),
+                'password field has error class (unknown email)'
+            ).to.be.false;
 
-                // error message
-                expect(find('p.main-error').text().trim(), 'error message')
-                    .to.equal('There is no user with that email address.');
-            });
+            // error message
+            expect(find('p.main-error').text().trim(), 'error message')
+                .to.equal('There is no user with that email address.');
         });
     });
 

--- a/tests/acceptance/settings/apps-test.js
+++ b/tests/acceptance/settings/apps-test.js
@@ -21,37 +21,31 @@ describe('Acceptance: Settings - Apps', function () {
         destroyApp(application);
     });
 
-    it('redirects to signin when not authenticated', function () {
+    it('redirects to signin when not authenticated', async function () {
         invalidateSession(application);
-        visit('/settings/apps');
+        await visit('/settings/apps');
 
-        andThen(function () {
-            expect(currentURL(), 'currentURL').to.equal('/signin');
-        });
+        expect(currentURL(), 'currentURL').to.equal('/signin');
     });
 
-    it('redirects to team page when authenticated as author', function () {
+    it('redirects to team page when authenticated as author', async function () {
         let role = server.create('role', {name: 'Author'});
         server.create('user', {roles: [role], slug: 'test-user'});
 
         authenticateSession(application);
-        visit('/settings/apps');
+        await visit('/settings/apps');
 
-        andThen(() => {
-            expect(currentURL(), 'currentURL').to.equal('/team/test-user');
-        });
+        expect(currentURL(), 'currentURL').to.equal('/team/test-user');
     });
 
-    it('redirects to team page when authenticated as editor', function () {
+    it('redirects to team page when authenticated as editor', async function () {
         let role = server.create('role', {name: 'Editor'});
         server.create('user', {roles: [role], slug: 'test-user'});
 
         authenticateSession(application);
-        visit('/settings/apps');
+        await visit('/settings/apps');
 
-        andThen(() => {
-            expect(currentURL(), 'currentURL').to.equal('/team');
-        });
+        expect(currentURL(), 'currentURL').to.equal('/team');
     });
 
     describe('when logged in', function () {
@@ -62,35 +56,27 @@ describe('Acceptance: Settings - Apps', function () {
             return authenticateSession(application);
         });
 
-        it('it redirects to Slack when clicking on the grid', function () {
-            visit('/settings/apps');
+        it('it redirects to Slack when clicking on the grid', async function () {
+            await visit('/settings/apps');
 
-            andThen(() => {
-                // has correct url
-                expect(currentURL(), 'currentURL').to.equal('/settings/apps');
-            });
+            // has correct url
+            expect(currentURL(), 'currentURL').to.equal('/settings/apps');
 
-            click('#slack-link');
+            await click('#slack-link');
 
-            andThen(() => {
-                // has correct url
-                expect(currentURL(), 'currentURL').to.equal('/settings/apps/slack');
-            });
+            // has correct url
+            expect(currentURL(), 'currentURL').to.equal('/settings/apps/slack');
         });
-        it('it redirects to AMP when clicking on the grid', function () {
-            visit('/settings/apps');
+        it('it redirects to AMP when clicking on the grid', async function () {
+            await visit('/settings/apps');
 
-            andThen(() => {
-                // has correct url
-                expect(currentURL(), 'currentURL').to.equal('/settings/apps');
-            });
+            // has correct url
+            expect(currentURL(), 'currentURL').to.equal('/settings/apps');
 
-            click('#amp-link');
+            await click('#amp-link');
 
-            andThen(() => {
-                // has correct url
-                expect(currentURL(), 'currentURL').to.equal('/settings/apps/amp');
-            });
+            // has correct url
+            expect(currentURL(), 'currentURL').to.equal('/settings/apps/amp');
         });
     });
 });

--- a/tests/acceptance/settings/code-injection-test.js
+++ b/tests/acceptance/settings/code-injection-test.js
@@ -23,37 +23,31 @@ describe('Acceptance: Settings - Code-Injection', function() {
         destroyApp(application);
     });
 
-    it('redirects to signin when not authenticated', function () {
+    it('redirects to signin when not authenticated', async function () {
         invalidateSession(application);
-        visit('/settings/code-injection');
+        await visit('/settings/code-injection');
 
-        andThen(function() {
-            expect(currentURL(), 'currentURL').to.equal('/signin');
-        });
+        expect(currentURL(), 'currentURL').to.equal('/signin');
     });
 
-    it('redirects to team page when authenticated as author', function () {
+    it('redirects to team page when authenticated as author', async function () {
         let role = server.create('role', {name: 'Author'});
         server.create('user', {roles: [role], slug: 'test-user'});
 
         authenticateSession(application);
-        visit('/settings/code-injection');
+        await visit('/settings/code-injection');
 
-        andThen(() => {
-            expect(currentURL(), 'currentURL').to.equal('/team/test-user');
-        });
+        expect(currentURL(), 'currentURL').to.equal('/team/test-user');
     });
 
-    it('redirects to team page when authenticated as editor', function () {
+    it('redirects to team page when authenticated as editor', async function () {
         let role = server.create('role', {name: 'Editor'});
         server.create('user', {roles: [role], slug: 'test-user'});
 
         authenticateSession(application);
-        visit('/settings/code-injection');
+        await visit('/settings/code-injection');
 
-        andThen(() => {
-            expect(currentURL(), 'currentURL').to.equal('/team');
-        });
+        expect(currentURL(), 'currentURL').to.equal('/team');
     });
 
     describe('when logged in', function () {
@@ -64,28 +58,26 @@ describe('Acceptance: Settings - Code-Injection', function() {
             return authenticateSession(application);
         });
 
-        it('it renders, loads editors correctly', function () {
-            visit('/settings/code-injection');
+        it('it renders, loads editors correctly', async function () {
+            await visit('/settings/code-injection');
 
-            andThen(() => {
-                // has correct url
-                expect(currentURL(), 'currentURL').to.equal('/settings/code-injection');
+            // has correct url
+            expect(currentURL(), 'currentURL').to.equal('/settings/code-injection');
 
-                // has correct page title
-                expect(document.title, 'page title').to.equal('Settings - Code injection - Test Blog');
+            // has correct page title
+            expect(document.title, 'page title').to.equal('Settings - Code injection - Test Blog');
 
-                // highlights nav menu
-                expect($('.gh-nav-settings-code-injection').hasClass('active'), 'highlights nav menu item')
-                    .to.be.true;
+            // highlights nav menu
+            expect($('.gh-nav-settings-code-injection').hasClass('active'), 'highlights nav menu item')
+                .to.be.true;
 
-                expect(find(testSelector('save-button')).text().trim(), 'save button text').to.equal('Save');
+            expect(find(testSelector('save-button')).text().trim(), 'save button text').to.equal('Save');
 
-                expect(find('#ghost-head .CodeMirror').length, 'ghost head codemirror element').to.equal(1);
-                expect($('#ghost-head .CodeMirror').hasClass('cm-s-xq-light'), 'ghost head editor theme').to.be.true;
+            expect(find('#ghost-head .CodeMirror').length, 'ghost head codemirror element').to.equal(1);
+            expect($('#ghost-head .CodeMirror').hasClass('cm-s-xq-light'), 'ghost head editor theme').to.be.true;
 
-                expect(find('#ghost-foot .CodeMirror').length, 'ghost head codemirror element').to.equal(1);
-                expect($('#ghost-foot .CodeMirror').hasClass('cm-s-xq-light'), 'ghost head editor theme').to.be.true;
-            });
+            expect(find('#ghost-foot .CodeMirror').length, 'ghost head codemirror element').to.equal(1);
+            expect($('#ghost-foot .CodeMirror').hasClass('cm-s-xq-light'), 'ghost head editor theme').to.be.true;
         });
     });
 });

--- a/tests/acceptance/settings/design-test.js
+++ b/tests/acceptance/settings/design-test.js
@@ -25,25 +25,21 @@ describe('Acceptance: Settings - Design', function () {
         destroyApp(application);
     });
 
-    it('redirects to signin when not authenticated', function () {
+    it('redirects to signin when not authenticated', async function () {
         invalidateSession(application);
-        visit('/settings/design');
+        await visit('/settings/design');
 
-        andThen(function () {
-            expect(currentURL(), 'currentURL').to.equal('/signin');
-        });
+        expect(currentURL(), 'currentURL').to.equal('/signin');
     });
 
-    it('redirects to team page when authenticated as author', function () {
+    it('redirects to team page when authenticated as author', async function () {
         let role = server.create('role', {name: 'Author'});
         server.create('user', {roles: [role], slug: 'test-user'});
 
         authenticateSession(application);
-        visit('/settings/design');
+        await visit('/settings/design');
 
-        andThen(function () {
-            expect(currentURL(), 'currentURL').to.equal('/team/test-user');
-        });
+        expect(currentURL(), 'currentURL').to.equal('/team/test-user');
     });
 
     describe('when logged in', function () {
@@ -54,173 +50,146 @@ describe('Acceptance: Settings - Design', function () {
             authenticateSession(application);
         });
 
-        it('can visit /settings/design', function () {
-            visit('/settings/design');
+        it('can visit /settings/design', async function () {
+            await visit('/settings/design');
 
-            andThen(function () {
-                expect(currentPath()).to.equal('settings.design.index');
+            expect(currentPath()).to.equal('settings.design.index');
 
-                // fixtures contain two nav items, check for three rows as we
-                // should have one extra that's blank
-                expect(
-                    find('.gh-blognav-item').length,
-                    'navigation items count'
-                ).to.equal(3);
-            });
+            // fixtures contain two nav items, check for three rows as we
+            // should have one extra that's blank
+            expect(
+                find('.gh-blognav-item').length,
+                'navigation items count'
+            ).to.equal(3);
         });
 
-        it('saves navigation settings', function () {
-            visit('/settings/design');
-            fillIn('.gh-blognav-label:first input', 'Test');
-            fillIn('.gh-blognav-url:first input', '/test');
-            triggerEvent('.gh-blognav-url:first input', 'blur');
+        it('saves navigation settings', async function () {
+            await visit('/settings/design');
+            await fillIn('.gh-blognav-label:first input', 'Test');
+            await fillIn('.gh-blognav-url:first input', '/test');
+            await triggerEvent('.gh-blognav-url:first input', 'blur');
 
-            click('.gh-btn-blue');
+            await click('.gh-btn-blue');
 
-            andThen(function () {
-                let [navSetting] = server.db.settings.where({key: 'navigation'});
+            let [navSetting] = server.db.settings.where({key: 'navigation'});
 
-                expect(navSetting.value).to.equal('[{"label":"Test","url":"/test/"},{"label":"About","url":"/about"}]');
+            expect(navSetting.value).to.equal('[{"label":"Test","url":"/test/"},{"label":"About","url":"/about"}]');
 
-                // don't test against .error directly as it will pick up failed
-                // tests "pre.error" elements
-                expect(find('span.error').length, 'error fields count').to.equal(0);
-                expect(find('.gh-alert').length, 'alerts count').to.equal(0);
-                expect(find('.response:visible').length, 'validation errors count')
-                    .to.equal(0);
-            });
+            // don't test against .error directly as it will pick up failed
+            // tests "pre.error" elements
+            expect(find('span.error').length, 'error fields count').to.equal(0);
+            expect(find('.gh-alert').length, 'alerts count').to.equal(0);
+            expect(find('.response:visible').length, 'validation errors count')
+                .to.equal(0);
         });
 
-        it('validates new item correctly on save', function () {
-            visit('/settings/design');
+        it('validates new item correctly on save', async function () {
+            await visit('/settings/design');
 
-            click('.gh-btn-blue');
+            await click('.gh-btn-blue');
 
-            andThen(function () {
-                expect(
-                    find('.gh-blognav-item').length,
-                    'number of nav items after saving with blank new item'
-                ).to.equal(3);
-            });
+            expect(
+                find('.gh-blognav-item').length,
+                'number of nav items after saving with blank new item'
+            ).to.equal(3);
 
-            fillIn('.gh-blognav-label:last input', 'Test');
-            fillIn('.gh-blognav-url:last input', 'http://invalid domain/');
-            triggerEvent('.gh-blognav-url:last input', 'blur');
+            await fillIn('.gh-blognav-label:last input', 'Test');
+            await fillIn('.gh-blognav-url:last input', 'http://invalid domain/');
+            await triggerEvent('.gh-blognav-url:last input', 'blur');
 
-            click('.gh-btn-blue');
+            await click('.gh-btn-blue');
 
-            andThen(function () {
-                expect(
-                    find('.gh-blognav-item').length,
-                    'number of nav items after saving with invalid new item'
-                ).to.equal(3);
+            expect(
+                find('.gh-blognav-item').length,
+                'number of nav items after saving with invalid new item'
+            ).to.equal(3);
 
-                expect(
-                    find('.gh-blognav-item:last .error').length,
-                    'number of invalid fields in new item'
-                ).to.equal(1);
-            });
+            expect(
+                find('.gh-blognav-item:last .error').length,
+                'number of invalid fields in new item'
+            ).to.equal(1);
         });
 
-        it('clears unsaved settings when navigating away', function () {
-            visit('/settings/design');
-            fillIn('.gh-blognav-label:first input', 'Test');
-            triggerEvent('.gh-blognav-label:first input', 'blur');
+        it('clears unsaved settings when navigating away', async function () {
+            await visit('/settings/design');
+            await fillIn('.gh-blognav-label:first input', 'Test');
+            await triggerEvent('.gh-blognav-label:first input', 'blur');
 
-            andThen(function () {
-                expect(find('.gh-blognav-label:first input').val()).to.equal('Test');
-            });
+            expect(find('.gh-blognav-label:first input').val()).to.equal('Test');
 
-            visit('/settings/code-injection');
-            visit('/settings/design');
+            await visit('/settings/code-injection');
+            await visit('/settings/design');
 
-            andThen(function () {
-                expect(find('.gh-blognav-label:first input').val()).to.equal('Home');
-            });
+            expect(find('.gh-blognav-label:first input').val()).to.equal('Home');
         });
 
-        it('can add and remove items', function (done) {
-            visit('/settings/design');
+        it('can add and remove items', async function () {
+            await visit('/settings/design');
+            await click('.gh-blognav-add');
 
-            click('.gh-blognav-add');
+            expect(
+                find('.gh-blognav-label:last .response').is(':visible'),
+                'blank label has validation error'
+            ).to.be.true;
 
-            andThen(function () {
-                expect(
-                    find('.gh-blognav-label:last .response').is(':visible'),
-                    'blank label has validation error'
-                ).to.be.true;
-            });
+            await fillIn('.gh-blognav-label:last input', 'New');
+            await triggerEvent('.gh-blognav-label:last input', 'keypress', {});
 
-            fillIn('.gh-blognav-label:last input', 'New');
-            triggerEvent('.gh-blognav-label:last input', 'keypress', {});
+            expect(
+                find('.gh-blognav-label:last .response').is(':visible'),
+                'label validation is visible after typing'
+            ).to.be.false;
 
-            andThen(function () {
-                expect(
-                    find('.gh-blognav-label:last .response').is(':visible'),
-                    'label validation is visible after typing'
-                ).to.be.false;
-            });
+            await fillIn('.gh-blognav-url:last input', '/new');
+            await triggerEvent('.gh-blognav-url:last input', 'keypress', {});
+            await triggerEvent('.gh-blognav-url:last input', 'blur');
 
-            fillIn('.gh-blognav-url:last input', '/new');
-            triggerEvent('.gh-blognav-url:last input', 'keypress', {});
-            triggerEvent('.gh-blognav-url:last input', 'blur');
+            expect(
+                find('.gh-blognav-url:last .response').is(':visible'),
+                'url validation is visible after typing'
+            ).to.be.false;
 
-            andThen(function () {
-                expect(
-                    find('.gh-blognav-url:last .response').is(':visible'),
-                    'url validation is visible after typing'
-                ).to.be.false;
+            expect(
+                find('.gh-blognav-url:last input').val()
+            ).to.equal(`${window.location.protocol}//${window.location.host}/new/`);
 
-                expect(
-                    find('.gh-blognav-url:last input').val()
-                ).to.equal(`${window.location.protocol}//${window.location.host}/new/`);
-            });
+            await click('.gh-blognav-add');
 
-            click('.gh-blognav-add');
+            expect(
+                find('.gh-blognav-item').length,
+                'number of nav items after successful add'
+            ).to.equal(4);
 
-            andThen(function () {
-                expect(
-                    find('.gh-blognav-item').length,
-                    'number of nav items after successful add'
-                ).to.equal(4);
+            expect(
+                find('.gh-blognav-label:last input').val(),
+                'new item label value after successful add'
+            ).to.be.blank;
 
-                expect(
-                    find('.gh-blognav-label:last input').val(),
-                    'new item label value after successful add'
-                ).to.be.blank;
+            expect(
+                find('.gh-blognav-url:last input').val(),
+                'new item url value after successful add'
+            ).to.equal(`${window.location.protocol}//${window.location.host}/`);
 
-                expect(
-                    find('.gh-blognav-url:last input').val(),
-                    'new item url value after successful add'
-                ).to.equal(`${window.location.protocol}//${window.location.host}/`);
+            expect(
+                find('.gh-blognav-item .response:visible').length,
+                'number or validation errors shown after successful add'
+            ).to.equal(0);
 
-                expect(
-                    find('.gh-blognav-item .response:visible').length,
-                    'number or validation errors shown after successful add'
-                ).to.equal(0);
-            });
+            await click('.gh-blognav-item:first .gh-blognav-delete');
 
-            click('.gh-blognav-item:first .gh-blognav-delete');
+            expect(
+                find('.gh-blognav-item').length,
+                'number of nav items after successful remove'
+            ).to.equal(3);
 
-            andThen(function () {
-                expect(
-                    find('.gh-blognav-item').length,
-                    'number of nav items after successful remove'
-                ).to.equal(3);
-            });
+            await click('.gh-btn-blue');
 
-            click('.gh-btn-blue');
+            let [navSetting] = server.db.settings.where({key: 'navigation'});
 
-            andThen(function () {
-                let [navSetting] = server.db.settings.where({key: 'navigation'});
-
-                expect(navSetting.value).to.equal('[{"label":"About","url":"/about"},{"label":"New","url":"/new/"}]');
-
-                done();
-            });
+            expect(navSetting.value).to.equal('[{"label":"About","url":"/about"},{"label":"New","url":"/new/"}]');
         });
 
-        it('allows management of themes', function () {
+        it('allows management of themes', async function () {
             // lists available themes + active theme is highlighted
 
             // theme upload
@@ -240,480 +209,445 @@ describe('Acceptance: Settings - Design', function () {
             // - deletes theme and refreshes list
 
             server.loadFixtures('themes');
-            visit('/settings/design');
+            await visit('/settings/design');
 
             // lists available themes (themes are specified in mirage/fixtures/settings)
-            andThen(() => {
-                expect(
-                    find(testSelector('theme-id')).length,
-                    'shows correct number of themes'
-                ).to.equal(3);
+            expect(
+                find(testSelector('theme-id')).length,
+                'shows correct number of themes'
+            ).to.equal(3);
 
-                expect(
-                    find(`${testSelector('theme-active', 'true')} ${testSelector('theme-title')}`).text().trim(),
-                    'Blog theme marked as active'
-                ).to.equal('Blog (default)');
-            });
+            expect(
+                find(`${testSelector('theme-active', 'true')} ${testSelector('theme-title')}`).text().trim(),
+                'Blog theme marked as active'
+            ).to.equal('Blog (default)');
 
             // theme upload displays modal
-            click(testSelector('upload-theme-button'));
-            andThen(() => {
-                expect(
-                    find('.fullscreen-modal .modal-content:contains("Upload a theme")').length,
-                    'theme upload modal displayed after button click'
-                ).to.equal(1);
-            });
+            await click(testSelector('upload-theme-button'));
+            expect(
+                find('.fullscreen-modal .modal-content:contains("Upload a theme")').length,
+                'theme upload modal displayed after button click'
+            ).to.equal(1);
 
             // cancelling theme upload closes modal
-            click(`.fullscreen-modal ${testSelector('close-button')}`);
-            andThen(() => {
-                expect(
-                    find('.fullscreen-modal').length === 0,
-                    'upload theme modal is closed when cancelling'
-                ).to.be.true;
-            });
+            await click(`.fullscreen-modal ${testSelector('close-button')}`);
+            expect(
+                find('.fullscreen-modal').length === 0,
+                'upload theme modal is closed when cancelling'
+            ).to.be.true;
 
             // theme upload validates mime type
-            click(testSelector('upload-theme-button'));
-            fileUpload('.fullscreen-modal input[type="file"]', ['test'], {type: 'text/csv'});
-            andThen(() => {
-                expect(
-                    find('.fullscreen-modal .failed').text(),
-                    'validation error is shown for invalid mime type'
-                ).to.match(/is not supported/);
-            });
+            await click(testSelector('upload-theme-button'));
+            await fileUpload('.fullscreen-modal input[type="file"]', ['test'], {type: 'text/csv'});
+            expect(
+                find('.fullscreen-modal .failed').text(),
+                'validation error is shown for invalid mime type'
+            ).to.match(/is not supported/);
 
             // theme upload validates casper.zip
-            click(testSelector('upload-try-again-button'));
-            fileUpload('.fullscreen-modal input[type="file"]', ['test'], {name: 'casper.zip', type: 'application/zip'});
-            andThen(() => {
-                expect(
-                    find('.fullscreen-modal .failed').text(),
-                    'validation error is shown when uploading casper.zip'
-                ).to.match(/default Casper theme cannot be overwritten/);
-            });
+            await click(testSelector('upload-try-again-button'));
+            await fileUpload('.fullscreen-modal input[type="file"]', ['test'], {name: 'casper.zip', type: 'application/zip'});
+            expect(
+                find('.fullscreen-modal .failed').text(),
+                'validation error is shown when uploading casper.zip'
+            ).to.match(/default Casper theme cannot be overwritten/);
 
             // theme upload handles upload errors
-            andThen(() => {
-                server.post('/themes/upload/', function () {
-                    return new Mirage.Response(422, {}, {
-                        errors: [{
-                            message: 'Invalid theme'
-                        }]
-                    });
+            server.post('/themes/upload/', function () {
+                return new Mirage.Response(422, {}, {
+                    errors: [{
+                        message: 'Invalid theme'
+                    }]
                 });
             });
-            click(testSelector('upload-try-again-button'));
-            fileUpload('.fullscreen-modal input[type="file"]', ['test'], {name: 'error.zip', type: 'application/zip'});
-            andThen(() => {
-                expect(
-                    find('.fullscreen-modal .failed').text().trim(),
-                    'validation error is passed through from server'
-                ).to.equal('Invalid theme');
+            await click(testSelector('upload-try-again-button'));
+            await fileUpload('.fullscreen-modal input[type="file"]', ['test'], {name: 'error.zip', type: 'application/zip'});
+            expect(
+                find('.fullscreen-modal .failed').text().trim(),
+                'validation error is passed through from server'
+            ).to.equal('Invalid theme');
 
-                // reset to default mirage handlers
-                mockThemes(server);
-            });
+            // reset to default mirage handlers
+            mockThemes(server);
 
             // theme upload handles validation errors
-            andThen(() => {
-                server.post('/themes/upload/', function () {
-                    return new Mirage.Response(422, {}, {
-                        errors: [
-                            {
-                                message: 'Theme is not compatible or contains errors.',
-                                errorType: 'ThemeValidationError',
-                                errorDetails: [
-                                    {
-                                        level: 'error',
-                                        rule: 'Templates must contain valid Handlebars.',
-                                        failures: [
-                                            {
-                                                ref: 'index.hbs',
-                                                message: 'The partial index_meta could not be found'
-                                            },
-                                            {
-                                                ref: 'tag.hbs',
-                                                message: 'The partial index_meta could not be found'
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        level: 'error',
-                                        rule: 'Assets such as CSS & JS must use the <code>{{asset}}</code> helper',
-                                        details: '<p>The listed files should be included using the <code>{{asset}}</code> helper.</p>',
-                                        failures: [
-                                            {
-                                                ref: '/assets/javascripts/ui.js'
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        ]
-                    });
+            server.post('/themes/upload/', function () {
+                return new Mirage.Response(422, {}, {
+                    errors: [
+                        {
+                            message: 'Theme is not compatible or contains errors.',
+                            errorType: 'ThemeValidationError',
+                            errorDetails: [
+                                {
+                                    level: 'error',
+                                    rule: 'Templates must contain valid Handlebars.',
+                                    failures: [
+                                        {
+                                            ref: 'index.hbs',
+                                            message: 'The partial index_meta could not be found'
+                                        },
+                                        {
+                                            ref: 'tag.hbs',
+                                            message: 'The partial index_meta could not be found'
+                                        }
+                                    ]
+                                },
+                                {
+                                    level: 'error',
+                                    rule: 'Assets such as CSS & JS must use the <code>{{asset}}</code> helper',
+                                    details: '<p>The listed files should be included using the <code>{{asset}}</code> helper.</p>',
+                                    failures: [
+                                        {
+                                            ref: '/assets/javascripts/ui.js'
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
                 });
             });
-            click(testSelector('upload-try-again-button'));
-            fileUpload('.fullscreen-modal input[type="file"]', ['test'], {name: 'bad-theme.zip', type: 'application/zip'});
-            andThen(() => {
-                expect(
-                    find('.fullscreen-modal h1').text().trim(),
-                    'modal title after uploading invalid theme'
-                ).to.equal('Invalid theme');
 
-                expect(
-                    find('.theme-validation-errors').text(),
-                    'top-level errors are displayed'
-                ).to.match(/Templates must contain valid Handlebars/);
+            await click(testSelector('upload-try-again-button'));
+            await fileUpload('.fullscreen-modal input[type="file"]', ['test'], {name: 'bad-theme.zip', type: 'application/zip'});
 
-                expect(
-                    find('.theme-validation-errors').text(),
-                    'top-level errors do not escape HTML'
-                ).to.match(/The listed files should be included using the {{asset}} helper/);
+            expect(
+                find('.fullscreen-modal h1').text().trim(),
+                'modal title after uploading invalid theme'
+            ).to.equal('Invalid theme');
 
-                expect(
-                    find('.theme-validation-errors').text(),
-                    'individual failures are displayed'
-                ).to.match(/index\.hbs: The partial index_meta could not be found/);
+            expect(
+                find('.theme-validation-errors').text(),
+                'top-level errors are displayed'
+            ).to.match(/Templates must contain valid Handlebars/);
 
-                // reset to default mirage handlers
-                mockThemes(server);
-            });
-            click(`.fullscreen-modal ${testSelector('try-again-button')}`);
-            andThen(() => {
-                expect(
-                    find('.theme-validation-errors').length,
-                    '"Try Again" resets form after theme validation error'
-                ).to.equal(0);
+            expect(
+                find('.theme-validation-errors').text(),
+                'top-level errors do not escape HTML'
+            ).to.match(/The listed files should be included using the {{asset}} helper/);
 
-                expect(
-                    find('.gh-image-uploader').length,
-                    '"Try Again" resets form after theme validation error'
-                ).to.equal(1);
+            expect(
+                find('.theme-validation-errors').text(),
+                'individual failures are displayed'
+            ).to.match(/index\.hbs: The partial index_meta could not be found/);
 
-                expect(
-                    find('.fullscreen-modal h1').text().trim(),
-                    '"Try Again" resets form after theme validation error'
-                ).to.equal('Upload a theme');
-            });
+            // reset to default mirage handlers
+            mockThemes(server);
+
+            await click(`.fullscreen-modal ${testSelector('try-again-button')}`);
+            expect(
+                find('.theme-validation-errors').length,
+                '"Try Again" resets form after theme validation error'
+            ).to.equal(0);
+
+            expect(
+                find('.gh-image-uploader').length,
+                '"Try Again" resets form after theme validation error'
+            ).to.equal(1);
+
+            expect(
+                find('.fullscreen-modal h1').text().trim(),
+                '"Try Again" resets form after theme validation error'
+            ).to.equal('Upload a theme');
 
             // theme upload handles validation warnings
-            andThen(() => {
-                server.post('/themes/upload/', function ({themes}) {
-                    let theme = {
-                        name: 'blackpalm',
-                        package: {
-                            name: 'BlackPalm',
-                            version: '1.0.0'
+            server.post('/themes/upload/', function ({themes}) {
+                let theme = {
+                    name: 'blackpalm',
+                    package: {
+                        name: 'BlackPalm',
+                        version: '1.0.0'
+                    }
+                };
+
+                themes.create(theme);
+
+                theme.warnings = [{
+                    level: 'warning',
+                    rule: 'Assets such as CSS & JS must use the <code>{{asset}}</code> helper',
+                    details: '<p>The listed files should be included using the <code>{{asset}}</code> helper.  For more information, please see the <a href="http://themes.ghost.org/docs/asset">asset helper documentation</a>.</p>',
+                    failures: [
+                        {
+                            ref: '/assets/dist/img/apple-touch-icon.png'
+                        },
+                        {
+                            ref: '/assets/dist/img/favicon.ico'
+                        },
+                        {
+                            ref: '/assets/dist/css/blackpalm.min.css'
+                        },
+                        {
+                            ref: '/assets/dist/js/blackpalm.min.js'
                         }
-                    };
+                    ],
+                    code: 'GS030-ASSET-REQ'
+                }];
 
-                    themes.create(theme);
-
-                    theme.warnings = [{
-                        level: 'warning',
-                        rule: 'Assets such as CSS & JS must use the <code>{{asset}}</code> helper',
-                        details: '<p>The listed files should be included using the <code>{{asset}}</code> helper.  For more information, please see the <a href="http://themes.ghost.org/docs/asset">asset helper documentation</a>.</p>',
-                        failures: [
-                            {
-                                ref: '/assets/dist/img/apple-touch-icon.png'
-                            },
-                            {
-                                ref: '/assets/dist/img/favicon.ico'
-                            },
-                            {
-                                ref: '/assets/dist/css/blackpalm.min.css'
-                            },
-                            {
-                                ref: '/assets/dist/js/blackpalm.min.js'
-                            }
-                        ],
-                        code: 'GS030-ASSET-REQ'
-                    }];
-
-                    return new Mirage.Response(200, {}, {
-                        themes: [theme]
-                    });
+                return new Mirage.Response(200, {}, {
+                    themes: [theme]
                 });
             });
-            fileUpload('.fullscreen-modal input[type="file"]', ['test'], {name: 'warning-theme.zip', type: 'application/zip'});
-            andThen(() => {
-                expect(
-                    find('.fullscreen-modal h1').text().trim(),
-                    'modal title after uploading theme with warnings'
-                ).to.equal('Uploaded with warnings');
 
-                expect(
-                    find('.theme-validation-errors').text(),
-                    'top-level warnings are displayed'
-                ).to.match(/The listed files should be included using the {{asset}} helper/);
+            await fileUpload('.fullscreen-modal input[type="file"]', ['test'], {name: 'warning-theme.zip', type: 'application/zip'});
 
-                expect(
-                    find('.theme-validation-errors').text(),
-                    'individual warning failures are displayed'
-                ).to.match(/\/assets\/dist\/img\/apple-touch-icon\.png/);
+            expect(
+                find('.fullscreen-modal h1').text().trim(),
+                'modal title after uploading theme with warnings'
+            ).to.equal('Uploaded with warnings');
 
-                // reset to default mirage handlers
-                mockThemes(server);
-            });
-            click(`.fullscreen-modal ${testSelector('close-button')}`);
+            expect(
+                find('.theme-validation-errors').text(),
+                'top-level warnings are displayed'
+            ).to.match(/The listed files should be included using the {{asset}} helper/);
+
+            expect(
+                find('.theme-validation-errors').text(),
+                'individual warning failures are displayed'
+            ).to.match(/\/assets\/dist\/img\/apple-touch-icon\.png/);
+
+            // reset to default mirage handlers
+            mockThemes(server);
+
+            await click(`.fullscreen-modal ${testSelector('close-button')}`);
 
             // theme upload handles success then close
-            click(testSelector('upload-theme-button'));
-            fileUpload('.fullscreen-modal input[type="file"]', ['test'], {name: 'theme-1.zip', type: 'application/zip'});
+            await click(testSelector('upload-theme-button'));
+            await fileUpload('.fullscreen-modal input[type="file"]', ['test'], {name: 'theme-1.zip', type: 'application/zip'});
 
-            andThen(() => {
-                expect(
-                    find('.fullscreen-modal h1').text().trim(),
-                    'modal header after successful upload'
-                ).to.equal('Upload successful!');
+            expect(
+                find('.fullscreen-modal h1').text().trim(),
+                'modal header after successful upload'
+            ).to.equal('Upload successful!');
 
-                expect(
-                    find('.modal-body').text(),
-                    'modal displays theme name after successful upload'
-                ).to.match(/"Test 1 - 0\.1" uploaded successfully/);
+            expect(
+                find('.modal-body').text(),
+                'modal displays theme name after successful upload'
+            ).to.match(/"Test 1 - 0\.1" uploaded successfully/);
 
-                expect(
-                    find(testSelector('theme-id')).length,
-                    'number of themes in list grows after upload'
-                ).to.equal(5);
+            expect(
+                find(testSelector('theme-id')).length,
+                'number of themes in list grows after upload'
+            ).to.equal(5);
 
-                expect(
-                    find(`${testSelector('theme-active', 'true')} ${testSelector('theme-title')}`).text().trim(),
-                    'newly uploaded theme is not active'
-                ).to.equal('Blog (default)');
-            });
-            click(`.fullscreen-modal ${testSelector('close-button')}`);
+            expect(
+                find(`${testSelector('theme-active', 'true')} ${testSelector('theme-title')}`).text().trim(),
+                'newly uploaded theme is not active'
+            ).to.equal('Blog (default)');
+
+            await click(`.fullscreen-modal ${testSelector('close-button')}`);
 
             // theme upload handles success then activate
-            click(testSelector('upload-theme-button'));
-            fileUpload('.fullscreen-modal input[type="file"]', ['test'], {name: 'theme-2.zip', type: 'application/zip'});
-            click(`.fullscreen-modal ${testSelector('activate-now-button')}`);
-            andThen(() => {
-                expect(
-                    find(testSelector('theme-id')).length,
-                    'number of themes in list grows after upload and activate'
-                ).to.equal(6);
+            await click(testSelector('upload-theme-button'));
+            await fileUpload('.fullscreen-modal input[type="file"]', ['test'], {name: 'theme-2.zip', type: 'application/zip'});
+            await click(`.fullscreen-modal ${testSelector('activate-now-button')}`);
 
-                expect(
-                    find(`${testSelector('theme-active', 'true')} ${testSelector('theme-title')}`).text().trim(),
-                    'newly uploaded+activated theme is active'
-                ).to.equal('Test 2');
-            });
+            expect(
+                find(testSelector('theme-id')).length,
+                'number of themes in list grows after upload and activate'
+            ).to.equal(6);
+
+            expect(
+                find(`${testSelector('theme-active', 'true')} ${testSelector('theme-title')}`).text().trim(),
+                'newly uploaded+activated theme is active'
+            ).to.equal('Test 2');
 
             // theme activation switches active theme
-            click(`${testSelector('theme-id', 'casper')} ${testSelector('theme-activate-button')}`);
-            andThen(() => {
-                expect(
-                    find(`${testSelector('theme-id', 'test-2')} .apps-card-app`).hasClass('theme-list-item--active'),
-                    'previously active theme is not active'
-                ).to.be.false;
+            await click(`${testSelector('theme-id', 'casper')} ${testSelector('theme-activate-button')}`);
 
-                expect(
-                    find(`${testSelector('theme-id', 'casper')} .apps-card-app`).hasClass('theme-list-item--active'),
-                    'activated theme is active'
-                ).to.be.true;
-            });
+            expect(
+                find(`${testSelector('theme-id', 'test-2')} .apps-card-app`).hasClass('theme-list-item--active'),
+                'previously active theme is not active'
+            ).to.be.false;
+
+            expect(
+                find(`${testSelector('theme-id', 'casper')} .apps-card-app`).hasClass('theme-list-item--active'),
+                'activated theme is active'
+            ).to.be.true;
 
             // theme activation shows errors
-            andThen(() => {
-                server.put('themes/:theme/activate', function () {
-                    return new Mirage.Response(422, {}, {
-                        errors: [
-                            {
-                                message: 'Theme is not compatible or contains errors.',
-                                errorType: 'ThemeValidationError',
-                                errorDetails: [
-                                    {
-                                        level: 'error',
-                                        rule: 'Templates must contain valid Handlebars.',
-                                        failures: [
-                                            {
-                                                ref: 'index.hbs',
-                                                message: 'The partial index_meta could not be found'
-                                            },
-                                            {
-                                                ref: 'tag.hbs',
-                                                message: 'The partial index_meta could not be found'
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        level: 'error',
-                                        rule: 'Assets such as CSS & JS must use the <code>{{asset}}</code> helper',
-                                        details: '<p>The listed files should be included using the <code>{{asset}}</code> helper.</p>',
-                                        failures: [
-                                            {
-                                                ref: '/assets/javascripts/ui.js'
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        ]
-                    });
+            server.put('themes/:theme/activate', function () {
+                return new Mirage.Response(422, {}, {
+                    errors: [
+                        {
+                            message: 'Theme is not compatible or contains errors.',
+                            errorType: 'ThemeValidationError',
+                            errorDetails: [
+                                {
+                                    level: 'error',
+                                    rule: 'Templates must contain valid Handlebars.',
+                                    failures: [
+                                        {
+                                            ref: 'index.hbs',
+                                            message: 'The partial index_meta could not be found'
+                                        },
+                                        {
+                                            ref: 'tag.hbs',
+                                            message: 'The partial index_meta could not be found'
+                                        }
+                                    ]
+                                },
+                                {
+                                    level: 'error',
+                                    rule: 'Assets such as CSS & JS must use the <code>{{asset}}</code> helper',
+                                    details: '<p>The listed files should be included using the <code>{{asset}}</code> helper.</p>',
+                                    failures: [
+                                        {
+                                            ref: '/assets/javascripts/ui.js'
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
                 });
             });
-            click(`${testSelector('theme-id', 'test-2')} ${testSelector('theme-activate-button')}`);
-            andThen(() => {
-                expect(find(testSelector('theme-warnings-modal'))).to.exist;
 
-                expect(
-                    find(testSelector('theme-warnings-title')).text().trim(),
-                    'modal title after activating invalid theme'
-                ).to.equal('Theme activation failed');
+            await click(`${testSelector('theme-id', 'test-2')} ${testSelector('theme-activate-button')}`);
 
-                expect(
-                    find(testSelector('theme-warnings')).text(),
-                    'top-level errors are displayed in activation errors'
-                ).to.match(/Templates must contain valid Handlebars/);
+            expect(find(testSelector('theme-warnings-modal'))).to.exist;
 
-                expect(
-                    find(testSelector('theme-warnings')).text(),
-                    'top-level errors do not escape HTML in activation errors'
-                ).to.match(/The listed files should be included using the {{asset}} helper/);
+            expect(
+                find(testSelector('theme-warnings-title')).text().trim(),
+                'modal title after activating invalid theme'
+            ).to.equal('Theme activation failed');
 
-                expect(
-                    find(testSelector('theme-warnings')).text(),
-                    'individual failures are displayed in activation errors'
-                ).to.match(/index\.hbs: The partial index_meta could not be found/);
+            expect(
+                find(testSelector('theme-warnings')).text(),
+                'top-level errors are displayed in activation errors'
+            ).to.match(/Templates must contain valid Handlebars/);
 
-                // restore default mirage handlers
-                mockThemes(server);
-            });
-            click(testSelector('modal-close-button'));
-            andThen(() => {
-                expect(find(testSelector('theme-warnings-modal'))).to.not.exist;
-            });
+            expect(
+                find(testSelector('theme-warnings')).text(),
+                'top-level errors do not escape HTML in activation errors'
+            ).to.match(/The listed files should be included using the {{asset}} helper/);
+
+            expect(
+                find(testSelector('theme-warnings')).text(),
+                'individual failures are displayed in activation errors'
+            ).to.match(/index\.hbs: The partial index_meta could not be found/);
+
+            // restore default mirage handlers
+            mockThemes(server);
+
+            await click(testSelector('modal-close-button'));
+            expect(find(testSelector('theme-warnings-modal'))).to.not.exist;
 
             // theme activation shows warnings
-            andThen(() => {
-                server.put('themes/:theme/activate', function ({themes}, {params}) {
-                    themes.all().update('active', false);
-                    let theme = themes.findBy({name: params.theme}).update({active: true});
+            server.put('themes/:theme/activate', function ({themes}, {params}) {
+                themes.all().update('active', false);
+                let theme = themes.findBy({name: params.theme}).update({active: true});
 
-                    theme.update({warnings: [{
-                        level: 'warning',
-                        rule: 'Assets such as CSS & JS must use the <code>{{asset}}</code> helper',
-                        details: '<p>The listed files should be included using the <code>{{asset}}</code> helper.  For more information, please see the <a href="http://themes.ghost.org/docs/asset">asset helper documentation</a>.</p>',
-                        failures: [
-                            {
-                                ref: '/assets/dist/img/apple-touch-icon.png'
-                            },
-                            {
-                                ref: '/assets/dist/img/favicon.ico'
-                            },
-                            {
-                                ref: '/assets/dist/css/blackpalm.min.css'
-                            },
-                            {
-                                ref: '/assets/dist/js/blackpalm.min.js'
-                            }
-                        ],
-                        code: 'GS030-ASSET-REQ'
-                    }]});
+                theme.update({warnings: [{
+                    level: 'warning',
+                    rule: 'Assets such as CSS & JS must use the <code>{{asset}}</code> helper',
+                    details: '<p>The listed files should be included using the <code>{{asset}}</code> helper.  For more information, please see the <a href="http://themes.ghost.org/docs/asset">asset helper documentation</a>.</p>',
+                    failures: [
+                        {
+                            ref: '/assets/dist/img/apple-touch-icon.png'
+                        },
+                        {
+                            ref: '/assets/dist/img/favicon.ico'
+                        },
+                        {
+                            ref: '/assets/dist/css/blackpalm.min.css'
+                        },
+                        {
+                            ref: '/assets/dist/js/blackpalm.min.js'
+                        }
+                    ],
+                    code: 'GS030-ASSET-REQ'
+                }]});
 
-                    return {themes: [theme]};
-                });
+                return {themes: [theme]};
             });
-            click(`${testSelector('theme-id', 'test-2')} ${testSelector('theme-activate-button')}`);
-            andThen(() => {
-                expect(find(testSelector('theme-warnings-modal'))).to.exist;
 
-                expect(
-                    find(testSelector('theme-warnings-title')).text().trim(),
-                    'modal title after activating theme with warnings'
-                ).to.equal('Theme activated with warnings');
+            await click(`${testSelector('theme-id', 'test-2')} ${testSelector('theme-activate-button')}`);
 
-                expect(
-                    find(testSelector('theme-warnings')).text(),
-                    'top-level warnings are displayed in activation warnings'
-                ).to.match(/The listed files should be included using the {{asset}} helper/);
+            expect(find(testSelector('theme-warnings-modal'))).to.exist;
 
-                expect(
-                    find(testSelector('theme-warnings')).text(),
-                    'individual warning failures are displayed in activation warnings'
-                ).to.match(/\/assets\/dist\/img\/apple-touch-icon\.png/);
+            expect(
+                find(testSelector('theme-warnings-title')).text().trim(),
+                'modal title after activating theme with warnings'
+            ).to.equal('Theme activated with warnings');
 
-                // restore default mirage handlers
-                mockThemes(server);
-            });
-            click(testSelector('modal-close-button'));
+            expect(
+                find(testSelector('theme-warnings')).text(),
+                'top-level warnings are displayed in activation warnings'
+            ).to.match(/The listed files should be included using the {{asset}} helper/);
+
+            expect(
+                find(testSelector('theme-warnings')).text(),
+                'individual warning failures are displayed in activation warnings'
+            ).to.match(/\/assets\/dist\/img\/apple-touch-icon\.png/);
+
+            // restore default mirage handlers
+            mockThemes(server);
+
+            await click(testSelector('modal-close-button'));
             // reactivate casper to continue tests
-            click(`${testSelector('theme-id', 'casper')} ${testSelector('theme-activate-button')}`);
+            await click(`${testSelector('theme-id', 'casper')} ${testSelector('theme-activate-button')}`);
 
             // theme deletion displays modal
-            click(`${testSelector('theme-id', 'test-1')} ${testSelector('theme-delete-button')}`);
-            andThen(() => {
-                expect(
-                    find(testSelector('delete-theme-modal')).length,
-                    'theme deletion modal displayed after button click'
-                ).to.equal(1);
-            });
+            await click(`${testSelector('theme-id', 'test-1')} ${testSelector('theme-delete-button')}`);
+            expect(
+                find(testSelector('delete-theme-modal')).length,
+                'theme deletion modal displayed after button click'
+            ).to.equal(1);
 
             // cancelling theme deletion closes modal
-            click(`.fullscreen-modal ${testSelector('cancel-button')}`);
-            andThen(() => {
-                expect(
-                    find('.fullscreen-modal').length === 0,
-                    'delete theme modal is closed when cancelling'
-                ).to.be.true;
-            });
+            await click(`.fullscreen-modal ${testSelector('cancel-button')}`);
+            expect(
+                find('.fullscreen-modal').length === 0,
+                'delete theme modal is closed when cancelling'
+            ).to.be.true;
 
             // confirming theme deletion closes modal and refreshes list
-            click(`${testSelector('theme-id', 'test-1')} ${testSelector('theme-delete-button')}`);
-            click(`.fullscreen-modal ${testSelector('delete-button')}`);
-            andThen(() => {
-                expect(
-                    find('.fullscreen-modal').length === 0,
-                    'delete theme modal closes after deletion'
-                ).to.be.true;
-            });
+            await click(`${testSelector('theme-id', 'test-1')} ${testSelector('theme-delete-button')}`);
+            await click(`.fullscreen-modal ${testSelector('delete-button')}`);
+            expect(
+                find('.fullscreen-modal').length === 0,
+                'delete theme modal closes after deletion'
+            ).to.be.true;
 
-            andThen(() => {
-                expect(
-                    find(testSelector('theme-id')).length,
-                    'number of themes in list shrinks after delete'
-                ).to.equal(5);
+            expect(
+                find(testSelector('theme-id')).length,
+                'number of themes in list shrinks after delete'
+            ).to.equal(5);
 
-                expect(
-                    find(testSelector('theme-title')).text(),
-                    'correct theme is removed from theme list after deletion'
-                ).to.not.match(/Test 1/);
-            });
+            expect(
+                find(testSelector('theme-title')).text(),
+                'correct theme is removed from theme list after deletion'
+            ).to.not.match(/Test 1/);
 
             // validation errors are handled when deleting a theme
-            andThen(() => {
-                server.del('/themes/:theme/', function () {
-                    return new Mirage.Response(422, {}, {
-                        errors: [{
-                            message: 'Can\'t delete theme'
-                        }]
-                    });
+            server.del('/themes/:theme/', function () {
+                return new Mirage.Response(422, {}, {
+                    errors: [{
+                        message: 'Can\'t delete theme'
+                    }]
                 });
             });
-            click(`${testSelector('theme-id', 'test-2')} ${testSelector('theme-delete-button')}`);
-            click(`.fullscreen-modal ${testSelector('delete-button')}`);
-            andThen(() => {
-                expect(
-                    find('.fullscreen-modal').length === 0,
-                    'delete theme modal closes after failed deletion'
-                ).to.be.true;
 
-                expect(
-                    find('.gh-alert').length,
-                    'alert is shown when deletion fails'
-                ).to.equal(1);
+            await click(`${testSelector('theme-id', 'test-2')} ${testSelector('theme-delete-button')}`);
+            await click(`.fullscreen-modal ${testSelector('delete-button')}`);
 
-                expect(
-                    find('.gh-alert').text(),
-                    'failed deletion alert has correct text'
-                ).to.match(/Can't delete theme/);
+            expect(
+                find('.fullscreen-modal').length === 0,
+                'delete theme modal closes after failed deletion'
+            ).to.be.true;
 
-                // restore default mirage handlers
-                mockThemes(server);
-            });
+            expect(
+                find('.gh-alert').length,
+                'alert is shown when deletion fails'
+            ).to.equal(1);
+
+            expect(
+                find('.gh-alert').text(),
+                'failed deletion alert has correct text'
+            ).to.match(/Can't delete theme/);
+
+            // restore default mirage handlers
+            mockThemes(server);
         });
 
     });

--- a/tests/acceptance/settings/general-test.js
+++ b/tests/acceptance/settings/general-test.js
@@ -23,37 +23,31 @@ describe('Acceptance: Settings - General', function () {
         destroyApp(application);
     });
 
-    it('redirects to signin when not authenticated', function () {
+    it('redirects to signin when not authenticated', async function () {
         invalidateSession(application);
-        visit('/settings/general');
+        await visit('/settings/general');
 
-        andThen(function () {
-            expect(currentURL(), 'currentURL').to.equal('/signin');
-        });
+        expect(currentURL(), 'currentURL').to.equal('/signin');
     });
 
-    it('redirects to team page when authenticated as author', function () {
+    it('redirects to team page when authenticated as author', async function () {
         let role = server.create('role', {name: 'Author'});
         server.create('user', {roles: [role], slug: 'test-user'});
 
         authenticateSession(application);
-        visit('/settings/general');
+        await visit('/settings/general');
 
-        andThen(() => {
-            expect(currentURL(), 'currentURL').to.equal('/team/test-user');
-        });
+        expect(currentURL(), 'currentURL').to.equal('/team/test-user');
     });
 
-    it('redirects to team page when authenticated as editor', function () {
+    it('redirects to team page when authenticated as editor', async function () {
         let role = server.create('role', {name: 'Editor'});
         server.create('user', {roles: [role], slug: 'test-user'});
 
         authenticateSession(application);
-        visit('/settings/general');
+        await visit('/settings/general');
 
-        andThen(() => {
-            expect(currentURL(), 'currentURL').to.equal('/team');
-        });
+        expect(currentURL(), 'currentURL').to.equal('/team');
     });
 
     describe('when logged in', function () {
@@ -64,297 +58,219 @@ describe('Acceptance: Settings - General', function () {
             return authenticateSession(application);
         });
 
-        it('it renders, shows image uploader modals', function () {
-            visit('/settings/general');
+        it('it renders, shows image uploader modals', async function () {
+            await visit('/settings/general');
 
-            andThen(() => {
-                // has correct url
-                expect(currentURL(), 'currentURL').to.equal('/settings/general');
+            // has correct url
+            expect(currentURL(), 'currentURL').to.equal('/settings/general');
 
-                // has correct page title
-                expect(document.title, 'page title').to.equal('Settings - General - Test Blog');
+            // has correct page title
+            expect(document.title, 'page title').to.equal('Settings - General - Test Blog');
 
-                // highlights nav menu
-                expect($('.gh-nav-settings-general').hasClass('active'), 'highlights nav menu item')
-                    .to.be.true;
+            // highlights nav menu
+            expect($('.gh-nav-settings-general').hasClass('active'), 'highlights nav menu item')
+                .to.be.true;
 
-                expect(find(testSelector('save-button')).text().trim(), 'save button text').to.equal('Save settings');
+            expect(find(testSelector('save-button')).text().trim(), 'save button text').to.equal('Save settings');
 
-                expect(find(testSelector('dated-permalinks-checkbox')).prop('checked'), 'date permalinks checkbox').to.be.false;
-            });
+            expect(find(testSelector('dated-permalinks-checkbox')).prop('checked'), 'date permalinks checkbox').to.be.false;
 
-            click(testSelector('toggle-pub-info'));
-            fillIn(testSelector('title-input'), 'New Blog Title');
-            click(testSelector('save-button'));
+            await click(testSelector('toggle-pub-info'));
+            await fillIn(testSelector('title-input'), 'New Blog Title');
+            await click(testSelector('save-button'));
+            expect(document.title, 'page title').to.equal('Settings - General - New Blog Title');
 
-            andThen(() => {
-                expect(document.title, 'page title').to.equal('Settings - General - New Blog Title');
-            });
+            await click('.blog-logo');
+            expect(find('.fullscreen-modal .modal-content .gh-image-uploader').length, 'modal selector').to.equal(1);
 
-            click('.blog-logo');
-
-            andThen(() => {
-                expect(find('.fullscreen-modal .modal-content .gh-image-uploader').length, 'modal selector').to.equal(1);
-            });
-
-            click('.fullscreen-modal .modal-content .gh-image-uploader .image-cancel');
-
-            andThen(() => {
-                expect(find(testSelector('file-input-description')).text()).to.equal('Upload an image');
-            });
+            await click('.fullscreen-modal .modal-content .gh-image-uploader .image-cancel');
+            expect(find(testSelector('file-input-description')).text()).to.equal('Upload an image');
 
             // click cancel button
-            click('.fullscreen-modal .modal-footer .gh-btn');
+            await click('.fullscreen-modal .modal-footer .gh-btn');
+            expect(find('.fullscreen-modal').length).to.equal(0);
 
-            andThen(() => {
-                expect(find('.fullscreen-modal').length).to.equal(0);
-            });
+            await click('.blog-icon');
+            expect(find('.fullscreen-modal .modal-content .gh-image-uploader').length, 'modal selector').to.equal(1);
 
-            click('.blog-icon');
-
-            andThen(() => {
-                expect(find('.fullscreen-modal .modal-content .gh-image-uploader').length, 'modal selector').to.equal(1);
-            });
-
-            click('.fullscreen-modal .modal-content .gh-image-uploader .image-cancel');
-
-            andThen(() => {
-                expect(find(testSelector('file-input-description')).text()).to.equal('Upload an image');
-            });
+            await click('.fullscreen-modal .modal-content .gh-image-uploader .image-cancel');
+            expect(find(testSelector('file-input-description')).text()).to.equal('Upload an image');
 
             // click cancel button
-            click('.fullscreen-modal .modal-footer .gh-btn');
+            await click('.fullscreen-modal .modal-footer .gh-btn');
+            expect(find('.fullscreen-modal').length).to.equal(0);
 
-            andThen(() => {
-                expect(find('.fullscreen-modal').length).to.equal(0);
-            });
+            await click('.blog-cover');
+            expect(find('.fullscreen-modal .modal-content .gh-image-uploader').length, 'modal selector').to.equal(1);
 
-            click('.blog-cover');
-
-            andThen(() => {
-                expect(find('.fullscreen-modal .modal-content .gh-image-uploader').length, 'modal selector').to.equal(1);
-            });
-
-            click(testSelector('modal-accept-button'));
-
-            andThen(() => {
-                expect(find('.fullscreen-modal').length).to.equal(0);
-            });
+            await click(testSelector('modal-accept-button'));
+            expect(find('.fullscreen-modal').length).to.equal(0);
         });
 
-        it('renders timezone selector correctly', function () {
-            visit('/settings/general');
-            click(testSelector('toggle-timezone'));
+        it('renders timezone selector correctly', async function () {
+            await visit('/settings/general');
+            await click(testSelector('toggle-timezone'));
 
-            andThen(() => {
-                expect(currentURL(), 'currentURL').to.equal('/settings/general');
+            expect(currentURL(), 'currentURL').to.equal('/settings/general');
 
-                expect(find('#activeTimezone option').length, 'available timezones').to.equal(66);
-                expect(find('#activeTimezone option:selected').text().trim()).to.equal('(GMT) UTC');
-                find('#activeTimezone option[value="Africa/Cairo"]').prop('selected', true);
-            });
+            expect(find('#activeTimezone option').length, 'available timezones').to.equal(66);
+            expect(find('#activeTimezone option:selected').text().trim()).to.equal('(GMT) UTC');
+            find('#activeTimezone option[value="Africa/Cairo"]').prop('selected', true);
 
-            triggerEvent('#activeTimezone', 'change');
-            click(testSelector('save-button'));
-
-            andThen(() => {
-                expect(find('#activeTimezone option:selected').text().trim()).to.equal('(GMT +2:00) Cairo, Egypt');
-            });
+            await triggerEvent('#activeTimezone', 'change');
+            await click(testSelector('save-button'));
+            expect(find('#activeTimezone option:selected').text().trim()).to.equal('(GMT +2:00) Cairo, Egypt');
         });
 
-        it('handles private blog settings correctly', function () {
-            visit('/settings/general');
+        it('handles private blog settings correctly', async function () {
+            await visit('/settings/general');
 
             // handles private blog settings correctly
-            andThen(() => {
-                expect(find(testSelector('private-checkbox')).prop('checked'), 'isPrivate checkbox').to.be.false;
-            });
+            expect(find(testSelector('private-checkbox')).prop('checked'), 'isPrivate checkbox').to.be.false;
 
-            click(testSelector('private-checkbox'));
+            await click(testSelector('private-checkbox'));
 
-            andThen(() => {
-                expect(find(testSelector('private-checkbox')).prop('checked'), 'isPrivate checkbox').to.be.true;
-                expect(find(testSelector('password-input')).length, 'password input').to.equal(1);
-                expect(find(testSelector('password-input')).val(), 'password default value').to.not.equal('');
-            });
+            expect(find(testSelector('private-checkbox')).prop('checked'), 'isPrivate checkbox').to.be.true;
+            expect(find(testSelector('password-input')).length, 'password input').to.equal(1);
+            expect(find(testSelector('password-input')).val(), 'password default value').to.not.equal('');
 
-            fillIn(testSelector('password-input'), '');
-            triggerEvent(testSelector('password-input'), 'blur');
+            await fillIn(testSelector('password-input'), '');
+            await triggerEvent(testSelector('password-input'), 'blur');
 
-            andThen(() => {
-                expect(find(testSelector('password-error')).text().trim(), 'empty password error')
-                    .to.equal('Password must be supplied');
-            });
+            expect(find(testSelector('password-error')).text().trim(), 'empty password error')
+                .to.equal('Password must be supplied');
 
-            fillIn(testSelector('password-input'), 'asdfg');
-            triggerEvent(testSelector('password-input'), 'blur');
+            await fillIn(testSelector('password-input'), 'asdfg');
+            await triggerEvent(testSelector('password-input'), 'blur');
 
-            andThen(() => {
-                expect(find(testSelector('password-error')).text().trim(), 'present password error')
-                    .to.equal('');
-            });
+            expect(find(testSelector('password-error')).text().trim(), 'present password error')
+                .to.equal('');
         });
 
-        it('handles social blog settings correctly', function () {
-            visit('/settings/general');
-            click(testSelector('toggle-social'));
+        it('handles social blog settings correctly', async function () {
+            await visit('/settings/general');
+            await click(testSelector('toggle-social'));
 
             // validates a facebook url correctly
-            andThen(() => {
-                // loads fixtures and performs transform
-                expect(find(testSelector('facebook-input')).val(), 'initial facebook value')
-                    .to.equal('https://www.facebook.com/test');
-            });
+            // loads fixtures and performs transform
+            expect(find(testSelector('facebook-input')).val(), 'initial facebook value')
+                .to.equal('https://www.facebook.com/test');
 
-            triggerEvent(testSelector('facebook-input'), 'focus');
-            triggerEvent(testSelector('facebook-input'), 'blur');
+            await triggerEvent(testSelector('facebook-input'), 'focus');
+            await triggerEvent(testSelector('facebook-input'), 'blur');
 
-            andThen(() => {
-                // regression test: we still have a value after the input is
-                // focused and then blurred without any changes
-                expect(find(testSelector('facebook-input')).val(), 'facebook value after blur with no change')
-                    .to.equal('https://www.facebook.com/test');
-            });
+            // regression test: we still have a value after the input is
+            // focused and then blurred without any changes
+            expect(find(testSelector('facebook-input')).val(), 'facebook value after blur with no change')
+                .to.equal('https://www.facebook.com/test');
 
-            fillIn(testSelector('facebook-input'), 'facebook.com/username');
-            triggerEvent(testSelector('facebook-input'), 'blur');
+            await fillIn(testSelector('facebook-input'), 'facebook.com/username');
+            await triggerEvent(testSelector('facebook-input'), 'blur');
 
-            andThen(() => {
-                expect(find(testSelector('facebook-input')).val()).to.be.equal('https://www.facebook.com/username');
-                expect(find(testSelector('facebook-error')).text().trim(), 'inline validation response')
-                    .to.equal('');
-            });
+            expect(find(testSelector('facebook-input')).val()).to.be.equal('https://www.facebook.com/username');
+            expect(find(testSelector('facebook-error')).text().trim(), 'inline validation response')
+                .to.equal('');
 
-            fillIn(testSelector('facebook-input'), 'facebook.com/pages/some-facebook-page/857469375913?ref=ts');
-            triggerEvent(testSelector('facebook-input'), 'blur');
+            await fillIn(testSelector('facebook-input'), 'facebook.com/pages/some-facebook-page/857469375913?ref=ts');
+            await triggerEvent(testSelector('facebook-input'), 'blur');
 
-            andThen(() => {
-                expect(find(testSelector('facebook-input')).val()).to.be.equal('https://www.facebook.com/pages/some-facebook-page/857469375913?ref=ts');
-                expect(find(testSelector('facebook-error')).text().trim(), 'inline validation response')
-                    .to.equal('');
-            });
+            expect(find(testSelector('facebook-input')).val()).to.be.equal('https://www.facebook.com/pages/some-facebook-page/857469375913?ref=ts');
+            expect(find(testSelector('facebook-error')).text().trim(), 'inline validation response')
+                .to.equal('');
 
-            fillIn(testSelector('facebook-input'), '*(&*(%%))');
-            triggerEvent(testSelector('facebook-input'), 'blur');
+            await fillIn(testSelector('facebook-input'), '*(&*(%%))');
+            await triggerEvent(testSelector('facebook-input'), 'blur');
 
-            andThen(() => {
-                expect(find(testSelector('facebook-error')).text().trim(), 'inline validation response')
-                    .to.equal('The URL must be in a format like https://www.facebook.com/yourPage');
-            });
+            expect(find(testSelector('facebook-error')).text().trim(), 'inline validation response')
+                .to.equal('The URL must be in a format like https://www.facebook.com/yourPage');
 
-            fillIn(testSelector('facebook-input'), 'http://github.com/username');
-            triggerEvent(testSelector('facebook-input'), 'blur');
+            await fillIn(testSelector('facebook-input'), 'http://github.com/username');
+            await triggerEvent(testSelector('facebook-input'), 'blur');
 
-            andThen(() => {
-                expect(find(testSelector('facebook-input')).val()).to.be.equal('https://www.facebook.com/username');
-                expect(find(testSelector('facebook-error')).text().trim(), 'inline validation response')
-                    .to.equal('');
-            });
+            expect(find(testSelector('facebook-input')).val()).to.be.equal('https://www.facebook.com/username');
+            expect(find(testSelector('facebook-error')).text().trim(), 'inline validation response')
+                .to.equal('');
 
-            fillIn(testSelector('facebook-input'), 'http://github.com/pages/username');
-            triggerEvent(testSelector('facebook-input'), 'blur');
+            await fillIn(testSelector('facebook-input'), 'http://github.com/pages/username');
+            await triggerEvent(testSelector('facebook-input'), 'blur');
 
-            andThen(() => {
-                expect(find(testSelector('facebook-input')).val()).to.be.equal('https://www.facebook.com/pages/username');
-                expect(find(testSelector('facebook-error')).text().trim(), 'inline validation response')
-                    .to.equal('');
-            });
+            expect(find(testSelector('facebook-input')).val()).to.be.equal('https://www.facebook.com/pages/username');
+            expect(find(testSelector('facebook-error')).text().trim(), 'inline validation response')
+                .to.equal('');
 
-            fillIn(testSelector('facebook-input'), 'testuser');
-            triggerEvent(testSelector('facebook-input'), 'blur');
+            await fillIn(testSelector('facebook-input'), 'testuser');
+            await triggerEvent(testSelector('facebook-input'), 'blur');
 
-            andThen(() => {
-                expect(find(testSelector('facebook-input')).val()).to.be.equal('https://www.facebook.com/testuser');
-                expect(find(testSelector('facebook-error')).text().trim(), 'inline validation response')
-                    .to.equal('');
-            });
+            expect(find(testSelector('facebook-input')).val()).to.be.equal('https://www.facebook.com/testuser');
+            expect(find(testSelector('facebook-error')).text().trim(), 'inline validation response')
+                .to.equal('');
 
-            fillIn(testSelector('facebook-input'), 'ab99');
-            triggerEvent(testSelector('facebook-input'), 'blur');
+            await fillIn(testSelector('facebook-input'), 'ab99');
+            await triggerEvent(testSelector('facebook-input'), 'blur');
 
-            andThen(() => {
-                expect(find(testSelector('facebook-error')).text().trim(), 'inline validation response')
-                    .to.equal('Your Page name is not a valid Facebook Page name');
-            });
+            expect(find(testSelector('facebook-error')).text().trim(), 'inline validation response')
+                .to.equal('Your Page name is not a valid Facebook Page name');
 
-            fillIn(testSelector('facebook-input'), 'page/ab99');
-            triggerEvent(testSelector('facebook-input'), 'blur');
+            await fillIn(testSelector('facebook-input'), 'page/ab99');
+            await triggerEvent(testSelector('facebook-input'), 'blur');
 
-            andThen(() => {
-                expect(find(testSelector('facebook-input')).val()).to.be.equal('https://www.facebook.com/page/ab99');
-                expect(find(testSelector('facebook-error')).text().trim(), 'inline validation response')
-                    .to.equal('');
-            });
+            expect(find(testSelector('facebook-input')).val()).to.be.equal('https://www.facebook.com/page/ab99');
+            expect(find(testSelector('facebook-error')).text().trim(), 'inline validation response')
+                .to.equal('');
 
-            fillIn(testSelector('facebook-input'), 'page/*(&*(%%))');
-            triggerEvent(testSelector('facebook-input'), 'blur');
+            await fillIn(testSelector('facebook-input'), 'page/*(&*(%%))');
+            await triggerEvent(testSelector('facebook-input'), 'blur');
 
-            andThen(() => {
-                expect(find(testSelector('facebook-input')).val()).to.be.equal('https://www.facebook.com/page/*(&*(%%))');
-                expect(find(testSelector('facebook-error')).text().trim(), 'inline validation response')
-                    .to.equal('');
-            });
+            expect(find(testSelector('facebook-input')).val()).to.be.equal('https://www.facebook.com/page/*(&*(%%))');
+            expect(find(testSelector('facebook-error')).text().trim(), 'inline validation response')
+                .to.equal('');
 
             // validates a twitter url correctly
 
-            andThen(() => {
-                // loads fixtures and performs transform
-                expect(find(testSelector('twitter-input')).val(), 'initial twitter value')
-                    .to.equal('https://twitter.com/test');
-            });
+            // loads fixtures and performs transform
+            expect(find(testSelector('twitter-input')).val(), 'initial twitter value')
+                .to.equal('https://twitter.com/test');
 
-            triggerEvent(testSelector('twitter-input'), 'focus');
-            triggerEvent(testSelector('twitter-input'), 'blur');
+            await triggerEvent(testSelector('twitter-input'), 'focus');
+            await triggerEvent(testSelector('twitter-input'), 'blur');
 
-            andThen(() => {
-                // regression test: we still have a value after the input is
-                // focused and then blurred without any changes
-                expect(find(testSelector('twitter-input')).val(), 'twitter value after blur with no change')
-                    .to.equal('https://twitter.com/test');
-            });
+            // regression test: we still have a value after the input is
+            // focused and then blurred without any changes
+            expect(find(testSelector('twitter-input')).val(), 'twitter value after blur with no change')
+                .to.equal('https://twitter.com/test');
 
-            fillIn(testSelector('twitter-input'), 'twitter.com/username');
-            triggerEvent(testSelector('twitter-input'), 'blur');
+            await fillIn(testSelector('twitter-input'), 'twitter.com/username');
+            await triggerEvent(testSelector('twitter-input'), 'blur');
 
-            andThen(() => {
-                expect(find(testSelector('twitter-input')).val()).to.be.equal('https://twitter.com/username');
-                expect(find(testSelector('twitter-error')).text().trim(), 'inline validation response')
-                    .to.equal('');
-            });
+            expect(find(testSelector('twitter-input')).val()).to.be.equal('https://twitter.com/username');
+            expect(find(testSelector('twitter-error')).text().trim(), 'inline validation response')
+                .to.equal('');
 
-            fillIn(testSelector('twitter-input'), '*(&*(%%))');
-            triggerEvent(testSelector('twitter-input'), 'blur');
+            await fillIn(testSelector('twitter-input'), '*(&*(%%))');
+            await triggerEvent(testSelector('twitter-input'), 'blur');
 
-            andThen(() => {
-                expect(find(testSelector('twitter-error')).text().trim(), 'inline validation response')
-                    .to.equal('The URL must be in a format like https://twitter.com/yourUsername');
-            });
+            expect(find(testSelector('twitter-error')).text().trim(), 'inline validation response')
+                .to.equal('The URL must be in a format like https://twitter.com/yourUsername');
 
-            fillIn(testSelector('twitter-input'), 'http://github.com/username');
-            triggerEvent(testSelector('twitter-input'), 'blur');
+            await fillIn(testSelector('twitter-input'), 'http://github.com/username');
+            await triggerEvent(testSelector('twitter-input'), 'blur');
 
-            andThen(() => {
-                expect(find(testSelector('twitter-input')).val()).to.be.equal('https://twitter.com/username');
-                expect(find(testSelector('twitter-error')).text().trim(), 'inline validation response')
-                    .to.equal('');
-            });
+            expect(find(testSelector('twitter-input')).val()).to.be.equal('https://twitter.com/username');
+            expect(find(testSelector('twitter-error')).text().trim(), 'inline validation response')
+                .to.equal('');
 
-            fillIn(testSelector('twitter-input'), 'thisusernamehasmorethan15characters');
-            triggerEvent(testSelector('twitter-input'), 'blur');
+            await fillIn(testSelector('twitter-input'), 'thisusernamehasmorethan15characters');
+            await triggerEvent(testSelector('twitter-input'), 'blur');
 
-            andThen(() => {
-                expect(find(testSelector('twitter-error')).text().trim(), 'inline validation response')
-                    .to.equal('Your Username is not a valid Twitter Username');
-            });
+            expect(find(testSelector('twitter-error')).text().trim(), 'inline validation response')
+                .to.equal('Your Username is not a valid Twitter Username');
 
-            fillIn(testSelector('twitter-input'), 'testuser');
-            triggerEvent(testSelector('twitter-input'), 'blur');
+            await fillIn(testSelector('twitter-input'), 'testuser');
+            await triggerEvent(testSelector('twitter-input'), 'blur');
 
-            andThen(() => {
-                expect(find(testSelector('twitter-input')).val()).to.be.equal('https://twitter.com/testuser');
-                expect(find(testSelector('twitter-error')).text().trim(), 'inline validation response')
-                    .to.equal('');
-            });
+            expect(find(testSelector('twitter-input')).val()).to.be.equal('https://twitter.com/testuser');
+            expect(find(testSelector('twitter-error')).text().trim(), 'inline validation response')
+                .to.equal('');
         });
     });
 });

--- a/tests/acceptance/settings/labs-test.js
+++ b/tests/acceptance/settings/labs-test.js
@@ -22,37 +22,31 @@ describe('Acceptance: Settings - Labs', function() {
         destroyApp(application);
     });
 
-    it('redirects to signin when not authenticated', function () {
+    it('redirects to signin when not authenticated', async function () {
         invalidateSession(application);
-        visit('/settings/labs');
+        await visit('/settings/labs');
 
-        andThen(function() {
-            expect(currentURL(), 'currentURL').to.equal('/signin');
-        });
+        expect(currentURL(), 'currentURL').to.equal('/signin');
     });
 
-    it('redirects to team page when authenticated as author', function () {
+    it('redirects to team page when authenticated as author', async function () {
         let role = server.create('role', {name: 'Author'});
         server.create('user', {roles: [role], slug: 'test-user'});
 
         authenticateSession(application);
-        visit('/settings/labs');
+        await visit('/settings/labs');
 
-        andThen(() => {
-            expect(currentURL(), 'currentURL').to.equal('/team/test-user');
-        });
+        expect(currentURL(), 'currentURL').to.equal('/team/test-user');
     });
 
-    it('redirects to team page when authenticated as editor', function () {
+    it('redirects to team page when authenticated as editor', async function () {
         let role = server.create('role', {name: 'Editor'});
         server.create('user', {roles: [role], slug: 'test-user'});
 
         authenticateSession(application);
-        visit('/settings/labs');
+        await visit('/settings/labs');
 
-        andThen(() => {
-            expect(currentURL(), 'currentURL').to.equal('/team');
-        });
+        expect(currentURL(), 'currentURL').to.equal('/team');
     });
 
     describe('when logged in', function () {
@@ -63,32 +57,24 @@ describe('Acceptance: Settings - Labs', function() {
             return authenticateSession(application);
         });
 
-        it.skip('it renders, loads modals correctly', function () {
-            visit('/settings/labs');
+        it.skip('it renders, loads modals correctly', async function () {
+            await visit('/settings/labs');
 
-            andThen(() => {
-                // has correct url
-                expect(currentURL(), 'currentURL').to.equal('/settings/labs');
+            // has correct url
+            expect(currentURL(), 'currentURL').to.equal('/settings/labs');
 
-                // has correct page title
-                expect(document.title, 'page title').to.equal('Settings - Labs - Test Blog');
+            // has correct page title
+            expect(document.title, 'page title').to.equal('Settings - Labs - Test Blog');
 
-                // highlights nav menu
-                expect($('.gh-nav-settings-labs').hasClass('active'), 'highlights nav menu item')
-                    .to.be.true;
-            });
+            // highlights nav menu
+            expect($('.gh-nav-settings-labs').hasClass('active'), 'highlights nav menu item')
+                .to.be.true;
 
-            click('#settings-resetdb .js-delete');
+            await click('#settings-resetdb .js-delete');
+            expect(find('.fullscreen-modal .modal-content').length, 'modal element').to.equal(1);
 
-            andThen(() => {
-                expect(find('.fullscreen-modal .modal-content').length, 'modal element').to.equal(1);
-            });
-
-            click('.fullscreen-modal .modal-footer .gh-btn');
-
-            andThen(() => {
-                expect(find('.fullscreen-modal').length, 'modal element').to.equal(0);
-            });
+            await click('.fullscreen-modal .modal-footer .gh-btn');
+            expect(find('.fullscreen-modal').length, 'modal element').to.equal(0);
         });
     });
 });

--- a/tests/acceptance/settings/tags-test.js
+++ b/tests/acceptance/settings/tags-test.js
@@ -53,25 +53,21 @@ describe('Acceptance: Settings - Tags', function () {
         destroyApp(application);
     });
 
-    it('redirects to signin when not authenticated', function () {
+    it('redirects to signin when not authenticated', async function () {
         invalidateSession(application);
-        visit('/settings/tags');
+        await visit('/settings/tags');
 
-        andThen(() => {
-            expect(currentURL()).to.equal('/signin');
-        });
+        expect(currentURL()).to.equal('/signin');
     });
 
-    it('redirects to team page when authenticated as author', function () {
+    it('redirects to team page when authenticated as author', async function () {
         let role = server.create('role', {name: 'Author'});
         server.create('user', {roles: [role], slug: 'test-user'});
 
         authenticateSession(application);
-        visit('/settings/design');
+        await visit('/settings/design');
 
-        andThen(() => {
-            expect(currentURL(), 'currentURL').to.equal('/team/test-user');
-        });
+        expect(currentURL(), 'currentURL').to.equal('/team/test-user');
     });
 
     describe('when logged in', function () {
@@ -82,240 +78,208 @@ describe('Acceptance: Settings - Tags', function () {
             return authenticateSession(application);
         });
 
-        it('it renders, can be navigated, can edit, create & delete tags', function () {
+        it('it renders, can be navigated, can edit, create & delete tags', async function () {
             let tag1 = server.create('tag');
             let tag2 = server.create('tag');
 
-            visit('/settings/tags');
+            await visit('/settings/tags');
 
-            andThen(() => {
-                // it redirects to first tag
-                expect(currentURL(), 'currentURL').to.equal(`/settings/tags/${tag1.slug}`);
+            // it redirects to first tag
+            expect(currentURL(), 'currentURL').to.equal(`/settings/tags/${tag1.slug}`);
 
-                // it has correct page title
-                expect(document.title, 'page title').to.equal('Settings - Tags - Test Blog');
+            // it has correct page title
+            expect(document.title, 'page title').to.equal('Settings - Tags - Test Blog');
 
-                // it highlights nav menu
-                expect($('.gh-nav-settings-tags').hasClass('active'), 'highlights nav menu item')
-                    .to.be.true;
+            // it highlights nav menu
+            expect($('.gh-nav-settings-tags').hasClass('active'), 'highlights nav menu item')
+                .to.be.true;
 
-                // it lists all tags
-                expect(find('.settings-tags .settings-tag').length, 'tag list count')
-                    .to.equal(2);
-                expect(find('.settings-tags .settings-tag:first .tag-title').text(), 'tag list item title')
-                    .to.equal(tag1.name);
+            // it lists all tags
+            expect(find('.settings-tags .settings-tag').length, 'tag list count')
+                .to.equal(2);
+            expect(find('.settings-tags .settings-tag:first .tag-title').text(), 'tag list item title')
+                .to.equal(tag1.name);
 
-                // it highlights selected tag
-                expect(find(`a[href="/ghost/settings/tags/${tag1.slug}"]`).hasClass('active'), 'highlights selected tag')
-                    .to.be.true;
+            // it highlights selected tag
+            expect(find(`a[href="/ghost/settings/tags/${tag1.slug}"]`).hasClass('active'), 'highlights selected tag')
+                .to.be.true;
 
-                // it shows selected tag form
-                expect(find('.tag-settings-pane h4').text(), 'settings pane title')
-                    .to.equal('Tag Settings');
-                expect(find('.tag-settings-pane input[name="name"]').val(), 'loads correct tag into form')
-                    .to.equal(tag1.name);
-            });
+            // it shows selected tag form
+            expect(find('.tag-settings-pane h4').text(), 'settings pane title')
+                .to.equal('Tag Settings');
+            expect(find('.tag-settings-pane input[name="name"]').val(), 'loads correct tag into form')
+                .to.equal(tag1.name);
 
             // click the second tag in the list
-            click('.tag-edit-button:last');
+            await click('.tag-edit-button:last');
 
-            andThen(() => {
-                // it navigates to selected tag
-                expect(currentURL(), 'url after clicking tag').to.equal(`/settings/tags/${tag2.slug}`);
+            // it navigates to selected tag
+            expect(currentURL(), 'url after clicking tag').to.equal(`/settings/tags/${tag2.slug}`);
 
-                // it highlights selected tag
-                expect(find(`a[href="/ghost/settings/tags/${tag2.slug}"]`).hasClass('active'), 'highlights selected tag')
-                    .to.be.true;
+            // it highlights selected tag
+            expect(find(`a[href="/ghost/settings/tags/${tag2.slug}"]`).hasClass('active'), 'highlights selected tag')
+                .to.be.true;
 
-                // it shows selected tag form
-                expect(find('.tag-settings-pane input[name="name"]').val(), 'loads correct tag into form')
-                    .to.equal(tag2.name);
+            // it shows selected tag form
+            expect(find('.tag-settings-pane input[name="name"]').val(), 'loads correct tag into form')
+                .to.equal(tag2.name);
+
+            // simulate up arrow press
+            run(() => {
+                keydown(38);
+                keyup(38);
             });
 
-            andThen(() => {
-                // simulate up arrow press
-                run(() => {
-                    keydown(38);
-                    keyup(38);
-                });
+            // it navigates to previous tag
+            expect(currentURL(), 'url after keyboard up arrow').to.equal(`/settings/tags/${tag1.slug}`);
+
+            // it highlights selected tag
+            expect(find(`a[href="/ghost/settings/tags/${tag1.slug}"]`).hasClass('active'), 'selects previous tag')
+                .to.be.true;
+
+            // simulate down arrow press
+            run(() => {
+                keydown(40);
+                keyup(40);
             });
 
-            andThen(() => {
-                // it navigates to previous tag
-                expect(currentURL(), 'url after keyboard up arrow').to.equal(`/settings/tags/${tag1.slug}`);
+            // it navigates to previous tag
+            expect(currentURL(), 'url after keyboard down arrow').to.equal(`/settings/tags/${tag2.slug}`);
 
-                // it highlights selected tag
-                expect(find(`a[href="/ghost/settings/tags/${tag1.slug}"]`).hasClass('active'), 'selects previous tag')
-                    .to.be.true;
-            });
-
-            andThen(() => {
-                // simulate down arrow press
-                run(() => {
-                    keydown(40);
-                    keyup(40);
-                });
-            });
-
-            andThen(() => {
-                // it navigates to previous tag
-                expect(currentURL(), 'url after keyboard down arrow').to.equal(`/settings/tags/${tag2.slug}`);
-
-                // it highlights selected tag
-                expect(find(`a[href="/ghost/settings/tags/${tag2.slug}"]`).hasClass('active'), 'selects next tag')
-                    .to.be.true;
-            });
+            // it highlights selected tag
+            expect(find(`a[href="/ghost/settings/tags/${tag2.slug}"]`).hasClass('active'), 'selects next tag')
+                .to.be.true;
 
             // trigger save
-            fillIn('.tag-settings-pane input[name="name"]', 'New Name');
-            triggerEvent('.tag-settings-pane input[name="name"]', 'blur');
-            andThen(() => {
-                // check we update with the data returned from the server
-                expect(find('.settings-tags .settings-tag:last .tag-title').text(), 'tag list updates on save')
-                    .to.equal('New Name');
-                expect(find('.tag-settings-pane input[name="name"]').val(), 'settings form updates on save')
-                    .to.equal('New Name');
-            });
+            await fillIn('.tag-settings-pane input[name="name"]', 'New Name');
+            await triggerEvent('.tag-settings-pane input[name="name"]', 'blur');
+
+            // check we update with the data returned from the server
+            expect(find('.settings-tags .settings-tag:last .tag-title').text(), 'tag list updates on save')
+                .to.equal('New Name');
+            expect(find('.tag-settings-pane input[name="name"]').val(), 'settings form updates on save')
+                .to.equal('New Name');
 
             // start new tag
-            click('.view-actions .gh-btn-green');
+            await click('.view-actions .gh-btn-green');
 
-            andThen(() => {
-                // it navigates to the new tag route
-                expect(currentURL(), 'new tag URL').to.equal('/settings/tags/new');
+            // it navigates to the new tag route
+            expect(currentURL(), 'new tag URL').to.equal('/settings/tags/new');
 
-                // it displays the new tag form
-                expect(find('.tag-settings-pane h4').text(), 'settings pane title')
-                    .to.equal('New Tag');
+            // it displays the new tag form
+            expect(find('.tag-settings-pane h4').text(), 'settings pane title')
+                .to.equal('New Tag');
 
-                // all fields start blank
-                find('.tag-settings-pane input, .tag-settings-pane textarea').each(function () {
-                    expect($(this).val(), `input field for ${$(this).attr('name')}`)
-                        .to.be.blank;
-                });
+            // all fields start blank
+            find('.tag-settings-pane input, .tag-settings-pane textarea').each(function () {
+                expect($(this).val(), `input field for ${$(this).attr('name')}`)
+                    .to.be.blank;
             });
 
             // save new tag
-            fillIn('.tag-settings-pane input[name="name"]', 'New Tag');
-            triggerEvent('.tag-settings-pane input[name="name"]', 'blur');
+            await fillIn('.tag-settings-pane input[name="name"]', 'New Tag');
+            await triggerEvent('.tag-settings-pane input[name="name"]', 'blur');
 
-            andThen(() => {
-                // it redirects to the new tag's URL
-                expect(currentURL(), 'URL after tag creation').to.equal('/settings/tags/new-tag');
+            // it redirects to the new tag's URL
+            expect(currentURL(), 'URL after tag creation').to.equal('/settings/tags/new-tag');
 
-                // it adds the tag to the list and selects
-                expect(find('.settings-tags .settings-tag').length, 'tag list count after creation')
-                    .to.equal(3);
-                expect(find('.settings-tags .settings-tag:last .tag-title').text(), 'new tag list item title')
-                    .to.equal('New Tag');
-                expect(find('a[href="/ghost/settings/tags/new-tag"]').hasClass('active'), 'highlights new tag')
-                    .to.be.true;
-            });
+            // it adds the tag to the list and selects
+            expect(find('.settings-tags .settings-tag').length, 'tag list count after creation')
+                .to.equal(3);
+            expect(find('.settings-tags .settings-tag:last .tag-title').text(), 'new tag list item title')
+                .to.equal('New Tag');
+            expect(find('a[href="/ghost/settings/tags/new-tag"]').hasClass('active'), 'highlights new tag')
+                .to.be.true;
 
             // delete tag
-            click('.settings-menu-delete-button');
-            click('.fullscreen-modal .gh-btn-red');
+            await click('.settings-menu-delete-button');
+            await click('.fullscreen-modal .gh-btn-red');
 
-            andThen(() => {
-                // it redirects to the first tag
-                expect(currentURL(), 'URL after tag deletion').to.equal(`/settings/tags/${tag1.slug}`);
+            // it redirects to the first tag
+            expect(currentURL(), 'URL after tag deletion').to.equal(`/settings/tags/${tag1.slug}`);
 
-                // it removes the tag from the list
-                expect(find('.settings-tags .settings-tag').length, 'tag list count after deletion')
-                    .to.equal(2);
-            });
+            // it removes the tag from the list
+            expect(find('.settings-tags .settings-tag').length, 'tag list count after deletion')
+                .to.equal(2);
         });
 
-        it('loads tag via slug when accessed directly', function () {
+        it('loads tag via slug when accessed directly', async function () {
             server.createList('tag', 2);
 
-            visit('/settings/tags/tag-1');
+            await visit('/settings/tags/tag-1');
 
-            andThen(() => {
-                expect(currentURL(), 'URL after direct load').to.equal('/settings/tags/tag-1');
+            expect(currentURL(), 'URL after direct load').to.equal('/settings/tags/tag-1');
 
-                // it loads all other tags
-                expect(find('.settings-tags .settings-tag').length, 'tag list count after direct load')
-                    .to.equal(2);
+            // it loads all other tags
+            expect(find('.settings-tags .settings-tag').length, 'tag list count after direct load')
+                .to.equal(2);
 
-                // selects tag in list
-                expect(find('a[href="/ghost/settings/tags/tag-1"]').hasClass('active'), 'highlights requested tag')
-                    .to.be.true;
+            // selects tag in list
+            expect(find('a[href="/ghost/settings/tags/tag-1"]').hasClass('active'), 'highlights requested tag')
+                .to.be.true;
 
-                // shows requested tag in settings pane
-                expect(find('.tag-settings-pane input[name="name"]').val(), 'loads correct tag into form')
-                    .to.equal('Tag 1');
-            });
+            // shows requested tag in settings pane
+            expect(find('.tag-settings-pane input[name="name"]').val(), 'loads correct tag into form')
+                .to.equal('Tag 1');
         });
 
-        it('has infinite scroll pagination of tags list', function () {
+        it('has infinite scroll pagination of tags list', async function () {
             server.createList('tag', 32);
 
-            visit('settings/tags/tag-0');
+            await visit('settings/tags/tag-0');
 
-            andThen(() => {
-                // it loads first page
-                expect(find('.settings-tags .settings-tag').length, 'tag list count on first load')
-                    .to.equal(15);
+            // it loads first page
+            expect(find('.settings-tags .settings-tag').length, 'tag list count on first load')
+                .to.equal(15);
 
-                find('.tag-list').scrollTop(find('.tag-list-content').height());
-            });
+            await find('.tag-list').scrollTop(find('.tag-list-content').height());
+            await triggerEvent('.tag-list', 'scroll');
 
-            triggerEvent('.tag-list', 'scroll');
+            // it loads the second page
+            expect(find('.settings-tags .settings-tag').length, 'tag list count on second load')
+                .to.equal(30);
 
-            andThen(() => {
-                // it loads the second page
-                expect(find('.settings-tags .settings-tag').length, 'tag list count on second load')
-                    .to.equal(30);
-
-                find('.tag-list').scrollTop(find('.tag-list-content').height());
-            });
+            await find('.tag-list').scrollTop(find('.tag-list-content').height());
 
             // NOTE: FF has issues with scrolling further in acceptance tests
             // but works fine outside of tests
             //
-            // triggerEvent('.tag-list', 'scroll');
+            // await triggerEvent('.tag-list', 'scroll');
             //
-            // andThen(() => {
-            //     // it loads the final page
-            //     expect(find('.settings-tags .settings-tag').length, 'tag list count on third load')
-            //         .to.equal(32);
-            // });
+            // // it loads the final page
+            // expect(find('.settings-tags .settings-tag').length, 'tag list count on third load')
+            //     .to.equal(32);
         });
 
-        it('shows the internal tag label', function () {
+        it('shows the internal tag label', async function () {
             server.create('tag', {name: '#internal-tag', slug: 'hash-internal-tag', visibility: 'internal'});
 
-            visit('settings/tags/');
+            await visit('settings/tags/');
 
-            andThen(() => {
-                expect(currentURL()).to.equal('/settings/tags/hash-internal-tag');
+            expect(currentURL()).to.equal('/settings/tags/hash-internal-tag');
 
-                expect(find('.settings-tags .settings-tag').length, 'tag list count')
-                    .to.equal(1);
+            expect(find('.settings-tags .settings-tag').length, 'tag list count')
+                .to.equal(1);
 
-                expect(find('.settings-tags .settings-tag:first .label.label-blue').length, 'internal tag label')
-                    .to.equal(1);
+            expect(find('.settings-tags .settings-tag:first .label.label-blue').length, 'internal tag label')
+                .to.equal(1);
 
-                expect(find('.settings-tags .settings-tag:first .label.label-blue').text().trim(), 'internal tag label text')
-                    .to.equal('internal');
-            });
+            expect(find('.settings-tags .settings-tag:first .label.label-blue').text().trim(), 'internal tag label text')
+                .to.equal('internal');
         });
 
-        it('redirects to 404 when tag does not exist', function () {
+        it('redirects to 404 when tag does not exist', async function () {
             server.get('/tags/slug/unknown/', function () {
                 return new Response(404, {'Content-Type': 'application/json'}, {errors: [{message: 'Tag not found.', errorType: 'NotFoundError'}]});
             });
 
             errorOverride();
 
-            visit('settings/tags/unknown');
+            await visit('settings/tags/unknown');
 
-            andThen(() => {
-                errorReset();
-                expect(currentPath()).to.equal('error404');
-                expect(currentURL()).to.equal('/settings/tags/unknown');
-            });
+            errorReset();
+            expect(currentPath()).to.equal('error404');
+            expect(currentURL()).to.equal('/settings/tags/unknown');
         });
     });
 });

--- a/tests/acceptance/signup-test.js
+++ b/tests/acceptance/signup-test.js
@@ -25,7 +25,7 @@ describe('Acceptance: Signup', function() {
         destroyApp(application);
     });
 
-    it('can signup successfully', function() {
+    it('can signup successfully', async function() {
         server.get('/authentication/invitation', function () {
             return {
                 invitation: [{valid: true}]
@@ -52,91 +52,79 @@ describe('Acceptance: Signup', function() {
 
         // token details:
         // "1470346017929|kevin+test2@ghost.org|2cDnQc3g7fQTj9nNK4iGPSGfvomkLdXf68FuWgS66Ug="
-        visit('/signup/MTQ3MDM0NjAxNzkyOXxrZXZpbit0ZXN0MkBnaG9zdC5vcmd8MmNEblFjM2c3ZlFUajluTks0aUdQU0dmdm9ta0xkWGY2OEZ1V2dTNjZVZz0');
+        await visit('/signup/MTQ3MDM0NjAxNzkyOXxrZXZpbit0ZXN0MkBnaG9zdC5vcmd8MmNEblFjM2c3ZlFUajluTks0aUdQU0dmdm9ta0xkWGY2OEZ1V2dTNjZVZz0');
 
-        andThen(function () {
-            expect(currentPath()).to.equal('signup');
+        expect(currentPath()).to.equal('signup');
 
-            // email address should be pre-filled and disabled
-            expect(
-                find('input[name="email"]').val(),
-                'email field value'
-            ).to.equal('kevin+test2@ghost.org');
+        // email address should be pre-filled and disabled
+        expect(
+            find('input[name="email"]').val(),
+            'email field value'
+        ).to.equal('kevin+test2@ghost.org');
 
-            expect(
-                find('input[name="email"]').is(':disabled'),
-                'email field is disabled'
-            ).to.be.true;
-        });
+        expect(
+            find('input[name="email"]').is(':disabled'),
+            'email field is disabled'
+        ).to.be.true;
 
         // focus out in Name field triggers inline error
-        triggerEvent('input[name="name"]', 'blur');
+        await triggerEvent('input[name="name"]', 'blur');
 
-        andThen(function () {
-            expect(
-                find('input[name="name"]').closest('.form-group').hasClass('error'),
-                'name field group has error class when empty'
-            ).to.be.true;
+        expect(
+            find('input[name="name"]').closest('.form-group').hasClass('error'),
+            'name field group has error class when empty'
+        ).to.be.true;
 
-            expect(
-                find('input[name="name"]').closest('.form-group').find('.response').text().trim(),
-                'name inline-error text'
-            ).to.match(/Please enter a name/);
-        });
+        expect(
+            find('input[name="name"]').closest('.form-group').find('.response').text().trim(),
+            'name inline-error text'
+        ).to.match(/Please enter a name/);
 
         // entering text in Name field clears error
-        fillIn('input[name="name"]', 'Test User');
-        triggerEvent('input[name="name"]', 'blur');
+        await fillIn('input[name="name"]', 'Test User');
+        await triggerEvent('input[name="name"]', 'blur');
 
-        andThen(function () {
-            expect(
-                find('input[name="name"]').closest('.form-group').hasClass('error'),
-                'name field loses error class after text input'
-            ).to.be.false;
+        expect(
+            find('input[name="name"]').closest('.form-group').hasClass('error'),
+            'name field loses error class after text input'
+        ).to.be.false;
 
-            expect(
-                find('input[name="name"]').closest('.form-group').find('.response').text().trim(),
-                'name field error is removed after text input'
-            ).to.equal('');
-        });
+        expect(
+            find('input[name="name"]').closest('.form-group').find('.response').text().trim(),
+            'name field error is removed after text input'
+        ).to.equal('');
 
         // focus out in Name field triggers inline error
-        triggerEvent('input[name="password"]', 'blur');
+        await triggerEvent('input[name="password"]', 'blur');
 
-        andThen(function () {
-            expect(
-                find('input[name="password"]').closest('.form-group').hasClass('error'),
-                'password field group has error class when empty'
-            ).to.be.true;
+        expect(
+            find('input[name="password"]').closest('.form-group').hasClass('error'),
+            'password field group has error class when empty'
+        ).to.be.true;
 
-            expect(
-                find('input[name="password"]').closest('.form-group').find('.response').text().trim(),
-                'password field error text'
-            ).to.match(/must be at least 8 characters/);
-        });
+        expect(
+            find('input[name="password"]').closest('.form-group').find('.response').text().trim(),
+            'password field error text'
+        ).to.match(/must be at least 8 characters/);
 
         // entering valid text in Password field clears error
-        fillIn('input[name="password"]', 'ValidPassword');
-        triggerEvent('input[name="password"]', 'blur');
+        await fillIn('input[name="password"]', 'ValidPassword');
+        await triggerEvent('input[name="password"]', 'blur');
 
-        andThen(function () {
-            expect(
-                find('input[name="password"]').closest('.form-group').hasClass('error'),
-                'password field loses error class after text input'
-            ).to.be.false;
+        expect(
+            find('input[name="password"]').closest('.form-group').hasClass('error'),
+            'password field loses error class after text input'
+        ).to.be.false;
 
-            expect(
-                find('input[name="password"]').closest('.form-group').find('.response').text().trim(),
-                'password field error is removed after text input'
-            ).to.equal('');
-        });
+        expect(
+            find('input[name="password"]').closest('.form-group').find('.response').text().trim(),
+            'password field error is removed after text input'
+        ).to.equal('');
 
         // submitting sends correct details and redirects to content screen
-        click('.gh-btn-green');
+        await click('.gh-btn-green');
 
-        andThen(function () {
-            expect(currentPath()).to.equal('posts.index');
-        });
+        expect(currentPath()).to.equal('posts.index');
     });
 
     it('redirects if already logged in');
@@ -157,46 +145,40 @@ describe('Acceptance: Signup', function() {
             });
         });
 
-        it('can sign up sucessfully', function () {
+        it('can sign up sucessfully', async function () {
             stubSuccessfulOAuthConnect(application);
 
             // token details:
             // "1470346017929|kevin+test2@ghost.org|2cDnQc3g7fQTj9nNK4iGPSGfvomkLdXf68FuWgS66Ug="
-            visit('/signup/MTQ3MDM0NjAxNzkyOXxrZXZpbit0ZXN0MkBnaG9zdC5vcmd8MmNEblFjM2c3ZlFUajluTks0aUdQU0dmdm9ta0xkWGY2OEZ1V2dTNjZVZz0');
+            await visit('/signup/MTQ3MDM0NjAxNzkyOXxrZXZpbit0ZXN0MkBnaG9zdC5vcmd8MmNEblFjM2c3ZlFUajluTks0aUdQU0dmdm9ta0xkWGY2OEZ1V2dTNjZVZz0');
 
-            andThen(() => {
-                expect(currentPath()).to.equal('signup');
+            expect(currentPath()).to.equal('signup');
 
-                expect(
-                    find('.gh-flow-content header p').text().trim(),
-                    'form header text'
-                ).to.equal('Accept your invite from Test Invite Creator');
-            });
+            expect(
+                find('.gh-flow-content header p').text().trim(),
+                'form header text'
+            ).to.equal('Accept your invite from Test Invite Creator');
 
-            click('button.login');
+            await click('button.login');
 
-            andThen(() => {
-                expect(currentPath()).to.equal('posts.index');
-            });
+            expect(currentPath()).to.equal('posts.index');
         });
 
-        it('handles failed connect', function () {
+        it('handles failed connect', async function () {
             stubFailedOAuthConnect(application);
 
             // token details:
             // "1470346017929|kevin+test2@ghost.org|2cDnQc3g7fQTj9nNK4iGPSGfvomkLdXf68FuWgS66Ug="
-            visit('/signup/MTQ3MDM0NjAxNzkyOXxrZXZpbit0ZXN0MkBnaG9zdC5vcmd8MmNEblFjM2c3ZlFUajluTks0aUdQU0dmdm9ta0xkWGY2OEZ1V2dTNjZVZz0');
+            await visit('/signup/MTQ3MDM0NjAxNzkyOXxrZXZpbit0ZXN0MkBnaG9zdC5vcmd8MmNEblFjM2c3ZlFUajluTks0aUdQU0dmdm9ta0xkWGY2OEZ1V2dTNjZVZz0');
 
-            click('button.login');
+            await click('button.login');
 
-            andThen(() => {
-                expect(currentPath()).to.equal('signup');
+            expect(currentPath()).to.equal('signup');
 
-                expect(
-                    find('.main-error').text().trim(),
-                    'flow error text'
-                ).to.match(/authentication with ghost\.org denied or failed/i);
-            });
+            expect(
+                find('.main-error').text().trim(),
+                'flow error text'
+            ).to.match(/authentication with ghost\.org denied or failed/i);
         });
     });
 });

--- a/tests/acceptance/subscribers-test.js
+++ b/tests/acceptance/subscribers-test.js
@@ -22,41 +22,35 @@ describe('Acceptance: Subscribers', function() {
         destroyApp(application);
     });
 
-    it('redirects to signin when not authenticated', function () {
+    it('redirects to signin when not authenticated', async function () {
         invalidateSession(application);
-        visit('/subscribers');
+        await visit('/subscribers');
 
-        andThen(function () {
-            expect(currentURL()).to.equal('/signin');
-        });
+        expect(currentURL()).to.equal('/signin');
     });
 
-    it('redirects editors to posts', function () {
+    it('redirects editors to posts', async function () {
         let role = server.create('role', {name: 'Editor'});
         server.create('user', {roles: [role]});
 
         authenticateSession(application);
-        visit('/subscribers');
+        await visit('/subscribers');
 
-        andThen(function () {
-            expect(currentURL()).to.equal('/');
-            expect(find('.gh-nav-main a:contains("Subscribers")').length, 'sidebar link is visible')
-                .to.equal(0);
-        });
+        expect(currentURL()).to.equal('/');
+        expect(find('.gh-nav-main a:contains("Subscribers")').length, 'sidebar link is visible')
+            .to.equal(0);
     });
 
-    it('redirects authors to posts', function () {
+    it('redirects authors to posts', async function () {
         let role = server.create('role', {name: 'Author'});
         server.create('user', {roles: [role]});
 
         authenticateSession(application);
-        visit('/subscribers');
+        await visit('/subscribers');
 
-        andThen(function () {
-            expect(currentURL()).to.equal('/');
-            expect(find('.gh-nav-main a:contains("Subscribers")').length, 'sidebar link is visible')
-                .to.equal(0);
-        });
+        expect(currentURL()).to.equal('/');
+        expect(find('.gh-nav-main a:contains("Subscribers")').length, 'sidebar link is visible')
+            .to.equal(0);
     });
 
     describe('an admin', function () {
@@ -67,214 +61,186 @@ describe('Acceptance: Subscribers', function() {
             return authenticateSession(application);
         });
 
-        it('can manage subscribers', function () {
+        it('can manage subscribers', async function () {
             server.createList('subscriber', 40);
 
             authenticateSession(application);
-            visit('/');
-            click('.gh-nav-main a:contains("Subscribers")');
+            await visit('/');
+            await click('.gh-nav-main a:contains("Subscribers")');
 
-            andThen(function() {
-                // it navigates to the correct page
-                expect(currentPath()).to.equal('subscribers.index');
+            // it navigates to the correct page
+            expect(currentPath()).to.equal('subscribers.index');
 
-                // it has correct page title
-                expect(document.title, 'page title')
-                    .to.equal('Subscribers - Test Blog');
+            // it has correct page title
+            expect(document.title, 'page title')
+                .to.equal('Subscribers - Test Blog');
 
-                // it loads the first page
-                expect(find('.subscribers-table .lt-body .lt-row').length, 'number of subscriber rows')
-                    .to.equal(30);
+            // it loads the first page
+            expect(find('.subscribers-table .lt-body .lt-row').length, 'number of subscriber rows')
+                .to.equal(30);
 
-                // it shows the total number of subscribers
-                expect(find(testSelector('total-subscribers')).text().trim(), 'displayed subscribers total')
-                    .to.equal('(40)');
+            // it shows the total number of subscribers
+            expect(find(testSelector('total-subscribers')).text().trim(), 'displayed subscribers total')
+                .to.equal('(40)');
 
-                // it defaults to sorting by created_at desc
-                let [lastRequest] = server.pretender.handledRequests.slice(-1);
-                expect(lastRequest.queryParams.order).to.equal('created_at desc');
+            // it defaults to sorting by created_at desc
+            let [lastRequest] = server.pretender.handledRequests.slice(-1);
+            expect(lastRequest.queryParams.order).to.equal('created_at desc');
 
-                let createdAtHeader = find('.subscribers-table th:contains("Subscription Date")');
-                expect(createdAtHeader.hasClass('is-sorted'), 'createdAt column is sorted')
-                    .to.be.true;
-                expect(createdAtHeader.find('.gh-icon-descending').length, 'createdAt column has descending icon')
-                    .to.equal(1);
-            });
+            let createdAtHeader = find('.subscribers-table th:contains("Subscription Date")');
+            expect(createdAtHeader.hasClass('is-sorted'), 'createdAt column is sorted')
+                .to.be.true;
+            expect(createdAtHeader.find('.gh-icon-descending').length, 'createdAt column has descending icon')
+                .to.equal(1);
 
             // click the column to re-order
-            click('th:contains("Subscription Date")');
+            await click('th:contains("Subscription Date")');
 
-            andThen(function () {
-                // it flips the directions and re-fetches
-                let [lastRequest] = server.pretender.handledRequests.slice(-1);
-                expect(lastRequest.queryParams.order).to.equal('created_at asc');
+            // it flips the directions and re-fetches
+            [lastRequest] = server.pretender.handledRequests.slice(-1);
+            expect(lastRequest.queryParams.order).to.equal('created_at asc');
 
-                let createdAtHeader = find('.subscribers-table th:contains("Subscription Date")');
-                expect(createdAtHeader.find('.gh-icon-ascending').length, 'createdAt column has ascending icon')
-                    .to.equal(1);
-            });
+            createdAtHeader = find('.subscribers-table th:contains("Subscription Date")');
+            expect(createdAtHeader.find('.gh-icon-ascending').length, 'createdAt column has ascending icon')
+                .to.equal(1);
 
             // TODO: scroll test disabled as ember-light-table doesn't calculate
             // the scroll trigger element's positioning against the scroll
             // container - https://github.com/offirgolan/ember-light-table/issues/201
             //
-            // andThen(() => {
-            //     // scroll to the bottom of the table to simulate infinite scroll
-            //     find('.subscribers-table').scrollTop(find('.subscribers-table .ember-light-table').height() - 50);
-            // });
+            // // scroll to the bottom of the table to simulate infinite scroll
+            // await find('.subscribers-table').scrollTop(find('.subscribers-table .ember-light-table').height() - 50);
             //
             // // trigger infinite scroll
-            // triggerEvent('.subscribers-table tbody', 'scroll');
+            // await triggerEvent('.subscribers-table tbody', 'scroll');
             //
-            // andThen(function () {
-            //     // it loads the next page
-            //     expect(find('.subscribers-table .lt-body .lt-row').length, 'number of subscriber rows after infinite-scroll')
-            //         .to.equal(40);
-            // });
+            // // it loads the next page
+            // expect(find('.subscribers-table .lt-body .lt-row').length, 'number of subscriber rows after infinite-scroll')
+            //     .to.equal(40);
 
             // click the add subscriber button
-            click('.gh-btn:contains("Add Subscriber")');
+            await click('.gh-btn:contains("Add Subscriber")');
 
-            andThen(function () {
-                // it displays the add subscriber modal
-                expect(find('.fullscreen-modal').length, 'add subscriber modal displayed')
-                    .to.equal(1);
-            });
+            // it displays the add subscriber modal
+            expect(find('.fullscreen-modal').length, 'add subscriber modal displayed')
+                .to.equal(1);
 
             // cancel the modal
-            click('.fullscreen-modal .gh-btn:contains("Cancel")');
+            await click('.fullscreen-modal .gh-btn:contains("Cancel")');
 
-            andThen(function () {
-                // it closes the add subscriber modal
-                expect(find('.fullscreen-modal').length, 'add subscriber modal displayed after cancel')
-                    .to.equal(0);
-            });
+            // it closes the add subscriber modal
+            expect(find('.fullscreen-modal').length, 'add subscriber modal displayed after cancel')
+                .to.equal(0);
 
             // save a new subscriber
-            click('.gh-btn:contains("Add Subscriber")');
-            fillIn('.fullscreen-modal input[name="email"]', 'test@example.com');
-            click('.fullscreen-modal .gh-btn:contains("Add")');
+            await click('.gh-btn:contains("Add Subscriber")');
+            await fillIn('.fullscreen-modal input[name="email"]', 'test@example.com');
+            await click('.fullscreen-modal .gh-btn:contains("Add")');
 
-            andThen(function () {
-                // the add subscriber modal is closed
-                expect(find('.fullscreen-modal').length, 'add subscriber modal displayed after save')
-                    .to.equal(0);
+            // the add subscriber modal is closed
+            expect(find('.fullscreen-modal').length, 'add subscriber modal displayed after save')
+                .to.equal(0);
 
-                // the subscriber is added to the table
-                expect(find('.subscribers-table .lt-body .lt-row:first-of-type .lt-cell:first-of-type').text().trim(), 'first email in list after addition')
-                    .to.equal('test@example.com');
+            // the subscriber is added to the table
+            expect(find('.subscribers-table .lt-body .lt-row:first-of-type .lt-cell:first-of-type').text().trim(), 'first email in list after addition')
+                .to.equal('test@example.com');
 
-                // the table is scrolled to the top
-                // TODO: implement scroll to new record after addition
-                // expect(find('.subscribers-table').scrollTop(), 'scroll position after addition')
-                //     .to.equal(0);
+            // the table is scrolled to the top
+            // TODO: implement scroll to new record after addition
+            // expect(find('.subscribers-table').scrollTop(), 'scroll position after addition')
+            //     .to.equal(0);
 
-                // the subscriber total is updated
-                expect(find(testSelector('total-subscribers')).text().trim(), 'subscribers total after addition')
-                    .to.equal('(41)');
-            });
+            // the subscriber total is updated
+            expect(find(testSelector('total-subscribers')).text().trim(), 'subscribers total after addition')
+                .to.equal('(41)');
 
             // saving a duplicate subscriber
-            click('.gh-btn:contains("Add Subscriber")');
-            fillIn('.fullscreen-modal input[name="email"]', 'test@example.com');
-            click('.fullscreen-modal .gh-btn:contains("Add")');
+            await click('.gh-btn:contains("Add Subscriber")');
+            await fillIn('.fullscreen-modal input[name="email"]', 'test@example.com');
+            await click('.fullscreen-modal .gh-btn:contains("Add")');
 
-            andThen(function () {
-                // the validation error is displayed
-                expect(find('.fullscreen-modal .error .response').text().trim(), 'duplicate email validation')
-                    .to.equal('Email already exists.');
+            // the validation error is displayed
+            expect(find('.fullscreen-modal .error .response').text().trim(), 'duplicate email validation')
+                .to.equal('Email already exists.');
 
-                // the subscriber is not added to the table
-                expect(find('.lt-cell:contains(test@example.com)').length, 'number of "test@example.com rows"')
-                    .to.equal(1);
+            // the subscriber is not added to the table
+            expect(find('.lt-cell:contains(test@example.com)').length, 'number of "test@example.com rows"')
+                .to.equal(1);
 
-                // the subscriber total is unchanged
-                expect(find(testSelector('total-subscribers')).text().trim(), 'subscribers total after failed add')
-                    .to.equal('(41)');
-            });
+            // the subscriber total is unchanged
+            expect(find(testSelector('total-subscribers')).text().trim(), 'subscribers total after failed add')
+                .to.equal('(41)');
 
             // deleting a subscriber
-            click('.fullscreen-modal .gh-btn:contains("Cancel")');
-            click('.subscribers-table tbody tr:first-of-type button:last-of-type');
+            await click('.fullscreen-modal .gh-btn:contains("Cancel")');
+            await click('.subscribers-table tbody tr:first-of-type button:last-of-type');
 
-            andThen(function () {
-                // it displays the delete subscriber modal
-                expect(find('.fullscreen-modal').length, 'delete subscriber modal displayed')
-                    .to.equal(1);
-            });
+            // it displays the delete subscriber modal
+            expect(find('.fullscreen-modal').length, 'delete subscriber modal displayed')
+                .to.equal(1);
 
             // cancel the modal
-            click('.fullscreen-modal .gh-btn:contains("Cancel")');
+            await click('.fullscreen-modal .gh-btn:contains("Cancel")');
 
-            andThen(function () {
-                // it closes the add subscriber modal
-                expect(find('.fullscreen-modal').length, 'delete subscriber modal displayed after cancel')
-                    .to.equal(0);
-            });
+            // it closes the add subscriber modal
+            expect(find('.fullscreen-modal').length, 'delete subscriber modal displayed after cancel')
+                .to.equal(0);
 
-            click('.subscribers-table tbody tr:first-of-type button:last-of-type');
-            click('.fullscreen-modal .gh-btn:contains("Delete")');
+            await click('.subscribers-table tbody tr:first-of-type button:last-of-type');
+            await click('.fullscreen-modal .gh-btn:contains("Delete")');
 
-            andThen(function () {
-                // the add subscriber modal is closed
-                expect(find('.fullscreen-modal').length, 'delete subscriber modal displayed after confirm')
-                    .to.equal(0);
+            // the add subscriber modal is closed
+            expect(find('.fullscreen-modal').length, 'delete subscriber modal displayed after confirm')
+                .to.equal(0);
 
-                // the subscriber is removed from the table
-                expect(find('.subscribers-table .lt-body .lt-row:first-of-type .lt-cell:first-of-type').text().trim(), 'first email in list after addition')
-                    .to.not.equal('test@example.com');
+            // the subscriber is removed from the table
+            expect(find('.subscribers-table .lt-body .lt-row:first-of-type .lt-cell:first-of-type').text().trim(), 'first email in list after addition')
+                .to.not.equal('test@example.com');
 
-                // the subscriber total is updated
-                expect(find(testSelector('total-subscribers')).text().trim(), 'subscribers total after addition')
-                    .to.equal('(40)');
-            });
+            // the subscriber total is updated
+            expect(find(testSelector('total-subscribers')).text().trim(), 'subscribers total after addition')
+                .to.equal('(40)');
 
             // click the import subscribers button
-            click('.gh-btn:contains("Import CSV")');
+            await click('.gh-btn:contains("Import CSV")');
 
-            andThen(function () {
-                // it displays the import subscribers modal
-                expect(find('.fullscreen-modal').length, 'import subscribers modal displayed')
-                    .to.equal(1);
-                expect(find('.fullscreen-modal input[type="file"]').length, 'import modal contains file input')
-                    .to.equal(1);
-            });
+            // it displays the import subscribers modal
+            expect(find('.fullscreen-modal').length, 'import subscribers modal displayed')
+                .to.equal(1);
+            expect(find('.fullscreen-modal input[type="file"]').length, 'import modal contains file input')
+                .to.equal(1);
 
             // cancel the modal
-            click('.fullscreen-modal .gh-btn:contains("Cancel")');
+            await click('.fullscreen-modal .gh-btn:contains("Cancel")');
 
-            andThen(function () {
-                // it closes the import subscribers modal
-                expect(find('.fullscreen-modal').length, 'import subscribers modal displayed after cancel')
-                    .to.equal(0);
-            });
+            // it closes the import subscribers modal
+            expect(find('.fullscreen-modal').length, 'import subscribers modal displayed after cancel')
+                .to.equal(0);
 
-            click('.gh-btn:contains("Import CSV")');
-            fileUpload('.fullscreen-modal input[type="file"]', ['test'], {name: 'test.csv'});
+            await click('.gh-btn:contains("Import CSV")');
+            await fileUpload('.fullscreen-modal input[type="file"]', ['test'], {name: 'test.csv'});
 
-            andThen(function () {
-                // modal title changes
-                expect(find('.fullscreen-modal h1').text().trim(), 'import modal title after import')
-                    .to.equal('Import Successful');
+            // modal title changes
+            expect(find('.fullscreen-modal h1').text().trim(), 'import modal title after import')
+                .to.equal('Import Successful');
 
-                // modal button changes
-                expect(find('.fullscreen-modal .modal-footer button').text().trim(), 'import modal button text after import')
-                    .to.equal('Close');
+            // modal button changes
+            expect(find('.fullscreen-modal .modal-footer button').text().trim(), 'import modal button text after import')
+                .to.equal('Close');
 
-                // subscriber total is updated
-                expect(find(testSelector('total-subscribers')).text().trim(), 'subscribers total after import')
-                    .to.equal('(90)');
+            // subscriber total is updated
+            expect(find(testSelector('total-subscribers')).text().trim(), 'subscribers total after import')
+                .to.equal('(90)');
 
-                // table is reset
-                let [lastRequest] = server.pretender.handledRequests.slice(-1);
-                expect(lastRequest.url, 'endpoint requested after import')
-                    .to.match(/\/subscribers\/\?/);
-                expect(lastRequest.queryParams.page, 'page requested after import')
-                    .to.equal('1');
+            // table is reset
+            [lastRequest] = server.pretender.handledRequests.slice(-1);
+            expect(lastRequest.url, 'endpoint requested after import')
+                .to.match(/\/subscribers\/\?/);
+            expect(lastRequest.queryParams.page, 'page requested after import')
+                .to.equal('1');
 
-                expect(find('.subscribers-table .lt-body .lt-row').length, 'number of rows in table after import')
-                    .to.equal(30);
-            });
+            expect(find('.subscribers-table .lt-body .lt-row').length, 'number of rows in table after import')
+                .to.equal(30);
 
             // close modal
         });

--- a/tests/acceptance/team-test.js
+++ b/tests/acceptance/team-test.js
@@ -26,41 +26,35 @@ describe('Acceptance: Team', function () {
         destroyApp(application);
     });
 
-    it('redirects to signin when not authenticated', function () {
+    it('redirects to signin when not authenticated', async function () {
         invalidateSession(application);
-        visit('/team');
+        await visit('/team');
 
-        andThen(function () {
-            expect(currentURL()).to.equal('/signin');
-        });
+        expect(currentURL()).to.equal('/signin');
     });
 
-    it('redirects correctly when authenticated as author', function () {
+    it('redirects correctly when authenticated as author', async function () {
         let role = server.create('role', {name: 'Author'});
         server.create('user', {roles: [role], slug: 'test-user'});
 
         server.create('user', {slug: 'no-access'});
 
         authenticateSession(application);
-        visit('/team/no-access');
+        await visit('/team/no-access');
 
-        andThen(() => {
-            expect(currentURL(), 'currentURL').to.equal('/team/test-user');
-        });
+        expect(currentURL(), 'currentURL').to.equal('/team/test-user');
     });
 
-    it('redirects correctly when authenticated as editor', function () {
+    it('redirects correctly when authenticated as editor', async function () {
         let role = server.create('role', {name: 'Editor'});
         server.create('user', {roles: [role], slug: 'test-user'});
 
         server.create('user', {slug: 'no-access'});
 
         authenticateSession(application);
-        visit('/team/no-access');
+        await visit('/team/no-access');
 
-        andThen(() => {
-            expect(currentURL(), 'currentURL').to.equal('/team');
-        });
+        expect(currentURL(), 'currentURL').to.equal('/team');
     });
 
     describe('when logged in as admin', function () {
@@ -81,334 +75,302 @@ describe('Acceptance: Team', function () {
             return authenticateSession(application);
         });
 
-        it('it renders and navigates correctly', function () {
+        it('it renders and navigates correctly', async function () {
             let user1 = server.create('user');
             let user2 = server.create('user');
 
-            visit('/team');
+            await visit('/team');
 
-            andThen(() => {
-                // doesn't do any redirecting
-                expect(currentURL(), 'currentURL').to.equal('/team');
+            // doesn't do any redirecting
+            expect(currentURL(), 'currentURL').to.equal('/team');
 
-                // it has correct page title
-                expect(document.title, 'page title').to.equal('Team - Test Blog');
+            // it has correct page title
+            expect(document.title, 'page title').to.equal('Team - Test Blog');
 
-                // it shows active users in active section
-                expect(
-                    find(`${testSelector('active-users')} ${testSelector('user-id')}`).length,
-                    'number of active users'
-                ).to.equal(3);
-                expect(
-                    find(`${testSelector('active-users')} ${testSelector('user-id', user1.id)}`)
-                ).to.exist;
-                expect(
-                    find(`${testSelector('active-users')} ${testSelector('user-id', user2.id)}`)
-                ).to.exist;
-                expect(
-                    find(`${testSelector('active-users')} ${testSelector('user-id', admin.id)}`)
-                ).to.exist;
+            // it shows active users in active section
+            expect(
+                find(`${testSelector('active-users')} ${testSelector('user-id')}`).length,
+                'number of active users'
+            ).to.equal(3);
+            expect(
+                find(`${testSelector('active-users')} ${testSelector('user-id', user1.id)}`)
+            ).to.exist;
+            expect(
+                find(`${testSelector('active-users')} ${testSelector('user-id', user2.id)}`)
+            ).to.exist;
+            expect(
+                find(`${testSelector('active-users')} ${testSelector('user-id', admin.id)}`)
+            ).to.exist;
 
-                // it shows suspended users in suspended section
-                expect(
-                    find(`${testSelector('suspended-users')} ${testSelector('user-id')}`).length,
-                    'number of suspended users'
-                ).to.equal(1);
-                expect(
-                    find(`${testSelector('suspended-users')} ${testSelector('user-id', suspendedUser.id)}`)
-                ).to.exist;
+            // it shows suspended users in suspended section
+            expect(
+                find(`${testSelector('suspended-users')} ${testSelector('user-id')}`).length,
+                'number of suspended users'
+            ).to.equal(1);
+            expect(
+                find(`${testSelector('suspended-users')} ${testSelector('user-id', suspendedUser.id)}`)
+            ).to.exist;
 
-                click(testSelector('user-id', user2.id));
+            await click(testSelector('user-id', user2.id));
 
-                andThen(() => {
-                    // url is correct
-                    expect(currentURL(), 'url after clicking user').to.equal(`/team/${user2.slug}`);
+            // url is correct
+            expect(currentURL(), 'url after clicking user').to.equal(`/team/${user2.slug}`);
 
-                    // title is correct
-                    expect(document.title, 'title after clicking user').to.equal('Team - User - Test Blog');
+            // title is correct
+            expect(document.title, 'title after clicking user').to.equal('Team - User - Test Blog');
 
-                    // view title should exist and be linkable and active
-                    expect(find('.view-title a[href="/ghost/team"]').hasClass('active'), 'has linkable url back to team main page')
-                        .to.be.true;
-                });
+            // view title should exist and be linkable and active
+            expect(find('.view-title a[href="/ghost/team"]').hasClass('active'), 'has linkable url back to team main page')
+                .to.be.true;
 
-                click('.view-title a');
+            await click('.view-title a');
 
-                andThen(() => {
-                    // url should be /team again
-                    expect(currentURL(), 'url after clicking back').to.equal('/team');
-                });
-            });
+            // url should be /team again
+            expect(currentURL(), 'url after clicking back').to.equal('/team');
         });
 
-        it('can manage invites', function () {
-            visit('/team');
+        it('can manage invites', async function () {
+            await visit('/team');
 
-            andThen(() => {
-                // invite user button exists
-                expect(
-                    find('.view-actions .gh-btn-green').text().trim(),
-                    'invite people button text'
-                ).to.equal('Invite People');
+            // invite user button exists
+            expect(
+                find('.view-actions .gh-btn-green').text().trim(),
+                'invite people button text'
+            ).to.equal('Invite People');
 
-                // existing users are listed
-                expect(
-                    find(testSelector('user-id')).length,
-                    'initial number of active users'
-                ).to.equal(2);
+            // existing users are listed
+            expect(
+                find(testSelector('user-id')).length,
+                'initial number of active users'
+            ).to.equal(2);
 
-                expect(
-                    find(testSelector('user-id', '1')).find(testSelector('role-name')).text().trim(),
-                    'active user\'s role label'
-                ).to.equal('Administrator');
+            expect(
+                find(testSelector('user-id', '1')).find(testSelector('role-name')).text().trim(),
+                'active user\'s role label'
+            ).to.equal('Administrator');
 
-                // existing invites are shown
-                expect(
-                    find(testSelector('invite-id')).length,
-                    'initial number of invited users'
-                ).to.equal(1);
+            // existing invites are shown
+            expect(
+                find(testSelector('invite-id')).length,
+                'initial number of invited users'
+            ).to.equal(1);
 
-                expect(
-                    find(testSelector('invite-id', '1')).find(testSelector('invite-description')).text(),
-                    'expired invite description'
-                ).to.match(/expired/);
-            });
+            expect(
+                find(testSelector('invite-id', '1')).find(testSelector('invite-description')).text(),
+                'expired invite description'
+            ).to.match(/expired/);
 
             // remove expired invite
-            click(`${testSelector('invite-id', '1')} ${testSelector('revoke-button')}`);
+            await click(`${testSelector('invite-id', '1')} ${testSelector('revoke-button')}`);
 
-            andThen(() => {
-                expect(
-                    find(testSelector('invite-id')).length,
-                    'initial number of invited users'
-                ).to.equal(0);
-            });
+            expect(
+                find(testSelector('invite-id')).length,
+                'initial number of invited users'
+            ).to.equal(0);
 
             // click the invite people button
-            click('.view-actions .gh-btn-green');
+            await click('.view-actions .gh-btn-green');
 
-            andThen(() => {
-                let roleOptions = find('.fullscreen-modal select[name="role"] option');
+            let roleOptions = find('.fullscreen-modal select[name="role"] option');
 
-                function checkOwnerExists() {
-                    for (let i in roleOptions) {
-                        if (roleOptions[i].tagName === 'option' && roleOptions[i].text === 'Owner') {
-                            return true;
-                        }
+            function checkOwnerExists() {
+                for (let i in roleOptions) {
+                    if (roleOptions[i].tagName === 'option' && roleOptions[i].text === 'Owner') {
+                        return true;
                     }
-                    return false;
                 }
+                return false;
+            }
 
-                function checkSelectedIsAuthor() {
-                    for (let i in roleOptions) {
-                        if (roleOptions[i].selected) {
-                            return roleOptions[i].text === 'Author';
-                        }
+            function checkSelectedIsAuthor() {
+                for (let i in roleOptions) {
+                    if (roleOptions[i].selected) {
+                        return roleOptions[i].text === 'Author';
                     }
-                    return false;
                 }
+                return false;
+            }
 
-                // modal is displayed
-                expect(
-                    find('.fullscreen-modal h1').text().trim(),
-                    'correct modal is displayed'
-                ).to.equal('Invite a New User');
+            // modal is displayed
+            expect(
+                find('.fullscreen-modal h1').text().trim(),
+                'correct modal is displayed'
+            ).to.equal('Invite a New User');
 
-                // number of roles is correct
-                expect(
-                    find('.fullscreen-modal select[name="role"] option').length,
-                    'number of selectable roles'
-                ).to.equal(3);
+            // number of roles is correct
+            expect(
+                find('.fullscreen-modal select[name="role"] option').length,
+                'number of selectable roles'
+            ).to.equal(3);
 
-                expect(checkOwnerExists(), 'owner role isn\'t available').to.be.false;
-                expect(checkSelectedIsAuthor(), 'author role is selected initially').to.be.true;
-            });
+            expect(checkOwnerExists(), 'owner role isn\'t available').to.be.false;
+            expect(checkSelectedIsAuthor(), 'author role is selected initially').to.be.true;
 
             // submit valid invite form
-            fillIn('.fullscreen-modal input[name="email"]', 'invite1@example.com');
-            click('.fullscreen-modal .gh-btn-green');
+            await fillIn('.fullscreen-modal input[name="email"]', 'invite1@example.com');
+            await click('.fullscreen-modal .gh-btn-green');
 
-            andThen(() => {
-                // modal closes
-                expect(
-                    find('.fullscreen-modal').length,
-                    'number of modals after sending invite'
-                ).to.equal(0);
+            // modal closes
+            expect(
+                find('.fullscreen-modal').length,
+                'number of modals after sending invite'
+            ).to.equal(0);
 
-                // invite is displayed, has correct e-mail + role
-                expect(
-                    find(testSelector('invite-id')).length,
-                    'number of invites after first invite'
-                ).to.equal(1);
+            // invite is displayed, has correct e-mail + role
+            expect(
+                find(testSelector('invite-id')).length,
+                'number of invites after first invite'
+            ).to.equal(1);
 
-                expect(
-                    find(testSelector('invite-id', '2')).find(testSelector('email')).text().trim(),
-                    'displayed email of first invite'
-                ).to.equal('invite1@example.com');
+            expect(
+                find(testSelector('invite-id', '2')).find(testSelector('email')).text().trim(),
+                'displayed email of first invite'
+            ).to.equal('invite1@example.com');
 
-                expect(
-                    find(testSelector('invite-id', '2')).find(testSelector('role-name')).text().trim(),
-                    'displayed role of first invite'
-                ).to.equal('Author');
+            expect(
+                find(testSelector('invite-id', '2')).find(testSelector('role-name')).text().trim(),
+                'displayed role of first invite'
+            ).to.equal('Author');
 
-                expect(
-                    find(testSelector('invite-id', '2')).find(testSelector('invite-description')).text(),
-                    'new invite description'
-                ).to.match(/expires/);
+            expect(
+                find(testSelector('invite-id', '2')).find(testSelector('invite-description')).text(),
+                'new invite description'
+            ).to.match(/expires/);
 
-                // number of users is unchanged
-                expect(
-                    find(testSelector('user-id')).length,
-                    'number of active users after first invite'
-                ).to.equal(2);
-            });
+            // number of users is unchanged
+            expect(
+                find(testSelector('user-id')).length,
+                'number of active users after first invite'
+            ).to.equal(2);
 
             // submit new invite with different role
-            click('.view-actions .gh-btn-green');
-            fillIn('.fullscreen-modal input[name="email"]', 'invite2@example.com');
-            fillIn('.fullscreen-modal select[name="role"]', '2');
-            click('.fullscreen-modal .gh-btn-green');
+            await click('.view-actions .gh-btn-green');
+            await fillIn('.fullscreen-modal input[name="email"]', 'invite2@example.com');
+            await fillIn('.fullscreen-modal select[name="role"]', '2');
+            await click('.fullscreen-modal .gh-btn-green');
 
-            andThen(() => {
-                // number of invites increases
-                expect(
-                    find(testSelector('invite-id')).length,
-                    'number of invites after second invite'
-                ).to.equal(2);
+            // number of invites increases
+            expect(
+                find(testSelector('invite-id')).length,
+                'number of invites after second invite'
+            ).to.equal(2);
 
-                // invite has correct e-mail + role
-                expect(
-                    find(testSelector('invite-id', '3')).find(testSelector('email')).text().trim(),
-                    'displayed email of second invite'
-                ).to.equal('invite2@example.com');
+            // invite has correct e-mail + role
+            expect(
+                find(testSelector('invite-id', '3')).find(testSelector('email')).text().trim(),
+                'displayed email of second invite'
+            ).to.equal('invite2@example.com');
 
-                expect(
-                    find(testSelector('invite-id', '3')).find(testSelector('role-name')).text().trim(),
-                    'displayed role of second invite'
-                ).to.equal('Editor');
-            });
+            expect(
+                find(testSelector('invite-id', '3')).find(testSelector('role-name')).text().trim(),
+                'displayed role of second invite'
+            ).to.equal('Editor');
 
             // submit invite form with existing user
-            click('.view-actions .gh-btn-green');
-            fillIn('.fullscreen-modal input[name="email"]', 'admin@example.com');
-            click('.fullscreen-modal .gh-btn-green');
+            await click('.view-actions .gh-btn-green');
+            await fillIn('.fullscreen-modal input[name="email"]', 'admin@example.com');
+            await click('.fullscreen-modal .gh-btn-green');
 
-            andThen(() => {
-                // validation message is displayed
-                expect(
-                    find('.fullscreen-modal .error .response').text().trim(),
-                    'inviting existing user error'
-                ).to.equal('A user with that email address already exists.');
-            });
+            // validation message is displayed
+            expect(
+                find('.fullscreen-modal .error .response').text().trim(),
+                'inviting existing user error'
+            ).to.equal('A user with that email address already exists.');
 
             // submit invite form with existing invite
-            fillIn('.fullscreen-modal input[name="email"]', 'invite1@example.com');
-            click('.fullscreen-modal .gh-btn-green');
+            await fillIn('.fullscreen-modal input[name="email"]', 'invite1@example.com');
+            await click('.fullscreen-modal .gh-btn-green');
 
-            andThen(() => {
-                // validation message is displayed
-                expect(
-                    find('.fullscreen-modal .error .response').text().trim(),
-                    'inviting invited user error'
-                ).to.equal('A user with that email address was already invited.');
-            });
+            // validation message is displayed
+            expect(
+                find('.fullscreen-modal .error .response').text().trim(),
+                'inviting invited user error'
+            ).to.equal('A user with that email address was already invited.');
 
             // submit invite form with an invalid email
-            fillIn('.fullscreen-modal input[name="email"]', 'test');
-            click('.fullscreen-modal .gh-btn-green');
+            await fillIn('.fullscreen-modal input[name="email"]', 'test');
+            await click('.fullscreen-modal .gh-btn-green');
 
-            andThen(() => {
-                // validation message is displayed
-                expect(
-                    find('.fullscreen-modal .error .response').text().trim(),
-                    'inviting invalid email error'
-                ).to.equal('Invalid Email.');
-            });
+            // validation message is displayed
+            expect(
+                find('.fullscreen-modal .error .response').text().trim(),
+                'inviting invalid email error'
+            ).to.equal('Invalid Email.');
 
-            click('.fullscreen-modal a.close');
+            await click('.fullscreen-modal a.close');
             // revoke latest invite
-            click(`${testSelector('invite-id', '3')} ${testSelector('revoke-button')}`);
+            await click(`${testSelector('invite-id', '3')} ${testSelector('revoke-button')}`);
 
-            andThen(() => {
-                // number of invites decreases
-                expect(
-                    find(testSelector('invite-id')).length,
-                    'number of invites after revoke'
-                ).to.equal(1);
+            // number of invites decreases
+            expect(
+                find(testSelector('invite-id')).length,
+                'number of invites after revoke'
+            ).to.equal(1);
 
-                // notification is displayed
-                expect(
-                    find('.gh-notification').text().trim(),
-                    'notifications contain revoke'
-                ).to.match(/Invitation revoked\. \(invite2@example\.com\)/);
+            // notification is displayed
+            expect(
+                find('.gh-notification').text().trim(),
+                'notifications contain revoke'
+            ).to.match(/Invitation revoked\. \(invite2@example\.com\)/);
 
-                // correct invite is removed
-                expect(
-                    find(testSelector('invite-id')).find(testSelector('email')).text().trim(),
-                    'displayed email of remaining invite'
-                ).to.equal('invite1@example.com');
-            });
+            // correct invite is removed
+            expect(
+                find(testSelector('invite-id')).find(testSelector('email')).text().trim(),
+                'displayed email of remaining invite'
+            ).to.equal('invite1@example.com');
 
             // add another invite to test ordering on resend
-            click('.view-actions .gh-btn-green');
-            fillIn('.fullscreen-modal input[name="email"]', 'invite3@example.com');
-            click('.fullscreen-modal .gh-btn-green');
+            await click('.view-actions .gh-btn-green');
+            await fillIn('.fullscreen-modal input[name="email"]', 'invite3@example.com');
+            await click('.fullscreen-modal .gh-btn-green');
 
-            andThen(() => {
-                // new invite should be last in the list
-                expect(
-                    find(`${testSelector('invite-id')}:last`).find(testSelector('email')).text().trim(),
-                    'last invite email in list'
-                ).to.equal('invite3@example.com');
-            });
+            // new invite should be last in the list
+            expect(
+                find(`${testSelector('invite-id')}:last`).find(testSelector('email')).text().trim(),
+                'last invite email in list'
+            ).to.equal('invite3@example.com');
 
             // resend first invite
-            click(`${testSelector('invite-id', '2')} ${testSelector('resend-button')}`);
+            await click(`${testSelector('invite-id', '2')} ${testSelector('resend-button')}`);
 
-            andThen(() => {
-                // notification is displayed
-                expect(
-                    find('.gh-notification').text().trim(),
-                    'notifications contain resend'
-                ).to.match(/Invitation resent! \(invite1@example\.com\)/);
+            // notification is displayed
+            expect(
+                find('.gh-notification').text().trim(),
+                'notifications contain resend'
+            ).to.match(/Invitation resent! \(invite1@example\.com\)/);
 
-                // first invite is still at the top
-                expect(
-                    find(`${testSelector('invite-id')}:first-of-type`).find(testSelector('email')).text().trim(),
-                    'first invite email in list'
-                ).to.equal('invite1@example.com');
-            });
+            // first invite is still at the top
+            expect(
+                find(`${testSelector('invite-id')}:first-of-type`).find(testSelector('email')).text().trim(),
+                'first invite email in list'
+            ).to.equal('invite1@example.com');
 
             // regression test: can revoke a resent invite
-            click(`${testSelector('invite-id')}:first-of-type ${testSelector('resend-button')}`);
-            click(`${testSelector('invite-id')}:first-of-type ${testSelector('revoke-button')}`);
+            await click(`${testSelector('invite-id')}:first-of-type ${testSelector('resend-button')}`);
+            await click(`${testSelector('invite-id')}:first-of-type ${testSelector('revoke-button')}`);
 
-            andThen(() => {
-                // number of invites decreases
-                expect(
-                    find(testSelector('invite-id')).length,
-                    'number of invites after resend/revoke'
-                ).to.equal(1);
+            // number of invites decreases
+            expect(
+                find(testSelector('invite-id')).length,
+                'number of invites after resend/revoke'
+            ).to.equal(1);
 
-                // notification is displayed
-                expect(
-                    find('.gh-notification').text().trim(),
-                    'notifications contain revoke after resend/revoke'
-                ).to.match(/Invitation revoked\. \(invite1@example\.com\)/);
-            });
+            // notification is displayed
+            expect(
+                find('.gh-notification').text().trim(),
+                'notifications contain revoke after resend/revoke'
+            ).to.match(/Invitation revoked\. \(invite1@example\.com\)/);
         });
 
-        it('can manage suspended users', function () {
-            visit('/team');
-            click(testSelector('user-id', suspendedUser.id));
+        it('can manage suspended users', async function () {
+            await visit('/team');
+            await click(testSelector('user-id', suspendedUser.id));
 
-            andThen(() => {
-                expect(testSelector('suspended-badge')).to.exist;
-            });
+            expect(testSelector('suspended-badge')).to.exist;
 
-            click(testSelector('user-actions'));
-            click(testSelector('unsuspend-button'));
-            click(testSelector('modal-confirm'));
+            await click(testSelector('user-actions'));
+            await click(testSelector('unsuspend-button'));
+            await click(testSelector('modal-confirm'));
 
             // NOTE: there seems to be a timing issue with this test - pausing
             // here confirms that the badge is removed but the andThen is firing
@@ -417,89 +379,77 @@ describe('Acceptance: Team', function () {
             //     expect(testSelector('suspended-badge')).to.not.exist;
             // });
 
-            click(testSelector('team-link'));
+            await click(testSelector('team-link'));
 
-            andThen(() => {
-                // suspendedUser is now in active list
-                expect(
-                    find(`${testSelector('active-users')} ${testSelector('user-id', suspendedUser.id)}`)
-                ).to.exist;
+            // suspendedUser is now in active list
+            expect(
+                find(`${testSelector('active-users')} ${testSelector('user-id', suspendedUser.id)}`)
+            ).to.exist;
 
-                // no suspended users
-                expect(
-                    find(`${testSelector('suspended-users')} ${testSelector('user-id')}`).length
-                ).to.equal(0);
-            });
+            // no suspended users
+            expect(
+                find(`${testSelector('suspended-users')} ${testSelector('user-id')}`).length
+            ).to.equal(0);
 
-            click(testSelector('user-id', suspendedUser.id));
+            await click(testSelector('user-id', suspendedUser.id));
 
-            click(testSelector('user-actions'));
-            click(testSelector('suspend-button'));
-            click(testSelector('modal-confirm'));
+            await click(testSelector('user-actions'));
+            await click(testSelector('suspend-button'));
+            await click(testSelector('modal-confirm'));
 
-            andThen(() => {
-                expect(testSelector('suspended-badge')).to.exist;
-            });
+            expect(testSelector('suspended-badge')).to.exist;
         });
 
-        it('can delete users', function () {
+        it('can delete users', async function () {
             let user1 = server.create('user');
             let user2 = server.create('user');
             let post = server.create('post');
 
             user2.posts = [post];
 
-            visit('/team');
-            click(testSelector('user-id', user1.id));
+            await visit('/team');
+            await click(testSelector('user-id', user1.id));
 
             // user deletion displays modal
-            click('button.delete');
-            andThen(() => {
-                expect(
-                    find('.fullscreen-modal .modal-content:contains("delete this user")').length,
-                    'user deletion modal displayed after button click'
-                ).to.equal(1);
+            await click('button.delete');
+            expect(
+                find('.fullscreen-modal .modal-content:contains("delete this user")').length,
+                'user deletion modal displayed after button click'
+            ).to.equal(1);
 
-                // user has no posts so no warning about post deletion
-                expect(
-                    find('.fullscreen-modal .modal-content:contains("is the author of")').length,
-                    'deleting user with no posts has no post count'
-                ).to.equal(0);
-            });
+            // user has no posts so no warning about post deletion
+            expect(
+                find('.fullscreen-modal .modal-content:contains("is the author of")').length,
+                'deleting user with no posts has no post count'
+            ).to.equal(0);
 
             // cancelling user deletion closes modal
-            click('.fullscreen-modal button:contains("Cancel")');
-            andThen(() => {
-                expect(
-                    find('.fullscreen-modal').length === 0,
-                    'delete user modal is closed when cancelling'
-                ).to.be.true;
-            });
+            await click('.fullscreen-modal button:contains("Cancel")');
+            expect(
+                find('.fullscreen-modal').length === 0,
+                'delete user modal is closed when cancelling'
+            ).to.be.true;
 
             // deleting a user with posts
-            visit('/team');
-            click(testSelector('user-id', user2.id));
+            await visit('/team');
+            await click(testSelector('user-id', user2.id));
 
-            click('button.delete');
-            andThen(() => {
-                // user has  posts so should warn about post deletion
-                expect(
-                    find('.fullscreen-modal .modal-content:contains("is the author of 1 post")').length,
-                    'deleting user with posts has post count'
-                ).to.equal(1);
-            });
+            await click('button.delete');
+            // user has  posts so should warn about post deletion
+            expect(
+                find('.fullscreen-modal .modal-content:contains("is the author of 1 post")').length,
+                'deleting user with posts has post count'
+            ).to.equal(1);
 
-            click('.fullscreen-modal button:contains("Delete")');
-            andThen(() => {
-                // redirected to team page
-                expect(currentURL()).to.equal('/team');
+            await click('.fullscreen-modal button:contains("Delete")');
+            // redirected to team page
+            expect(currentURL()).to.equal('/team');
 
-                // deleted user is not in list
-                expect(
-                    find(testSelector('user-id', user2.id)).length,
-                    'deleted user is not in user list after deletion'
-                ).to.equal(0);
-            });
+            // deleted user is not in list
+            expect(
+                find(testSelector('user-id', user2.id)).length,
+                'deleted user is not in user list after deletion'
+            ).to.equal(0);
         });
 
         describe('existing user', function () {
@@ -514,292 +464,234 @@ describe('Acceptance: Team', function () {
                 });
             });
 
-            it('input fields reset and validate correctly', function () {
+            it('input fields reset and validate correctly', async function () {
                 // test user name
-                visit('/team/test-1');
+                await visit('/team/test-1');
 
-                andThen(() => {
-                    expect(currentURL(), 'currentURL').to.equal('/team/test-1');
-                    expect(find('.user-details-top .first-form-group input.user-name').val(), 'current user name').to.equal('Test User');
-                });
+                expect(currentURL(), 'currentURL').to.equal('/team/test-1');
+                expect(find('.user-details-top .first-form-group input.user-name').val(), 'current user name').to.equal('Test User');
 
                 // test empty user name
-                fillIn('.user-details-top .first-form-group input.user-name', '');
-                triggerEvent('.user-details-top .first-form-group input.user-name', 'blur');
+                await fillIn('.user-details-top .first-form-group input.user-name', '');
+                await triggerEvent('.user-details-top .first-form-group input.user-name', 'blur');
 
-                andThen(() => {
-                    expect(find('.user-details-top .first-form-group').hasClass('error'), 'username input is in error state with blank input').to.be.true;
-                });
+                expect(find('.user-details-top .first-form-group').hasClass('error'), 'username input is in error state with blank input').to.be.true;
 
                 // test too long user name
-                fillIn('.user-details-top .first-form-group input.user-name', new Array(160).join('a'));
-                triggerEvent('.user-details-top .first-form-group input.user-name', 'blur');
+                await fillIn('.user-details-top .first-form-group input.user-name', new Array(160).join('a'));
+                await triggerEvent('.user-details-top .first-form-group input.user-name', 'blur');
 
-                andThen(() => {
-                    expect(find('.user-details-top .first-form-group').hasClass('error'), 'username input is in error state with too long input').to.be.true;
-                });
+                expect(find('.user-details-top .first-form-group').hasClass('error'), 'username input is in error state with too long input').to.be.true;
 
                 // reset name field
-                fillIn('.user-details-top .first-form-group input.user-name', 'Test User');
+                await fillIn('.user-details-top .first-form-group input.user-name', 'Test User');
 
-                andThen(() => {
-                    expect(find('.user-details-bottom input[name="user"]').val(), 'slug value is default').to.equal('test-1');
-                });
+                expect(find('.user-details-bottom input[name="user"]').val(), 'slug value is default').to.equal('test-1');
 
-                fillIn('.user-details-bottom input[name="user"]', '');
-                triggerEvent('.user-details-bottom input[name="user"]', 'blur');
+                await fillIn('.user-details-bottom input[name="user"]', '');
+                await triggerEvent('.user-details-bottom input[name="user"]', 'blur');
 
-                andThen(() => {
-                    expect(find('.user-details-bottom input[name="user"]').val(), 'slug value is reset to original upon empty string').to.equal('test-1');
-                });
+                expect(find('.user-details-bottom input[name="user"]').val(), 'slug value is reset to original upon empty string').to.equal('test-1');
 
-                fillIn('.user-details-bottom input[name="user"]', 'white space');
-                triggerEvent('.user-details-bottom input[name="user"]', 'blur');
+                await fillIn('.user-details-bottom input[name="user"]', 'white space');
+                await triggerEvent('.user-details-bottom input[name="user"]', 'blur');
 
-                andThen(() => {
-                    expect(find('.user-details-bottom input[name="user"]').val(), 'slug value is correctly dasherized').to.equal('white-space');
-                });
+                expect(find('.user-details-bottom input[name="user"]').val(), 'slug value is correctly dasherized').to.equal('white-space');
 
-                fillIn('.user-details-bottom input[name="email"]', 'thisisnotanemail');
-                triggerEvent('.user-details-bottom input[name="email"]', 'blur');
+                await fillIn('.user-details-bottom input[name="email"]', 'thisisnotanemail');
+                await triggerEvent('.user-details-bottom input[name="email"]', 'blur');
 
-                andThen(() => {
-                    expect(find('.user-details-bottom .form-group:nth-of-type(2)').hasClass('error'), 'email input should be in error state with invalid email').to.be.true;
-                });
+                expect(find('.user-details-bottom .form-group:nth-of-type(2)').hasClass('error'), 'email input should be in error state with invalid email').to.be.true;
 
-                fillIn('.user-details-bottom input[name="email"]', 'test@example.com');
-                fillIn('#user-location', new Array(160).join('a'));
-                triggerEvent('#user-location', 'blur');
+                await fillIn('.user-details-bottom input[name="email"]', 'test@example.com');
+                await fillIn('#user-location', new Array(160).join('a'));
+                await triggerEvent('#user-location', 'blur');
 
-                andThen(() => {
-                    expect(find('#user-location').closest('.form-group').hasClass('error'), 'location input should be in error state').to.be.true;
-                });
+                expect(find('#user-location').closest('.form-group').hasClass('error'), 'location input should be in error state').to.be.true;
 
-                fillIn('#user-location', '');
-                fillIn('#user-website', 'thisisntawebsite');
-                triggerEvent('#user-website', 'blur');
+                await fillIn('#user-location', '');
+                await fillIn('#user-website', 'thisisntawebsite');
+                await triggerEvent('#user-website', 'blur');
 
-                andThen(() => {
-                    expect(find('#user-website').closest('.form-group').hasClass('error'), 'website input should be in error state').to.be.true;
-                });
+                expect(find('#user-website').closest('.form-group').hasClass('error'), 'website input should be in error state').to.be.true;
 
                 // Testing Facebook input
 
-                andThen(() => {
-                    // displays initial value
-                    expect(find('#user-facebook').val(), 'initial facebook value')
-                        .to.equal('https://www.facebook.com/test');
-                });
+                // displays initial value
+                expect(find('#user-facebook').val(), 'initial facebook value')
+                    .to.equal('https://www.facebook.com/test');
 
-                triggerEvent('#user-facebook', 'focus');
-                triggerEvent('#user-facebook', 'blur');
+                await triggerEvent('#user-facebook', 'focus');
+                await triggerEvent('#user-facebook', 'blur');
 
-                andThen(() => {
-                    // regression test: we still have a value after the input is
-                    // focused and then blurred without any changes
-                    expect(find('#user-facebook').val(), 'facebook value after blur with no change')
-                        .to.equal('https://www.facebook.com/test');
-                });
+                // regression test: we still have a value after the input is
+                // focused and then blurred without any changes
+                expect(find('#user-facebook').val(), 'facebook value after blur with no change')
+                    .to.equal('https://www.facebook.com/test');
 
-                fillIn('#user-facebook', '');
-                fillIn('#user-facebook', ')(*&%^%)');
-                triggerEvent('#user-facebook', 'blur');
+                await fillIn('#user-facebook', '');
+                await fillIn('#user-facebook', ')(*&%^%)');
+                await triggerEvent('#user-facebook', 'blur');
 
-                andThen(() => {
-                    expect(find('#user-facebook').closest('.form-group').hasClass('error'), 'facebook input should be in error state').to.be.true;
-                });
+                expect(find('#user-facebook').closest('.form-group').hasClass('error'), 'facebook input should be in error state').to.be.true;
 
-                fillIn('#user-facebook', '');
-                fillIn('#user-facebook', 'pages/)(*&%^%)');
-                triggerEvent('#user-facebook', 'blur');
+                await fillIn('#user-facebook', '');
+                await fillIn('#user-facebook', 'pages/)(*&%^%)');
+                await triggerEvent('#user-facebook', 'blur');
 
-                andThen(() => {
-                    expect(find('#user-facebook').val()).to.be.equal('https://www.facebook.com/pages/)(*&%^%)');
-                    expect(find('#user-facebook').closest('.form-group').hasClass('error'), 'facebook input should be in error state').to.be.false;
-                });
+                expect(find('#user-facebook').val()).to.be.equal('https://www.facebook.com/pages/)(*&%^%)');
+                expect(find('#user-facebook').closest('.form-group').hasClass('error'), 'facebook input should be in error state').to.be.false;
 
-                fillIn('#user-facebook', '');
-                fillIn('#user-facebook', 'testing');
-                triggerEvent('#user-facebook', 'blur');
+                await fillIn('#user-facebook', '');
+                await fillIn('#user-facebook', 'testing');
+                await triggerEvent('#user-facebook', 'blur');
 
-                andThen(() => {
-                    expect(find('#user-facebook').val()).to.be.equal('https://www.facebook.com/testing');
-                    expect(find('#user-facebook').closest('.form-group').hasClass('error'), 'facebook input should be in error state').to.be.false;
-                });
+                expect(find('#user-facebook').val()).to.be.equal('https://www.facebook.com/testing');
+                expect(find('#user-facebook').closest('.form-group').hasClass('error'), 'facebook input should be in error state').to.be.false;
 
-                fillIn('#user-facebook', '');
-                fillIn('#user-facebook', 'somewebsite.com/pages/some-facebook-page/857469375913?ref=ts');
-                triggerEvent('#user-facebook', 'blur');
+                await fillIn('#user-facebook', '');
+                await fillIn('#user-facebook', 'somewebsite.com/pages/some-facebook-page/857469375913?ref=ts');
+                await triggerEvent('#user-facebook', 'blur');
 
-                andThen(() => {
-                    expect(find('#user-facebook').val()).to.be.equal('https://www.facebook.com/pages/some-facebook-page/857469375913?ref=ts');
-                    expect(find('#user-facebook').closest('.form-group').hasClass('error'), 'facebook input should be in error state').to.be.false;
-                });
+                expect(find('#user-facebook').val()).to.be.equal('https://www.facebook.com/pages/some-facebook-page/857469375913?ref=ts');
+                expect(find('#user-facebook').closest('.form-group').hasClass('error'), 'facebook input should be in error state').to.be.false;
 
-                fillIn('#user-facebook', '');
-                fillIn('#user-facebook', 'test');
-                triggerEvent('#user-facebook', 'blur');
+                await fillIn('#user-facebook', '');
+                await fillIn('#user-facebook', 'test');
+                await triggerEvent('#user-facebook', 'blur');
 
-                andThen(() => {
-                    expect(find('#user-facebook').closest('.form-group').hasClass('error'), 'facebook input should be in error state').to.be.true;
-                });
+                expect(find('#user-facebook').closest('.form-group').hasClass('error'), 'facebook input should be in error state').to.be.true;
 
-                fillIn('#user-facebook', '');
-                fillIn('#user-facebook', 'http://twitter.com/testuser');
-                triggerEvent('#user-facebook', 'blur');
+                await fillIn('#user-facebook', '');
+                await fillIn('#user-facebook', 'http://twitter.com/testuser');
+                await triggerEvent('#user-facebook', 'blur');
 
-                andThen(() => {
-                    expect(find('#user-facebook').val()).to.be.equal('https://www.facebook.com/testuser');
-                    expect(find('#user-facebook').closest('.form-group').hasClass('error'), 'facebook input should be in error state').to.be.false;
-                });
+                expect(find('#user-facebook').val()).to.be.equal('https://www.facebook.com/testuser');
+                expect(find('#user-facebook').closest('.form-group').hasClass('error'), 'facebook input should be in error state').to.be.false;
 
-                fillIn('#user-facebook', '');
-                fillIn('#user-facebook', 'facebook.com/testing');
-                triggerEvent('#user-facebook', 'blur');
+                await fillIn('#user-facebook', '');
+                await fillIn('#user-facebook', 'facebook.com/testing');
+                await triggerEvent('#user-facebook', 'blur');
 
-                andThen(() => {
-                    expect(find('#user-facebook').val()).to.be.equal('https://www.facebook.com/testing');
-                    expect(find('#user-facebook').closest('.form-group').hasClass('error'), 'facebook input should be in error state').to.be.false;
-                });
+                expect(find('#user-facebook').val()).to.be.equal('https://www.facebook.com/testing');
+                expect(find('#user-facebook').closest('.form-group').hasClass('error'), 'facebook input should be in error state').to.be.false;
 
                 // Testing Twitter input
 
-                andThen(() => {
-                    // loads fixtures and performs transform
-                    expect(find('#user-twitter').val(), 'initial twitter value')
-                        .to.equal('https://twitter.com/test');
-                });
+                // loads fixtures and performs transform
+                expect(find('#user-twitter').val(), 'initial twitter value')
+                    .to.equal('https://twitter.com/test');
 
-                triggerEvent('#user-twitter', 'focus');
-                triggerEvent('#user-twitter', 'blur');
+                await triggerEvent('#user-twitter', 'focus');
+                await triggerEvent('#user-twitter', 'blur');
 
-                andThen(() => {
-                    // regression test: we still have a value after the input is
-                    // focused and then blurred without any changes
-                    expect(find('#user-twitter').val(), 'twitter value after blur with no change')
-                        .to.equal('https://twitter.com/test');
-                });
+                // regression test: we still have a value after the input is
+                // focused and then blurred without any changes
+                expect(find('#user-twitter').val(), 'twitter value after blur with no change')
+                    .to.equal('https://twitter.com/test');
 
-                fillIn('#user-twitter', '');
-                fillIn('#user-twitter', ')(*&%^%)');
-                triggerEvent('#user-twitter', 'blur');
+                await fillIn('#user-twitter', '');
+                await fillIn('#user-twitter', ')(*&%^%)');
+                await triggerEvent('#user-twitter', 'blur');
 
-                andThen(() => {
-                    expect(find('#user-twitter').closest('.form-group').hasClass('error'), 'twitter input should be in error state').to.be.true;
-                });
+                expect(find('#user-twitter').closest('.form-group').hasClass('error'), 'twitter input should be in error state').to.be.true;
 
-                fillIn('#user-twitter', '');
-                fillIn('#user-twitter', 'name');
-                triggerEvent('#user-twitter', 'blur');
+                await fillIn('#user-twitter', '');
+                await fillIn('#user-twitter', 'name');
+                await triggerEvent('#user-twitter', 'blur');
 
-                andThen(() => {
-                    expect(find('#user-twitter').val()).to.be.equal('https://twitter.com/name');
-                    expect(find('#user-twitter').closest('.form-group').hasClass('error'), 'twitter input should be in error state').to.be.false;
-                });
+                expect(find('#user-twitter').val()).to.be.equal('https://twitter.com/name');
+                expect(find('#user-twitter').closest('.form-group').hasClass('error'), 'twitter input should be in error state').to.be.false;
 
-                fillIn('#user-twitter', '');
-                fillIn('#user-twitter', 'http://github.com/user');
-                triggerEvent('#user-twitter', 'blur');
+                await fillIn('#user-twitter', '');
+                await fillIn('#user-twitter', 'http://github.com/user');
+                await triggerEvent('#user-twitter', 'blur');
 
-                andThen(() => {
-                    expect(find('#user-twitter').val()).to.be.equal('https://twitter.com/user');
-                    expect(find('#user-twitter').closest('.form-group').hasClass('error'), 'twitter input should be in error state').to.be.false;
-                });
+                expect(find('#user-twitter').val()).to.be.equal('https://twitter.com/user');
+                expect(find('#user-twitter').closest('.form-group').hasClass('error'), 'twitter input should be in error state').to.be.false;
 
-                fillIn('#user-twitter', '');
-                fillIn('#user-twitter', 'twitter.com/user');
-                triggerEvent('#user-twitter', 'blur');
+                await fillIn('#user-twitter', '');
+                await fillIn('#user-twitter', 'twitter.com/user');
+                await triggerEvent('#user-twitter', 'blur');
 
-                andThen(() => {
-                    expect(find('#user-twitter').val()).to.be.equal('https://twitter.com/user');
-                    expect(find('#user-twitter').closest('.form-group').hasClass('error'), 'twitter input should be in error state').to.be.false;
-                });
+                expect(find('#user-twitter').val()).to.be.equal('https://twitter.com/user');
+                expect(find('#user-twitter').closest('.form-group').hasClass('error'), 'twitter input should be in error state').to.be.false;
 
-                fillIn('#user-website', '');
-                fillIn('#user-bio', new Array(210).join('a'));
-                triggerEvent('#user-bio', 'blur');
+                await fillIn('#user-website', '');
+                await fillIn('#user-bio', new Array(210).join('a'));
+                await triggerEvent('#user-bio', 'blur');
 
-                andThen(() => {
-                    expect(find('#user-bio').closest('.form-group').hasClass('error'), 'bio input should be in error state').to.be.true;
-                });
+                expect(find('#user-bio').closest('.form-group').hasClass('error'), 'bio input should be in error state').to.be.true;
 
                 // password reset ------
 
                 // button triggers validation
-                click('.button-change-password');
+                await click('.button-change-password');
 
-                andThen(() => {
-                    expect(
-                        find('#user-password-new').closest('.form-group').hasClass('error'),
-                        'new password has error class when blank'
-                    ).to.be.true;
+                expect(
+                    find('#user-password-new').closest('.form-group').hasClass('error'),
+                    'new password has error class when blank'
+                ).to.be.true;
 
-                    expect(
-                        find('#user-password-new').siblings('.response').text(),
-                        'new password error when blank'
-                    ).to.match(/can't be blank/);
-                });
+                expect(
+                    find('#user-password-new').siblings('.response').text(),
+                    'new password error when blank'
+                ).to.match(/can't be blank/);
 
                 // typing in inputs clears validation
-                fillIn('#user-password-new', 'password');
-                triggerEvent('#user-password-new', 'input');
+                await fillIn('#user-password-new', 'password');
+                await triggerEvent('#user-password-new', 'input');
 
-                andThen(() => {
-                    expect(
-                        find('#user-password-new').closest('.form-group').hasClass('error'),
-                        'password validation is visible after typing'
-                    ).to.be.false;
-                });
+                expect(
+                    find('#user-password-new').closest('.form-group').hasClass('error'),
+                    'password validation is visible after typing'
+                ).to.be.false;
 
                 // enter key triggers action
-                keyEvent('#user-password-new', 'keyup', 13);
+                await keyEvent('#user-password-new', 'keyup', 13);
 
-                andThen(() => {
-                    expect(
-                        find('#user-new-password-verification').closest('.form-group').hasClass('error'),
-                        'confirm password has error class when it doesn\'t match'
-                    ).to.be.true;
+                expect(
+                    find('#user-new-password-verification').closest('.form-group').hasClass('error'),
+                    'confirm password has error class when it doesn\'t match'
+                ).to.be.true;
 
-                    expect(
-                        find('#user-new-password-verification').siblings('.response').text(),
-                        'confirm password error when it doesn\'t match'
-                    ).to.match(/do not match/);
-                });
+                expect(
+                    find('#user-new-password-verification').siblings('.response').text(),
+                    'confirm password error when it doesn\'t match'
+                ).to.match(/do not match/);
 
                 // submits with correct details
-                fillIn('#user-new-password-verification', 'password');
-                click('.button-change-password');
+                await fillIn('#user-new-password-verification', 'password');
+                await click('.button-change-password');
 
-                andThen(() => {
-                    // hits the endpoint
-                    let [lastRequest] = server.pretender.handledRequests.slice(-1);
-                    let params = JSON.parse(lastRequest.requestBody);
+                // hits the endpoint
+                let [lastRequest] = server.pretender.handledRequests.slice(-1);
+                let params = JSON.parse(lastRequest.requestBody);
 
-                    expect(lastRequest.url, 'password request URL')
-                        .to.match(/\/users\/password/);
+                expect(lastRequest.url, 'password request URL')
+                    .to.match(/\/users\/password/);
 
-                    // eslint-disable-next-line camelcase
-                    expect(params.password[0].user_id).to.equal(user.id.toString());
-                    expect(params.password[0].newPassword).to.equal('password');
-                    expect(params.password[0].ne2Password).to.equal('password');
+                // eslint-disable-next-line camelcase
+                expect(params.password[0].user_id).to.equal(user.id.toString());
+                expect(params.password[0].newPassword).to.equal('password');
+                expect(params.password[0].ne2Password).to.equal('password');
 
-                    // clears the fields
-                    expect(
-                        find('#user-password-new').val(),
-                        'password field after submit'
-                    ).to.be.blank;
+                // clears the fields
+                expect(
+                    find('#user-password-new').val(),
+                    'password field after submit'
+                ).to.be.blank;
 
-                    expect(
-                        find('#user-new-password-verification').val(),
-                        'password verification field after submit'
-                    ).to.be.blank;
+                expect(
+                    find('#user-new-password-verification').val(),
+                    'password verification field after submit'
+                ).to.be.blank;
 
-                    // displays a notification
-                    expect(
-                        find('.gh-notifications .gh-notification').length,
-                        'password saved notification is displayed'
-                    ).to.equal(1);
-                });
+                // displays a notification
+                expect(
+                    find('.gh-notifications .gh-notification').length,
+                    'password saved notification is displayed'
+                ).to.equal(1);
             });
         });
 
@@ -808,89 +700,81 @@ describe('Acceptance: Team', function () {
                 enableGhostOAuth(server);
             });
 
-            it('doesn\'t show the password reset form', function () {
-                visit(`/team/${admin.slug}`);
+            it('doesn\'t show the password reset form', async function () {
+                await visit(`/team/${admin.slug}`);
 
-                andThen(() => {
-                    // ensure that the normal form is displayed so we don't get
-                    // false positives
-                    expect(
-                        find('input#user-slug').length,
-                        'profile form is displayed'
-                    ).to.equal(1);
+                // ensure that the normal form is displayed so we don't get
+                // false positives
+                expect(
+                    find('input#user-slug').length,
+                    'profile form is displayed'
+                ).to.equal(1);
 
-                    // check that the password form is hidden
-                    expect(
-                        find('#password-reset').length,
-                        'presence of password reset form'
-                    ).to.equal(0);
+                // check that the password form is hidden
+                expect(
+                    find('#password-reset').length,
+                    'presence of password reset form'
+                ).to.equal(0);
 
-                    expect(
-                        find('#user-password-new').length,
-                        'presence of new password field'
-                    ).to.equal(0);
-                });
+                expect(
+                    find('#user-password-new').length,
+                    'presence of new password field'
+                ).to.equal(0);
             });
         });
 
         describe('own user', function () {
-            it('requires current password when changing password', function () {
-                visit(`/team/${admin.slug}`);
+            it('requires current password when changing password', async function () {
+                await visit(`/team/${admin.slug}`);
 
                 // test the "old password" field is validated
-                click('.button-change-password');
+                await click('.button-change-password');
 
-                andThen(() => {
-                    // old password has error
-                    expect(
-                        find('#user-password-old').closest('.form-group').hasClass('error'),
-                        'old password has error class when blank'
-                    ).to.be.true;
+                // old password has error
+                expect(
+                    find('#user-password-old').closest('.form-group').hasClass('error'),
+                    'old password has error class when blank'
+                ).to.be.true;
 
-                    expect(
-                        find('#user-password-old').siblings('.response').text(),
-                        'old password error when blank'
-                    ).to.match(/is required/);
+                expect(
+                    find('#user-password-old').siblings('.response').text(),
+                    'old password error when blank'
+                ).to.match(/is required/);
 
-                    // new password has error
-                    expect(
-                        find('#user-password-new').closest('.form-group').hasClass('error'),
-                        'new password has error class when blank'
-                    ).to.be.true;
+                // new password has error
+                expect(
+                    find('#user-password-new').closest('.form-group').hasClass('error'),
+                    'new password has error class when blank'
+                ).to.be.true;
 
-                    expect(
-                        find('#user-password-new').siblings('.response').text(),
-                        'new password error when blank'
-                    ).to.match(/can't be blank/);
-                });
+                expect(
+                    find('#user-password-new').siblings('.response').text(),
+                    'new password error when blank'
+                ).to.match(/can't be blank/);
 
                 // validation is cleared when typing
-                fillIn('#user-password-old', 'password');
-                triggerEvent('#user-password-old', 'input');
+                await fillIn('#user-password-old', 'password');
+                await triggerEvent('#user-password-old', 'input');
 
-                andThen(() => {
-                    expect(
-                        find('#user-password-old').closest('.form-group').hasClass('error'),
-                        'old password validation is in error state after typing'
-                    ).to.be.false;
-                });
+                expect(
+                    find('#user-password-old').closest('.form-group').hasClass('error'),
+                    'old password validation is in error state after typing'
+                ).to.be.false;
             });
         });
 
-        it('redirects to 404 when user does not exist', function () {
+        it('redirects to 404 when user does not exist', async function () {
             server.get('/users/slug/unknown/', function () {
                 return new Response(404, {'Content-Type': 'application/json'}, {errors: [{message: 'User not found.', errorType: 'NotFoundError'}]});
             });
 
             errorOverride();
 
-            visit('/team/unknown');
+            await visit('/team/unknown');
 
-            andThen(() => {
-                errorReset();
-                expect(currentPath()).to.equal('error404');
-                expect(currentURL()).to.equal('/team/unknown');
-            });
+            errorReset();
+            expect(currentPath()).to.equal('error404');
+            expect(currentURL()).to.equal('/team/unknown');
         });
     });
 
@@ -914,19 +798,17 @@ describe('Acceptance: Team', function () {
             return authenticateSession(application);
         });
 
-        it('can access the team page', function () {
+        it('can access the team page', async function () {
             server.create('user', {roles: [adminRole]});
             server.create('invite', {roles: [authorRole]});
 
             errorOverride();
 
-            visit('/team');
+            await visit('/team');
 
-            andThen(() => {
-                errorReset();
-                expect(currentPath()).to.equal('team.index');
-                expect(find('.gh-alert').length).to.equal(0);
-            });
+            errorReset();
+            expect(currentPath()).to.equal('team.index');
+            expect(find('.gh-alert').length).to.equal(0);
         });
     });
 });

--- a/tests/acceptance/version-mismatch-test.js
+++ b/tests/acceptance/version-mismatch-test.js
@@ -31,96 +31,82 @@ describe('Acceptance: Version Mismatch', function() {
             return authenticateSession(application);
         });
 
-        it('displays an alert and disables navigation when saving', function () {
+        it('displays an alert and disables navigation when saving', async function () {
             server.createList('post', 3);
 
             // mock the post save endpoint to return version mismatch
             server.put('/posts/:id', versionMismatchResponse);
 
-            visit('/');
-            click('.posts-list li:nth-of-type(2) a'); // select second post
-            click(testSelector('publishmenu-trigger'));
-            click(testSelector('publishmenu-save')); // "Save post"
+            await visit('/');
+            await click('.posts-list li:nth-of-type(2) a'); // select second post
+            await click(testSelector('publishmenu-trigger'));
+            await click(testSelector('publishmenu-save')); // "Save post"
 
-            andThen(() => {
-                // has the refresh to update alert
-                expect(find('.gh-alert').length).to.equal(1);
-                expect(find('.gh-alert').text()).to.match(/refresh/);
-            });
+            // has the refresh to update alert
+            expect(find('.gh-alert').length).to.equal(1);
+            expect(find('.gh-alert').text()).to.match(/refresh/);
 
             // try navigating back to the content list
-            click('.gh-nav-main-content');
+            await click('.gh-nav-main-content');
 
-            andThen(() => {
-                expect(currentPath()).to.equal('editor.edit');
-            });
+            expect(currentPath()).to.equal('editor.edit');
         });
 
-        it('displays alert and aborts the transition when navigating', function () {
-            visit('/');
+        it('displays alert and aborts the transition when navigating', async function () {
+            await visit('/');
 
-            andThen(() => {
-                // mock the tags endpoint to return version mismatch
-                server.get('/tags/', versionMismatchResponse);
-            });
+            // mock the tags endpoint to return version mismatch
+            server.get('/tags/', versionMismatchResponse);
 
-            click('.gh-nav-settings-tags');
+            await click('.gh-nav-settings-tags');
 
-            andThen(() => {
-                // navigation is blocked on loading screen
-                expect(currentPath()).to.equal('settings.tags_loading');
+            // navigation is blocked on loading screen
+            expect(currentPath()).to.equal('settings.tags_loading');
 
-                // has the refresh to update alert
-                expect(find('.gh-alert').length).to.equal(1);
-                expect(find('.gh-alert').text()).to.match(/refresh/);
-            });
+            // has the refresh to update alert
+            expect(find('.gh-alert').length).to.equal(1);
+            expect(find('.gh-alert').text()).to.match(/refresh/);
         });
 
-        it('displays alert and aborts the transition when an ember-ajax error is thrown whilst navigating', function () {
+        it('displays alert and aborts the transition when an ember-ajax error is thrown whilst navigating', async function () {
             server.get('/configuration/timezones/', versionMismatchResponse);
 
-            visit('/settings/tags');
-            click('.gh-nav-settings-general');
+            await visit('/settings/tags');
+            await click('.gh-nav-settings-general');
 
-            andThen(() => {
-                // navigation is blocked
-                expect(currentPath()).to.equal('settings.general_loading');
+            // navigation is blocked
+            expect(currentPath()).to.equal('settings.general_loading');
 
-                // has the refresh to update alert
-                expect(find('.gh-alert').length).to.equal(1);
-                expect(find('.gh-alert').text()).to.match(/refresh/);
-            });
+            // has the refresh to update alert
+            expect(find('.gh-alert').length).to.equal(1);
+            expect(find('.gh-alert').text()).to.match(/refresh/);
         });
 
-        it('can be triggered when passed in to a component', function () {
+        it('can be triggered when passed in to a component', async function () {
             server.post('/subscribers/csv/', versionMismatchResponse);
 
-            visit('/subscribers');
-            click('.gh-btn:contains("Import CSV")');
-            fileUpload('.fullscreen-modal input[type="file"]', ['test'], {name: 'test.csv'});
+            await visit('/subscribers');
+            await click('.gh-btn:contains("Import CSV")');
+            await fileUpload('.fullscreen-modal input[type="file"]', ['test'], {name: 'test.csv'});
 
-            andThen(() => {
-                // alert is shown
-                expect(find('.gh-alert').length).to.equal(1);
-                expect(find('.gh-alert').text()).to.match(/refresh/);
-            });
+            // alert is shown
+            expect(find('.gh-alert').length).to.equal(1);
+            expect(find('.gh-alert').text()).to.match(/refresh/);
         });
     });
 
     describe('logged out', function () {
-        it('displays alert', function () {
+        it('displays alert', async function () {
             server.post('/authentication/token', versionMismatchResponse);
 
-            visit('/signin');
-            fillIn('[name="identification"]', 'test@example.com');
-            fillIn('[name="password"]', 'password');
-            click('.gh-btn-blue');
+            await visit('/signin');
+            await fillIn('[name="identification"]', 'test@example.com');
+            await fillIn('[name="password"]', 'password');
+            await click('.gh-btn-blue');
 
-            andThen(() => {
-                // has the refresh to update alert
-                expect(find('.gh-alert').length).to.equal(1);
-                expect(find('.gh-alert').text()).to.match(/refresh/);
-            });
+            // has the refresh to update alert
+            expect(find('.gh-alert').length).to.equal(1);
+            expect(find('.gh-alert').text()).to.match(/refresh/);
         });
     });
 });


### PR DESCRIPTION
no issue
- replaces `andThen(() => {}` blocks with `async/await` in acceptance tests

![](https://media.giphy.com/media/bzaEWi1Z1xzby/giphy.gif)

https://www.youtube.com/watch?v=oqwzuiSy9y0
