### PR TITLE
🐛 fix visible scroll bars and disable preview in split-screen

### DIFF
--- a/app/components/gh-markdown-editor.js
+++ b/app/components/gh-markdown-editor.js
@@ -296,6 +296,7 @@ export default Component.extend({
 
         toggleSplitScreen() {
             let isSplitScreen = !this.get('_isSplitScreen');
+            let previewButton = this._editor.toolbarElements.preview;
 
             this.set('_isSplitScreen', isSplitScreen);
             this._updateButtonState();
@@ -304,8 +305,19 @@ export default Component.extend({
             // afterRender is needed so that necessary components have been
             // added/removed and editor pane length has settled
             if (isSplitScreen) {
+                // disable the normal SimpleMDE preview if it's active
+                if (this._editor.isPreviewActive()) {
+                    let preview = this._editor.toolbar.find((button) => {
+                        return button.name === 'preview';
+                    });
+
+                    preview.action(this._editor);
+                }
+
+                previewButton.classList.add('disabled');
                 run.scheduleOnce('afterRender', this, this._connectSplitPreview);
             } else {
+                previewButton.classList.remove('disabled');
                 run.scheduleOnce('afterRender', this, this._disconnectSplitPreview);
             }
 

--- a/app/styles/layouts/editor.css
+++ b/app/styles/layouts/editor.css
@@ -298,6 +298,11 @@
     overflow: visible;
 }
 
+/* fix visible scrollbars when OSX is set to show them */
+.gh-editor .CodeMirror-scroll {
+    overflow: visible !important;
+}
+
 .gh-editor .gh-editor-title,
 .gh-editor .CodeMirror-wrap {
     max-width: 760px;
@@ -360,4 +365,13 @@
 /* TODO: need a way to make stroke + fill global without causing issues with certain icons */
 .gh-editor-image-upload .gh-btn-grey svg path {
     stroke: color(var(--darkgrey) l(+15%));
+}
+
+.editor-toolbar a.disabled {
+    pointer-events: none;
+    color: lightgray !important;
+}
+
+.editor-toolbar a.disabled:hover {
+    border: none;
 }


### PR DESCRIPTION
no issue
- fix visible scroll bars being rendered to the right and bottom of the internal editor area in certain browser/OS configurations
- disable the preview button when in split-screen mode as it's not any use there
- exit SimpleMDE preview mode if it's active when entering split-screen mode