### PR TITLE
🐝 Strip HTML from title.

### DIFF
--- a/tests/acceptance/editor-test.js
+++ b/tests/acceptance/editor-test.js
@@ -12,7 +12,7 @@ import {invalidateSession, authenticateSession} from 'ghost-admin/tests/helpers/
 import Mirage from 'ember-cli-mirage';
 import sinon from 'sinon';
 import testSelector from 'ember-test-selectors';
-import {titleRendered} from '../helpers/editor-helpers';
+import {titleRendered, replaceTitleHTML} from '../helpers/editor-helpers';
 import moment from 'moment';
 
 describe('Acceptance: Editor', function() {
@@ -326,7 +326,7 @@ describe('Acceptance: Editor', function() {
             ).to.match(/Title cannot be longer than 150 characters/);
         });
 
-        it('if title is blank it correctly shows the placeholder', async function () {
+        it('inserts a placeholder if the title is blank', async function () {
             server.createList('post', 1);
 
             // post id 1 is a draft, checking for draft behaviour now
@@ -346,6 +346,22 @@ describe('Acceptance: Editor', function() {
             await title.html('test');
 
             expect(title.hasClass('no-content')).to.be.false;
+        });
+
+        it('removes HTML from the title.', async function () {
+            server.createList('post', 1);
+
+            // post id 1 is a draft, checking for draft behaviour now
+            await visit('/editor/1');
+
+            expect(currentURL(), 'currentURL')
+                .to.equal('/editor/1');
+
+            titleRendered();
+
+            let title = find('#gh-editor-title div');
+            await replaceTitleHTML('<div>TITLE&nbsp;&#09;&nbsp;&thinsp;&ensp;&emsp;TEST</div>&nbsp;');
+            expect(title.html()).to.equal('TITLE      TEST ');
         });
 
         it('renders first countdown notification before scheduled time', async function () {

--- a/tests/helpers/editor-helpers.js
+++ b/tests/helpers/editor-helpers.js
@@ -29,6 +29,29 @@ export function titleRendered() {
     });
 }
 
+// replaces the title text content with HTML and returns once the HTML has been placed.
+// takes into account converting to plaintext.
+export function replaceTitleHTML(HTML) {
+        return Ember.Test.promise(function (resolve, reject) { // eslint-disable-line
+            let startTimestamp = Date.now();
+            let title = $('#gh-editor-title div');
+            title.html(HTML);
+            function checkTitle() {
+                if (!title[0].innerHTML.includes('<')) {
+                    return resolve();
+                } else {
+                    // timeout after 200ms
+                    if (Date.now() + 200 < startTimestamp) {
+                        return reject();
+                    } else {
+                        window.requestAnimationFrame(checkTitle);
+                    }
+                }
+            }
+            checkTitle();
+        });
+}
+
 // simulates text inputs into the editor, unfortunately the helper Ember helper functions
 // don't work on content editable so we have to manipuate the text input event manager
 // in mobiledoc-kit directly. This is a private API.

--- a/tests/helpers/editor-helpers.js
+++ b/tests/helpers/editor-helpers.js
@@ -1,5 +1,9 @@
 import Ember from 'ember';
 import $ from 'jquery';
+import run from 'ember-runloop';
+import wait from 'ember-test-helpers/wait';
+import {findWithAssert} from 'ember-native-dom-helpers';
+
 // polls the editor until it's started.
 export function editorRendered() {
     return Ember.Test.promise(function (resolve) { // eslint-disable-line
@@ -32,24 +36,9 @@ export function titleRendered() {
 // replaces the title text content with HTML and returns once the HTML has been placed.
 // takes into account converting to plaintext.
 export function replaceTitleHTML(HTML) {
-        return Ember.Test.promise(function (resolve, reject) { // eslint-disable-line
-            let startTimestamp = Date.now();
-            let title = $('#gh-editor-title div');
-            title.html(HTML);
-            function checkTitle() {
-                if (!title[0].innerHTML.includes('<')) {
-                    return resolve();
-                } else {
-                    // timeout after 200ms
-                    if (Date.now() + 200 < startTimestamp) {
-                        return reject();
-                    } else {
-                        window.requestAnimationFrame(checkTitle);
-                    }
-                }
-            }
-            checkTitle();
-        });
+    let el = findWithAssert('#gh-editor-title div');
+    run(() => el.innerHTML = HTML);
+    return (window.wait || wait)();
 }
 
 // simulates text inputs into the editor, unfortunately the helper Ember helper functions


### PR DESCRIPTION
Closes: https://github.com/TryGhost/Ghost/issues/8353

Currently when you paste HTML into the title (or modify the title in some other way that inserts HTML) the title keeps the styling which is not saved.

This update detects if HTML is included into the title and strips it if it exists. 

![pastehtmlintotitle](https://cloud.githubusercontent.com/assets/73181/25323784/dd4bf2e4-2915-11e7-880b-68086be5bca6.gif)
