### PR TITLE
Card creation and deletion bugs.

### DIFF
--- a/lib/gh-koenig/addon/components/cards/card-markdown.js
+++ b/lib/gh-koenig/addon/components/cards/card-markdown.js
@@ -42,6 +42,10 @@ export default Component.extend({
     didReceiveAttrs() {
         if (!this.get('isEditing')) {
             this.set('preview', formatMarkdown([this.get('payload').markdown]));
+        } else {
+            run.next(() => {
+                this.$('textarea').focus();
+            });
         }
     },
 

--- a/lib/gh-koenig/addon/components/gh-koenig.js
+++ b/lib/gh-koenig/addon/components/gh-koenig.js
@@ -363,18 +363,16 @@ export default Component.extend({
                 if (forwards && section.next) {
                     range = section.next.toRange();
                     range.tail.offset = 0;
-                    editor.selectRange(range);
                 } else if (section.prev) {
                     range = section.prev.toRange();
                     range.head.offset = range.tail.offset;
-                    editor.selectRange(range);
                 } else if (section.next) {
                     range = section.next.toRange();
                     range.tail.offset = 0;
-                    editor.selectRange(range);
                 }
 
                 card.env.remove();
+                editor.selectRange(range);
             });
         },
         stopEditingCard() {

--- a/lib/gh-koenig/addon/components/gh-koenig.js
+++ b/lib/gh-koenig/addon/components/gh-koenig.js
@@ -369,6 +369,9 @@ export default Component.extend({
                 } else if (section.next) {
                     range = section.next.toRange();
                     range.tail.offset = 0;
+                } else {
+                    card.env.remove();
+                    return;
                 }
 
                 card.env.remove();

--- a/lib/gh-koenig/addon/components/koenig-card.js
+++ b/lib/gh-koenig/addon/components/koenig-card.js
@@ -12,7 +12,7 @@ export default Component.extend({
         this._super(...arguments);
         let card = this.get('card');
         if (card.newlyCreated) {
-            run.schedule('afterRender', this, () => {
+            run.next(() => {
                 if (card.card.launchMode === 'edit') {
                     this.send('startEdit');
                     this.send('selectCard');

--- a/lib/gh-koenig/addon/components/koenig-plus-menu.js
+++ b/lib/gh-koenig/addon/components/koenig-plus-menu.js
@@ -73,10 +73,9 @@ export default Component.extend({
         let $editor = $(this.get('containerSelector'));
 
         input.blur(() => {
-            // nasty hack - give the tool time to execute before removing this from the dom.
-            window.setTimeout(() => {
+            run.later(() => {
                 this.send('closeMenuKeepButton');
-            }, 200);
+            }, 100);
         });
 
         editor.cursorDidChange(() => {
@@ -107,13 +106,7 @@ export default Component.extend({
             run.schedule('afterRender', this,
                 () => {
                     let button = this.$('.gh-cardmenu-button');
-
                     button.css('top', offset.top + $editor.scrollTop() - editorOffset.top - 2);
-                    if (currentNode.tagName.toLowerCase() === 'li') {
-                     //   button.css('left', this.$(currentNode.parentNode).position().left + $editor.scrollLeft());
-                    } else {
-                     //   button.css('left', offset.left + $editor.scrollLeft() - 50);
-                    }
                 });
         });
     },


### PR DESCRIPTION
Closes: https://github.com/TryGhost/Ghost/issues/8312

1. Currently when adding cards via the `+` menu the card is not selected or placed in edit mode. This update means that cards created with the `+` menu behave the way as with the `/` menu.

2. If a card is deleted and the deletion places the cursor in an empty section of the document the editor places the `+` menu icon before the card is deleted, this means that the `+` button appears below the actual blank paragraph. Now the card placement occurs after the card has been removed from the editor.

3. Currently when a markdown card is created it does not launch in edit mode, this has now been rectified.


![menu fix](https://cloud.githubusercontent.com/assets/73181/25321816/befb78a6-2905-11e7-9a25-1d8d6b407656.gif)
