### PR TITLE
Ensure that editing cards are not hard-selected

### DIFF
--- a/lib/gh-koenig/addon/components/gh-koenig.js
+++ b/lib/gh-koenig/addon/components/gh-koenig.js
@@ -240,6 +240,12 @@ export default Component.extend({
                 throw new Error('A selection must include a cardId');
             }
 
+            // don't hard select an editing card.
+            if (this.editedCard && this.editedCard.id === cardId) {
+                this.send('editCard', cardId);
+                return;
+            }
+
             let card = this.get('emberCards').find((card) => card.id === cardId);
             let cardHolder = $(`#${cardId}`).parents('.kg-card');
             let selectedCard = this.get('selectedCard');
@@ -353,6 +359,7 @@ export default Component.extend({
         editCard(cardId) {
             let card = this.get('emberCards').find((card) => card.id === cardId);
             this.set('editedCard', card);
+            this.send('selectCard', cardId);
         },
         deleteCard(cardId, forwards = false) {
             let editor = this.get('editor');


### PR DESCRIPTION
If a card that is being edited is hard-selected then make sure that it is in fact soft-selected.

closes https://github.com/TryGhost/Ghost/issues/8385

![hard-select-bug](https://cloud.githubusercontent.com/assets/73181/25383365/e99adc0e-2a0f-11e7-8ed8-8ba00d696078.gif)

