### PR TITLE
🗜  Database soft limits

### DIFF
--- a/app/validators/post.js
+++ b/app/validators/post.js
@@ -13,8 +13,8 @@ export default BaseValidator.create({
             this.invalidate();
         }
 
-        if (!validator.isLength(title, 0, 150)) {
-            model.get('errors').add('title', 'Title cannot be longer than 150 characters.');
+        if (!validator.isLength(title, 0, 255)) {
+            model.get('errors').add('title', 'Title cannot be longer than 255 characters.');
             this.invalidate();
         }
     },
@@ -22,8 +22,8 @@ export default BaseValidator.create({
     metaTitle(model) {
         let metaTitle = model.get('metaTitle');
 
-        if (!validator.isLength(metaTitle, 0, 150)) {
-            model.get('errors').add('metaTitle', 'Meta Title cannot be longer than 150 characters.');
+        if (!validator.isLength(metaTitle, 0, 300)) {
+            model.get('errors').add('metaTitle', 'Meta Title cannot be longer than 300 characters.');
             this.invalidate();
         }
     },
@@ -31,8 +31,8 @@ export default BaseValidator.create({
     metaDescription(model) {
         let metaDescription = model.get('metaDescription');
 
-        if (!validator.isLength(metaDescription, 0, 200)) {
-            model.get('errors').add('metaDescription', 'Meta Description cannot be longer than 200 characters.');
+        if (!validator.isLength(metaDescription, 0, 500)) {
+            model.get('errors').add('metaDescription', 'Meta Description cannot be longer than 500 characters.');
             this.invalidate();
         }
     },

--- a/app/validators/tag-settings.js
+++ b/app/validators/tag-settings.js
@@ -39,8 +39,8 @@ export default BaseValidator.create({
     metaTitle(model) {
         let metaTitle = model.get('metaTitle');
 
-        if (!validator.isLength(metaTitle, 0, 150)) {
-            model.get('errors').add('metaTitle', 'Meta Title cannot be longer than 150 characters.');
+        if (!validator.isLength(metaTitle, 0, 300)) {
+            model.get('errors').add('metaTitle', 'Meta Title cannot be longer than 300 characters.');
             this.invalidate();
         }
     },
@@ -48,8 +48,8 @@ export default BaseValidator.create({
     metaDescription(model) {
         let metaDescription = model.get('metaDescription');
 
-        if (!validator.isLength(metaDescription, 0, 200)) {
-            model.get('errors').add('metaDescription', 'Meta Description cannot be longer than 200 characters.');
+        if (!validator.isLength(metaDescription, 0, 500)) {
+            model.get('errors').add('metaDescription', 'Meta Description cannot be longer than 500 characters.');
             this.invalidate();
         }
     }

--- a/tests/acceptance/editor-test.js
+++ b/tests/acceptance/editor-test.js
@@ -325,7 +325,7 @@ describe('Acceptance: Editor', function() {
             expect(currentURL(), 'currentURL')
                 .to.equal('/editor/1');
 
-            await fillIn(testSelector('editor-title-input'), Array(160).join('a'));
+            await fillIn(testSelector('editor-title-input'), Array(260).join('a'));
             await click(testSelector('publishmenu-trigger'));
             await click(testSelector('publishmenu-save'));
 
@@ -337,7 +337,7 @@ describe('Acceptance: Editor', function() {
             expect(
                 find('.gh-alert').text(),
                 'alert text after invalid title'
-            ).to.match(/Title cannot be longer than 150 characters/);
+            ).to.match(/Title cannot be longer than 255 characters/);
         });
 
         // NOTE: these tests are specific to the mobiledoc editor

--- a/tests/unit/validators/tag-settings-test.js
+++ b/tests/unit/validators/tag-settings-test.js
@@ -224,10 +224,10 @@ describe('Unit: Validator: tag-settings', function () {
     // model/validator respectively - this should be standardised
     it('passes with a valid metaTitle', function () {
         // longest valid metaTitle
-        let tag = Tag.create({metaTitle: (new Array(151).join('x'))});
+        let tag = Tag.create({metaTitle: (new Array(301).join('x'))});
         let passed = false;
 
-        expect(tag.get('metaTitle').length, 'metaTitle length').to.equal(150);
+        expect(tag.get('metaTitle').length, 'metaTitle length').to.equal(300);
 
         run(() => {
             tag.validate({property: 'metaTitle'}).then(() => {
@@ -241,11 +241,11 @@ describe('Unit: Validator: tag-settings', function () {
 
     it('validates metaTitle length', function () {
         // shortest invalid metaTitle
-        let tag = Tag.create({metaTitle: (new Array(152).join('x'))});
+        let tag = Tag.create({metaTitle: (new Array(302).join('x'))});
         let passed = false;
         let errors;
 
-        expect(tag.get('metaTitle').length, 'metaTitle length').to.equal(151);
+        expect(tag.get('metaTitle').length, 'metaTitle length').to.equal(301);
 
         run(() => {
             tag.validate({property: 'metaTitle'}).then(() => {
@@ -255,7 +255,7 @@ describe('Unit: Validator: tag-settings', function () {
 
         errors = tag.get('errors').errorsFor('metaTitle')[0];
         expect(errors.attribute, 'errors.metaTitle.attribute').to.equal('metaTitle');
-        expect(errors.message, 'errors.metaTitle.message').to.equal('Meta Title cannot be longer than 150 characters.');
+        expect(errors.message, 'errors.metaTitle.message').to.equal('Meta Title cannot be longer than 300 characters.');
 
         expect(passed, 'passed').to.be.false;
         expect(tag.get('hasValidated'), 'hasValidated').to.include('metaTitle');
@@ -265,10 +265,10 @@ describe('Unit: Validator: tag-settings', function () {
     // the model/validator respectively - this should be standardised
     it('passes with a valid metaDescription', function () {
         // longest valid description
-        let tag = Tag.create({metaDescription: (new Array(201).join('x'))});
+        let tag = Tag.create({metaDescription: (new Array(501).join('x'))});
         let passed = false;
 
-        expect(tag.get('metaDescription').length, 'metaDescription length').to.equal(200);
+        expect(tag.get('metaDescription').length, 'metaDescription length').to.equal(500);
 
         run(() => {
             tag.validate({property: 'metaDescription'}).then(() => {
@@ -282,11 +282,11 @@ describe('Unit: Validator: tag-settings', function () {
 
     it('validates metaDescription length', function () {
         // shortest invalid metaDescription
-        let tag = Tag.create({metaDescription: (new Array(202).join('x'))});
+        let tag = Tag.create({metaDescription: (new Array(502).join('x'))});
         let passed = false;
         let errors;
 
-        expect(tag.get('metaDescription').length, 'metaDescription length').to.equal(201);
+        expect(tag.get('metaDescription').length, 'metaDescription length').to.equal(501);
 
         run(() => {
             tag.validate({property: 'metaDescription'}).then(() => {
@@ -296,7 +296,7 @@ describe('Unit: Validator: tag-settings', function () {
 
         errors = tag.get('errors').errorsFor('metaDescription')[0];
         expect(errors.attribute, 'errors.metaDescription.attribute').to.equal('metaDescription');
-        expect(errors.message, 'errors.metaDescription.message').to.equal('Meta Description cannot be longer than 200 characters.');
+        expect(errors.message, 'errors.metaDescription.message').to.equal('Meta Description cannot be longer than 500 characters.');
 
         expect(passed, 'passed').to.be.false;
         expect(tag.get('hasValidated'), 'hasValidated').to.include('metaDescription');


### PR DESCRIPTION
closes TryGhost/Ghost#8143

- uses new soft limits in validation:
	- post title to 255
	- meta title (post and tag) to 300
	- meta description (post and tag) to 500
- updates test