### PR TITLE
✨ use image name as alt text when inserting images

### DIFF
--- a/app/components/gh-markdown-editor.js
+++ b/app/components/gh-markdown-editor.js
@@ -170,7 +170,15 @@ export default Component.extend({
 
         // loop through urls and generate image markdown
         let images = urls.map((url) => {
-            return `![](${url})`;
+            let filename = url.split('/').pop();
+            let alt = filename;
+
+            // if we have a normal filename.ext, set alt to filename -ext
+            if (filename.lastIndexOf('.') > 0) {
+                alt = filename.slice(0, filename.lastIndexOf('.'));
+            }
+
+            return `![${alt}](${url})`;
         });
         let text = images.join(' ');
 


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8462
- grab image filename and remove extension before inserting it as `alt` text when uploading images