### PR TITLE
Fixes broken team screen issue

### DIFF
--- a/app/templates/team/index.hbs
+++ b/app/templates/team/index.hbs
@@ -88,7 +88,9 @@
                     {{/gh-user-active}}
                 {{else}}
                     {{#gh-user-active user=user as |component|}}
-                        <li class="ember-view active user-list-item">{{partial 'user-list-item'}}</li>
+                        {{#if (is-equal session.user.id user.id)}}
+                            {{partial 'user-list-item'}}
+                        {{/if}}
                     {{/gh-user-active}}
                 {{/unless}}
             {{/each}}


### PR DESCRIPTION
closes - TryGhost/Ghost#8409

This PR changes - 
1. Fixes the styling issue of Team Screen page when logged is as Author.
2. Authors now only be able to view their own user in the Team list.