### PR TITLE
✨ upload images via editor toolbar

### DIFF
--- a/app/components/gh-editor.js
+++ b/app/components/gh-editor.js
@@ -147,6 +147,10 @@ export default Component.extend({
             run.scheduleOnce('afterRender', this, this._setHeaderClass);
         },
 
+        uploadImages(fileList) {
+            this.set('droppedFiles', fileList);
+        },
+
         uploadComplete(uploads) {
             this.set('uploadedImageUrls', uploads.mapBy('url'));
             this.set('droppedFiles', null);

--- a/app/components/gh-simplemde.js
+++ b/app/components/gh-simplemde.js
@@ -31,10 +31,6 @@ export default TextArea.extend({
             autofocus: this.get('autofocus'),
             indentWithTabs: false,
             placeholder: this.get('placeholder'),
-            shortcuts: {
-                toggleSideBySide: null,
-                toggleFullScreen: null
-            },
             tabSize: 4
         };
     }),

--- a/app/templates/components/gh-editor.hbs
+++ b/app/templates/components/gh-editor.hbs
@@ -10,4 +10,5 @@
     toggleSplitScreen=(action "toggleSplitScreen")
     uploadComplete=(action "uploadComplete")
     uploadCancelled=(action "uploadCancelled")
+    uploadImages=(action "uploadImages")
 )}}

--- a/app/templates/components/gh-markdown-editor.hbs
+++ b/app/templates/components/gh-markdown-editor.hbs
@@ -11,3 +11,7 @@
     isSplitScreen=_isSplitScreen
     focus=(action "focusEditor")
 )}}
+
+<div style="display:none">
+    {{gh-file-input multiple=true action=(action onImageFilesSelected) accept=imageMimeTypes}}
+</div>

--- a/app/templates/editor/edit.hbs
+++ b/app/templates/editor/edit.hbs
@@ -43,7 +43,9 @@
         onChange=(action "updateScratch")
         onFullScreen=(action editor.toggleFullScreen)
         onSplitScreen=(action editor.toggleSplitScreen)
+        onImageFilesSelected=(action editor.uploadImages)
         showMarkdownHelp=(route-action "toggleMarkdownHelpModal")
+        imageMimeTypes=editor.imageMimeTypes
         as |markdown|
     }}
         <div class="gh-markdown-editor-pane">


### PR DESCRIPTION
no issue
- adds a hidden file input to the `gh-markdown-editor` component
- when the editor image toolbar button is clicked, capture the current selection (it gets during the file upload), trigger the file dialog then when files are selected initiate the same upload+insert process as drag/drop image uploads