### PR TITLE
[i18n] Added "Language and locale" to Settings

### DIFF
--- a/app/templates/settings/general.hbs
+++ b/app/templates/settings/general.hbs
@@ -63,9 +63,9 @@
                 <div class="gh-setting-desc">Ghost's frontend and theme language</div>
                 {{#liquid-if defaultLangOpen}}
                 <div class="gh-setting-content-extended">
-                    {{#gh-form-group errors=model.errors hasValidated=model.hasValidated property="default_lang"}}
-                        {{gh-input model.default_lang type="text" focusOut=(action "validate" "default_lang" target=model) update=(action (mut model.default_lang)) data-test-default_lang-input=true}}
-                        {{gh-error-message errors=model.errors property="default_lang"}}
+                    {{#gh-form-group errors=model.errors hasValidated=model.hasValidated property="defaultLang"}}
+                        {{gh-input model.defaultLang type="text" focusOut=(action "validate" "defaultLang" target=model) update=(action (mut model.defaultLang)) data-test-default-lang-input=true}}
+                        {{gh-error-message errors=model.errors property="defaultLang"}}
                         <p>Default: <strong>English (en)</strong>; currently available: <strong>Spanish (es)</strong>; you can add translation files for <strong>any language</strong><br>
                         (click on the <strong>"Save settings"</strong> button above, and <strong>restart</strong> Ghost to activate the new language)</p>
                     {{/gh-form-group}}

--- a/app/templates/settings/general.hbs
+++ b/app/templates/settings/general.hbs
@@ -57,6 +57,25 @@
                 <button type="button" class="gh-btn gh-btn-hover-blue" {{action (toggle "timezoneOpen" this)}} data-test-toggle-timezone><span>{{if timezoneOpen "Close" "Expand"}}</span></button>
             </div>
         </div>
+        <div class="gh-setting">
+            <div class="gh-setting-content">
+                <div class="gh-setting-title">Language</div>
+                <div class="gh-setting-desc">Ghost's frontend and theme language</div>
+                {{#liquid-if defaultLangOpen}}
+                <div class="gh-setting-content-extended">
+                    {{#gh-form-group errors=model.errors hasValidated=model.hasValidated property="default_lang"}}
+                        {{gh-input model.default_lang type="text" focusOut=(action "validate" "default_lang" target=model) update=(action (mut model.default_lang)) data-test-default_lang-input=true}}
+                        {{gh-error-message errors=model.errors property="default_lang"}}
+                        <p>Default: <strong>English (en)</strong>; currently available: <strong>Spanish (es)</strong>; you can add translation files for <strong>any language</strong><br>
+                        (click on the <strong>"Save settings"</strong> button above, and <strong>restart</strong> Ghost to activate the new language)</p>
+                    {{/gh-form-group}}
+                </div>
+                {{/liquid-if}}
+            </div>
+            <div class="gh-setting-action">
+                <button type="button" class="gh-btn gh-btn-hover-blue" {{action (toggle "defaultLangOpen" this)}} data-test-toggle-default-lang><span>{{if defaultLangOpen "Close" "Expand"}}</span></button>
+            </div>
+        </div>
 
         <div class="gh-setting-header">Publication identity</div>
         <div class="gh-setting" data-test-setting="icon">

--- a/app/templates/settings/general.hbs
+++ b/app/templates/settings/general.hbs
@@ -61,18 +61,18 @@
             <div class="gh-setting-content">
                 <div class="gh-setting-title">Language</div>
                 <div class="gh-setting-desc">Ghost's frontend and theme language</div>
-                {{#liquid-if defaultLangOpen}}
+                {{#liquid-if defaultLocaleOpen}}
                 <div class="gh-setting-content-extended">
-                    {{#gh-form-group errors=model.errors hasValidated=model.hasValidated property="defaultLang"}}
-                        {{gh-input model.defaultLang type="text" focusOut=(action "validate" "defaultLang" target=model) update=(action (mut model.defaultLang)) data-test-default-lang-input=true}}
-                        {{gh-error-message errors=model.errors property="defaultLang"}}
+                    {{#gh-form-group errors=model.errors hasValidated=model.hasValidated property="defaultLocale"}}
+                        {{gh-input model.defaultLocale type="text" focusOut=(action "validate" "defaultLocale" target=model) update=(action (mut model.defaultLocale)) data-test-default-locale-input=true}}
+                        {{gh-error-message errors=model.errors property="defaultLocale"}}
                         <p>Default: <strong>English (en)</strong>; currently available: <strong>Spanish (es)</strong>; you can add translation files for <strong>any language</strong></p>
                     {{/gh-form-group}}
                 </div>
                 {{/liquid-if}}
             </div>
             <div class="gh-setting-action">
-                <button type="button" class="gh-btn gh-btn-hover-blue" {{action (toggle "defaultLangOpen" this)}} data-test-toggle-default-lang><span>{{if defaultLangOpen "Close" "Expand"}}</span></button>
+                <button type="button" class="gh-btn gh-btn-hover-blue" {{action (toggle "defaultLocaleOpen" this)}} data-test-toggle-default-locale><span>{{if defaultLocaleOpen "Close" "Expand"}}</span></button>
             </div>
         </div>
 

--- a/app/templates/settings/general.hbs
+++ b/app/templates/settings/general.hbs
@@ -59,14 +59,14 @@
         </div>
         <div class="gh-setting">
             <div class="gh-setting-content">
-                <div class="gh-setting-title">Language and locale</div>
-                <div class="gh-setting-desc">Ghost's frontend and theme language/locale</div>
+                <div class="gh-setting-title">Publication Language</div>
+                <div class="gh-setting-desc">Set the language/locale which is used on your site</div>
                 {{#liquid-if defaultLocaleOpen}}
                 <div class="gh-setting-content-extended">
                     {{#gh-form-group errors=model.errors hasValidated=model.hasValidated property="defaultLocale"}}
                         {{gh-input model.defaultLocale type="text" focusOut=(action "validate" "defaultLocale" target=model) update=(action (mut model.defaultLocale)) data-test-default-locale-input=true}}
                         {{gh-error-message errors=model.errors property="defaultLocale"}}
-                        <p>Default: English (<strong>en</strong>); you can add translation files for <strong>any language</strong></p>
+                        <p>Default: English (<strong>en</strong>); you can add translation files to your theme for <a href="https://themes.ghost.org/v1.20.0/docs/i18n" target="_blank" rel="noopener">any language</a></p>
                     {{/gh-form-group}}
                 </div>
                 {{/liquid-if}}

--- a/app/templates/settings/general.hbs
+++ b/app/templates/settings/general.hbs
@@ -66,8 +66,7 @@
                     {{#gh-form-group errors=model.errors hasValidated=model.hasValidated property="defaultLang"}}
                         {{gh-input model.defaultLang type="text" focusOut=(action "validate" "defaultLang" target=model) update=(action (mut model.defaultLang)) data-test-default-lang-input=true}}
                         {{gh-error-message errors=model.errors property="defaultLang"}}
-                        <p>Default: <strong>English (en)</strong>; currently available: <strong>Spanish (es)</strong>; you can add translation files for <strong>any language</strong><br>
-                        (click on the <strong>"Save settings"</strong> button above, and <strong>restart</strong> Ghost to activate the new language)</p>
+                        <p>Default: <strong>English (en)</strong>; currently available: <strong>Spanish (es)</strong>; you can add translation files for <strong>any language</strong></p>
                     {{/gh-form-group}}
                 </div>
                 {{/liquid-if}}

--- a/app/templates/settings/general.hbs
+++ b/app/templates/settings/general.hbs
@@ -59,14 +59,14 @@
         </div>
         <div class="gh-setting">
             <div class="gh-setting-content">
-                <div class="gh-setting-title">Language</div>
-                <div class="gh-setting-desc">Ghost's frontend and theme language</div>
+                <div class="gh-setting-title">Language and locale</div>
+                <div class="gh-setting-desc">Ghost's frontend and theme language/locale</div>
                 {{#liquid-if defaultLocaleOpen}}
                 <div class="gh-setting-content-extended">
                     {{#gh-form-group errors=model.errors hasValidated=model.hasValidated property="defaultLocale"}}
                         {{gh-input model.defaultLocale type="text" focusOut=(action "validate" "defaultLocale" target=model) update=(action (mut model.defaultLocale)) data-test-default-locale-input=true}}
                         {{gh-error-message errors=model.errors property="defaultLocale"}}
-                        <p>Default: <strong>English (en)</strong>; currently available: <strong>Spanish (es)</strong>; you can add translation files for <strong>any language</strong></p>
+                        <p>Default: English (<strong>en</strong>); you can add translation files for <strong>any language</strong></p>
                     {{/gh-form-group}}
                 </div>
                 {{/liquid-if}}


### PR DESCRIPTION
pull request #703

- added Language option to General Settings, just a text field for
flexibility, to allow any language
- click on the "Save settings" button, and restart Ghost to activate the
new language
- default: English (en); currently available: Spanish (es); translation
files can be added for any language
- the corresponding translation files should be at
_core/server/translations/en.json_, _es.json_... and
_content/themes/mytheme/assets/translations/mytheme_en.json_,
_mytheme_en.css_...
- `currentLocale`, dynamically based on overall settings (key =
"`default_lang`") in the `settings` db table
- during Ghost's initialization, settings available inside `i18n`
functions; see files _core/server/i18n.js_ and _index.js_
- there is a complementary commit for Ghost's PR TryGhost/Ghost#8437
