### PR TITLE
✨ streamline image uploads in settings/general

### DIFF
--- a/app/components/gh-uploader.js
+++ b/app/components/gh-uploader.js
@@ -153,6 +153,7 @@ export default Component.extend({
     _uploadFiles: task(function* (files) {
         let uploads = [];
 
+        this._reset();
         this.onStart();
 
         // NOTE: for...of loop results in a transpilation that errors in Edge,
@@ -269,10 +270,11 @@ export default Component.extend({
     },
 
     _reset() {
-        this.set('errors', null);
+        this.set('errors', []);
         this.set('totalSize', 0);
         this.set('uploadedSize', 0);
         this.set('uploadPercentage', 0);
+        this.set('uploadUrls', []);
         this._uploadTrackers = [];
     },
 

--- a/app/components/gh-uploader.js
+++ b/app/components/gh-uploader.js
@@ -18,6 +18,13 @@ import run from 'ember-runloop';
 // "allowMultiple" attribute so that single-image uploads don't allow multiple
 // simultaneous uploads
 
+/**
+ * Result from a file upload
+ * @typedef {Object} UploadResult
+ * @property {string} fileName - file name, eg "my-image.png"
+ * @property {string} url - url relative to Ghost root,eg "/content/images/2017/05/my-image.png"
+ */
+
 const UploadTracker = EmberObject.extend({
     file: null,
     total: 0,
@@ -240,7 +247,7 @@ export default Component.extend({
     // NOTE: this is necessary because the API doesn't accept direct file uploads
     _getFormData(file) {
         let formData = new FormData();
-        formData.append(this.get('paramName'), file);
+        formData.append(this.get('paramName'), file, file.name);
         return formData;
     },
 

--- a/app/styles/layouts/settings.css
+++ b/app/styles/layouts/settings.css
@@ -33,12 +33,24 @@
     letter-spacing: 0.3px;
 }
 
+.gh-setting-error {
+    margin-top: 1em;
+    line-height: 1.3em;
+    color: var(--red);
+    font-weight: 200;
+    letter-spacing: 0.3px;
+}
+
 .gh-setting-action {
     flex-shrink: 0;
     margin: 1px 0 0 0;
 }
 
 /* Images */
+
+.gh-setting-action-smallimg {
+    position: relative;
+}
 
 .gh-setting-action-smallimg img {
     height: 50px;
@@ -57,6 +69,36 @@
     cursor: pointer;
 }
 
+.gh-setting-action-smallimg-delete,
+.gh-setting-action-largeimg-delete {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    color: var(--midgrey);
+    text-decoration: none;
+    font-size: 13px;
+    line-height: 10px;
+}
+
+.gh-setting-action-smallimg-delete:hover,
+.gh-setting-action-largeimg-delete:hover {
+    color: var(--red);
+    text-decoration: underline;
+}
+
+.gh-setting-action .gh-progress-container {
+    width: 113px;
+    height: 100%;
+}
+
+.gh-setting-action .gh-progress-container-progress {
+    width: 100%;
+}
+
+.gh-setting-action .gh-progress-bar {
+    height: 9px;
+}
 
 /* Checkboxes */
 

--- a/app/templates/components/gh-uploader.hbs
+++ b/app/templates/components/gh-uploader.hbs
@@ -1,6 +1,7 @@
 {{yield (hash
-    progressBar=(component "gh-progress-bar" percentage=uploadPercentage)
-    files=files
-    errors=errors
     cancel=(action "cancel")
+    errors=errors
+    files=files
+    isUploading=_uploadFiles.isRunning
+    progressBar=(component "gh-progress-bar" percentage=uploadPercentage)
 )}}

--- a/app/templates/settings/general.hbs
+++ b/app/templates/settings/general.hbs
@@ -52,65 +52,111 @@
         </div>
 
         <div class="gh-setting-header">Publication identity</div>
-        <div class="gh-setting">
+        <div class="gh-setting" data-test-setting="icon">
+            {{#gh-uploader
+                files=iconUpload
+                extensions=iconExtensions
+                uploadUrl="/uploads/icon/"
+                onComplete=(action "imageUploaded" "icon")
+                as |uploader|
+            }}
             <div class="gh-setting-content">
                 <div class="gh-setting-title">Publication icon</div>
                 <div class="gh-setting-desc">A square, social icon used in the UI of your publication, at least 60x60px</div>
+                {{#if uploader.errors}}
+                    {{#each uploader.errors as |error|}}
+                        <div class="gh-setting-error" data-test-error="icon">{{error.message}}</div>
+                    {{/each}}
+                {{/if}}
             </div>
             <div class="gh-setting-action gh-setting-action-smallimg">
                 {{#if model.icon}}
-                    <img class="blog-icon" src="{{model.icon}}" alt="icon" role="button" {{action "toggleUploadIconModal"}}>
+                    <img class="blog-icon" src="{{model.icon}}" alt="icon" data-test-icon-img>
+                    <button type="button" class="gh-setting-action-smallimg-delete" {{action "removeImage" "icon"}} data-test-delete-image="icon">
+                        <span>delete</span>
+                    </button>
+                {{else if uploader.isUploading}}
+                    {{uploader.progressBar}}
                 {{else}}
-                    <button type="button" class="gh-btn" {{action "toggleUploadIconModal"}}><span>Upload Image</span></button>
+                    <button type="button" class="gh-btn" onClick={{action "triggerFileDialog"}} data-test-image-upload-btn="icon">
+                        <span>Upload Image</span>
+                    </button>
                 {{/if}}
-
-                {{#if showUploadIconModal}}
-                    {{gh-fullscreen-modal "upload-image"
-                            model=(hash model=model imageProperty="icon" accept=iconMimeTypes extensions=iconExtensions uploadUrl="/uploads/icon/")
-                            close=(action "toggleUploadIconModal")
-                            modifier="action wide"}}
-                {{/if}}
+                <div style="display:none">
+                    {{gh-file-input multiple=false action=(action (mut iconUpload)) accept=iconMimeTypes data-test-file-input="icon"}}
+                </div>
             </div>
+            {{/gh-uploader}}
         </div>
-        <div class="gh-setting">
+        <div class="gh-setting" data-test-setting="logo">
+            {{#gh-uploader
+                files=logoUpload
+                extensions=imageExtensions
+                onComplete=(action "imageUploaded" "logo")
+                as |uploader|
+            }}
             <div class="gh-setting-content">
                 <div class="gh-setting-title">Publication logo</div>
                 <div class="gh-setting-desc">The primary logo for your brand displayed across your theme, should be transparent and at least 600px x 72px</div>
+                {{#if uploader.errors}}
+                    {{#each uploader.errors as |error|}}
+                        <div class="gh-setting-error" data-test-error="logo">{{error.message}}</div>
+                    {{/each}}
+                {{/if}}
             </div>
             <div class="gh-setting-action gh-setting-action-smallimg">
                 {{#if model.logo}}
-                    <img class="blog-logo" src="{{model.logo}}" alt="logo" role="button" {{action "toggleUploadLogoModal"}}>
+                    <img class="blog-logo" src="{{model.logo}}" alt="logo" data-test-logo-img>
+                    <button type="button" class="gh-setting-action-smallimg-delete" {{action "removeImage" "logo"}} data-test-delete-image="logo">
+                        <span>delete</span>
+                    </button>
+                {{else if uploader.isUploading}}
+                    {{uploader.progressBar}}
                 {{else}}
-                    <button type="button" class="gh-btn" {{action "toggleUploadLogoModal"}}><span>Upload Image</span></button>
+                    <button type="button" class="gh-btn" onClick={{action "triggerFileDialog"}} data-test-image-upload-btn="logo">
+                        <span>Upload Image</span>
+                    </button>
                 {{/if}}
-
-                {{#if showUploadLogoModal}}
-                    {{gh-fullscreen-modal "upload-image"
-                            model=(hash model=model imageProperty="logo")
-                            close=(action "toggleUploadLogoModal")
-                            modifier="action wide"}}
-                {{/if}}
+                <div style="display:none">
+                    {{gh-file-input multiple=false action=(action (mut logoUpload)) accept=imageMimeTypes data-test-file-input="logo"}}
+                </div>
             </div>
+            {{/gh-uploader}}
         </div>
-        <div class="gh-setting">
+        <div class="gh-setting" data-test-setting="coverImage">
+            {{#gh-uploader
+                files=coverImageUpload
+                extensions=imageExtensions
+                onComplete=(action "imageUploaded" "coverImage")
+                as |uploader|
+            }}
             <div class="gh-setting-content">
                 <div class="gh-setting-title">Publication cover</div>
                 <div class="gh-setting-desc">An optional large background image for your site</div>
+                {{#if uploader.errors}}
+                    {{#each uploader.errors as |error|}}
+                        <div class="gh-setting-error" data-test-error="coverImage">{{error.message}}</div>
+                    {{/each}}
+                {{/if}}
             </div>
             <div class="gh-setting-action gh-setting-action-largeimg">
                 {{#if model.coverImage}}
-                    <img class="blog-cover" src="{{model.coverImage}}" alt="cover photo" role="button" {{action "toggleUploadCoverModal"}}>
+                    <img class="blog-cover" src="{{model.coverImage}}" alt="cover photo" data-test-cover-img>
+                    <button type="button" class="gh-setting-action-largeimg-delete" {{action "removeImage" "coverImage"}} data-test-delete-image="coverImage">
+                        <span>delete</span>
+                    </button>
+                {{else if uploader.isUploading}}
+                    {{uploader.progressBar}}
                 {{else}}
-                    <button type="button" class="gh-btn" {{action "toggleUploadCoverModal"}}><span>Upload Image</span></button>
+                    <button type="button" class="gh-btn" onClick={{action "triggerFileDialog"}} data-test-image-upload-btn="coverImage">
+                        <span>Upload Image</span>
+                    </button>
                 {{/if}}
-
-                {{#if showUploadCoverModal}}
-                    {{gh-fullscreen-modal "upload-image"
-                            model=(hash model=model imageProperty="coverImage")
-                            close=(action "toggleUploadCoverModal")
-                            modifier="action wide"}}
-                {{/if}}
+                <div style="display:none">
+                    {{gh-file-input multiple=false action=(action (mut coverImageUpload)) accept=imageMimeTypes data-test-file-input="coverImage"}}
+                </div>
             </div>
+            {{/gh-uploader}}
         </div>
 
         <div class="gh-setting-header">Social accounts</div>

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -8,6 +8,7 @@ import mockSlugs from './config/slugs';
 import mockSubscribers from './config/subscribers';
 import mockTags from './config/tags';
 import mockThemes from './config/themes';
+import mockUploads from './config/uploads';
 import mockUsers from './config/users';
 
 // import {versionMismatchResponse} from 'utils';
@@ -48,13 +49,14 @@ export function testConfig() {
     mockSubscribers(this);
     mockTags(this);
     mockThemes(this);
+    mockUploads(this);
     mockUsers(this);
 
     /* Notifications -------------------------------------------------------- */
 
     this.get('/notifications/');
 
-    /* Apps - Slack Test Notification --------------------------------------------------------- */
+    /* Apps - Slack Test Notification --------------------------------------- */
 
     this.post('/slack/test', function () {
         return {};

--- a/mirage/config/uploads.js
+++ b/mirage/config/uploads.js
@@ -1,0 +1,17 @@
+const fileUploadResponse = function (db, {requestBody}) {
+    let [file] = requestBody.getAll('uploadimage');
+    let now = new Date();
+    let year = now.getFullYear();
+    let month = `${now.getMonth()}`;
+
+    if (month.length === 1) {
+        month = `0${month}`;
+    }
+
+    return `"/content/images/${year}/${month}/${file.name}"`;
+};
+
+export default function mockUploads(server) {
+    server.post('/uploads/', fileUploadResponse, 200, {timing: 100});
+    server.post('/uploads/icon/', fileUploadResponse, 200, {timing: 100});
+}

--- a/tests/helpers/file-upload.js
+++ b/tests/helpers/file-upload.js
@@ -30,6 +30,6 @@ export default Test.registerAsyncHelper('fileUpload', function(app, selector, co
     return triggerEvent(
         selector,
         'change',
-        {foor: 'bar', testingFiles: [file]}
+        {testingFiles: [file]}
     );
 });

--- a/tests/integration/components/gh-uploader-test.js
+++ b/tests/integration/components/gh-uploader-test.js
@@ -162,6 +162,27 @@ describe('Integration: Component: gh-uploader', function() {
             errorSpy.restore();
         });
 
+        it('yields isUploading whilst upload is in progress', async function () {
+            stubSuccessfulUpload(server, 200);
+
+            this.render(hbs`
+            {{#gh-uploader files=files as |uploader|}}
+                {{#if uploader.isUploading}}
+                    <div class="is-uploading-test"></div>
+                {{/if}}
+            {{/gh-uploader}}`);
+
+            this.set('files', [createFile(), createFile()]);
+
+            run.later(() => {
+                expect(find('.is-uploading-test')).to.exist;
+            }, 100);
+
+            await wait();
+
+            expect(find('.is-uploading-test')).to.not.exist;
+        });
+
         it('yields progressBar component with total upload progress', async function () {
             stubSuccessfulUpload(server, 200);
 

--- a/tests/integration/components/gh-uploader-test.js
+++ b/tests/integration/components/gh-uploader-test.js
@@ -118,6 +118,26 @@ describe('Integration: Component: gh-uploader', function() {
             expect(result[1].url).to.equal('/content/images/test.png');
         });
 
+        it('onComplete only passes results for last upload', async function () {
+            this.set('uploadsFinished', sinon.spy());
+
+            this.render(hbs`{{#gh-uploader files=files onComplete=(action uploadsFinished)}}{{/gh-uploader}}`);
+            this.set('files', [
+                createFile(['test'], {name: 'file1.png'})
+            ]);
+            await wait();
+
+            this.set('files', [
+                createFile(['test'], {name: 'file2.png'})
+            ]);
+
+            await wait();
+
+            let [results] = this.get('uploadsFinished').getCall(1).args;
+            expect(results.length).to.equal(1);
+            expect(results[0].fileName).to.equal('file2.png');
+        });
+
         it('doesn\'t allow new files to be set whilst uploading', async function () {
             let errorSpy = sinon.spy(console, 'error');
             stubSuccessfulUpload(server, 100);


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/8455
- ensure `uploadUrls` and `errors` are cleared in `gh-uploader` when new uploads are started
- yield `isUploading` from `gh-uploader` component
- use `gh-uploader` to implement modal-less image uploads in settings/general

TODO:
- [x] finish updating settings/general acceptance tests