### PR TITLE
[WIP] Only execute a slashmenu tool on enter if it exists.

### DIFF
--- a/lib/gh-koenig/addon/components/koenig-slash-menu.js
+++ b/lib/gh-koenig/addon/components/koenig-slash-menu.js
@@ -184,9 +184,12 @@ export default Component.extend({
 
                     let {range} = postEditor;
 
-                    range.head.offset = self.get('range').startOffset - 1;
-                    postEditor.deleteRange(range);
-                    self.get('selectedTool').onClick(self.get('editor'));
+                    if (self.get('selectedTool')) {
+                        range.head.offset = self.get('range').startOffset - 1;
+                        postEditor.deleteRange(range);
+                        self.get('selectedTool').onClick(self.get('editor'));
+                    }
+
                     self.send('closeMenu');
                 }
             });


### PR DESCRIPTION
Prevents the slash menu from deleting the content from the '/' to the end of the range if no command is entered.

issue https://github.com/TryGhost/Ghost/issues/8387
![slashmenu-fix](https://cloud.githubusercontent.com/assets/73181/25384151/50240d62-2a13-11e7-96a7-4e2d57653acb.gif)
