### PR TITLE
Fix for Spinner invisible issue

### DIFF
--- a/app/components/gh-task-button.js
+++ b/app/components/gh-task-button.js
@@ -32,7 +32,7 @@ const GhTaskButton = Component.extend({
     buttonText: 'Save',
     runningText: reads('buttonText'),
     idleClass: '',
-    runningClass: '',
+    runningClass: 'gh-btn-blue',
     successText: 'Saved',
     successClass: 'gh-btn-green',
     failureText: 'Retry',


### PR DESCRIPTION
closes - TryGhost/Ghost#8412

Added the class name for running buttons in `gh-task-button.js`  . Now the running button becomes blue and makes the spinner visible.