### PR TITLE
🖌  Remove "Fira Sans" system font

### DIFF
--- a/app/styles/patterns/global.css
+++ b/app/styles/patterns/global.css
@@ -16,7 +16,7 @@
     --green: #a4d037;
     /* Style values */
     --border-radius: 4px;
-    --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+    --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Droid Sans", "Helvetica Neue", sans-serif;
     --font-family-mono: Consolas, "Liberation Mono", Menlo, Courier, monospace;
 }
 


### PR DESCRIPTION
closes TryGhost/Ghost#8136

The "Fira Sans" system font looks - even on a retina display - not very readable for users.

![image](https://cloud.githubusercontent.com/assets/8037602/25327924/417ac564-28d6-11e7-87f0-9789ea6862a9.png)
