### PR TITLE
🐛 fix editor image uploads in Edge

### DIFF
--- a/app/components/gh-uploader.js
+++ b/app/components/gh-uploader.js
@@ -106,7 +106,10 @@ export default Component.extend({
         let ok = [];
         let errors = [];
 
-        for (let file of files) {
+        // NOTE: for...of loop results in a transpilation that errors in Edge,
+        // once we drop IE11 support we should be able to use native for...of
+        for (let i = 0; i < files.length; i++) {
+            let file = files[i];
             let result = validate(file);
             if (result === true) {
                 ok.push(file);
@@ -147,8 +150,10 @@ export default Component.extend({
 
         this.onStart();
 
-        for (let file of files) {
-            uploads.push(this.get('_uploadFile').perform(file));
+        // NOTE: for...of loop results in a transpilation that errors in Edge,
+        // once we drop IE11 support we should be able to use native for...of
+        for (let i = 0; i < files.length; i++) {
+            uploads.push(this.get('_uploadFile').perform(files[i]));
         }
 
         // populates this.errors and this.uploadUrls


### PR DESCRIPTION
no issue
- babel's transpilation of the `for...of` loops was resulting in an error in MS Edge, dropping back to an old `for` loop fixed it
