### PR TITLE
🐛 fix broken editor layout in Safari

### DIFF
--- a/app/styles/layouts/editor.css
+++ b/app/styles/layouts/editor.css
@@ -241,7 +241,7 @@
 .gh-markdown-editor {
     position: relative;
     width: 100%;
-    height: 100%;
+    height: 100vh;
     overflow-y: auto;
     z-index: 0;
 }


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8459
- use `vh` instead of `%` for editor height