### PR TITLE
🐛 permit Facebook usernames with less than 5 chars

### DIFF
--- a/app/controllers/settings/general.js
+++ b/app/controllers/settings/general.js
@@ -168,8 +168,8 @@ export default Controller.extend(SettingsSaveMixin, {
                     // we got a page url, now save the username without the / in the beginning
 
                     [ , username ] = username.match(/^(?:\/)?(pages?\/\S+)/mi);
-                } else if (username.match(/^(http|www)|(\/)/) || !username.match(/^([a-z\d\.]{5,50})$/mi)) {
-                    errMessage = !username.match(/^([a-z\d\.]{5,50})$/mi) ? 'Your Page name is not a valid Facebook Page name' : 'The URL must be in a format like https://www.facebook.com/yourPage';
+                } else if (username.match(/^(http|www)|(\/)/) || !username.match(/^([a-z\d\.]{1,50})$/mi)) {
+                    errMessage = !username.match(/^([a-z\d\.]{1,50})$/mi) ? 'Your Page name is not a valid Facebook Page name' : 'The URL must be in a format like https://www.facebook.com/yourPage';
 
                     this.get('model.errors').add('facebook', errMessage);
                     this.get('model.hasValidated').pushObject('facebook');

--- a/app/controllers/team/user.js
+++ b/app/controllers/team/user.js
@@ -240,8 +240,8 @@ export default Controller.extend({
                     // we got a page url, now save the username without the / in the beginning
 
                     [ , username ] = username.match(/^(?:\/)?(pages?\/\S+)/mi);
-                } else if (username.match(/^(http|www)|(\/)/) || !username.match(/^([a-z\d\.]{5,50})$/mi)) {
-                    errMessage = !username.match(/^([a-z\d\.]{5,50})$/mi) ? 'Your Username is not a valid Facebook Username' : 'The URL must be in a format like https://www.facebook.com/yourUsername';
+                } else if (username.match(/^(http|www)|(\/)/) || !username.match(/^([a-z\d\.]{1,50})$/mi)) {
+                    errMessage = !username.match(/^([a-z\d\.]{1,50})$/mi) ? 'Your Username is not a valid Facebook Username' : 'The URL must be in a format like https://www.facebook.com/yourUsername';
 
                     this.get('user.errors').add('facebook', errMessage);
                     this.get('user.hasValidated').pushObject('facebook');

--- a/tests/acceptance/settings/general-test.js
+++ b/tests/acceptance/settings/general-test.js
@@ -255,8 +255,9 @@ describe('Acceptance: Settings - General', function () {
             triggerEvent('#settings-general input[name="general[facebook]"]', 'blur');
 
             andThen(() => {
+                expect(find('#settings-general input[name="general[facebook]"]').val()).to.be.equal('https://www.facebook.com/ab99');
                 expect(find('#settings-general .error .response').text().trim(), 'inline validation response')
-                    .to.equal('Your Page name is not a valid Facebook Page name');
+                    .to.equal('');
             });
 
             fillIn('#settings-general input[name="general[facebook]"]', 'page/ab99');

--- a/tests/acceptance/team-test.js
+++ b/tests/acceptance/team-test.js
@@ -438,7 +438,8 @@ describe('Acceptance: Team', function () {
                 triggerEvent('#user-facebook', 'blur');
 
                 andThen(() => {
-                    expect(find('#user-facebook').closest('.form-group').hasClass('error'), 'facebook input should be in error state').to.be.true;
+                    expect(find('#user-facebook').val()).to.be.equal('https://www.facebook.com/test');
+                    expect(find('#user-facebook').closest('.form-group').hasClass('error'), 'facebook input should be in error state').to.be.false;
                 });
 
                 fillIn('#user-facebook', '');


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8296
- permit Facebook usernames with less than 5 chars
    - brands are allowed to have Page names with less than 5 chars (ex: facebook.com/nike)
    - current/former employees are allowed to have usernames with less than 5 chars (ex: facebook.com/zuck)