### PR TITLE
🛀🏾  Clear `core/built/assets` content in dev mode

### DIFF
--- a/lib/asset-delivery/index.js
+++ b/lib/asset-delivery/index.js
@@ -39,6 +39,10 @@ module.exports = {
         if (fs.existsSync(results.directory + '/index.min.html')) {
             fs.copySync(results.directory + '/index.min.html', `${templateOutDir}/default-prod.html`, {overwrite: true});
         } else {
+            fs.emptyDir(assetsOut, err => {
+                if (err) {return new Error(err);}
+            });
+
             fs.copySync(results.directory + '/index.html', `${templateOutDir}/default.html`, {overwrite: true});
         }
 


### PR DESCRIPTION
closes TryGhost/Ghost#8162

When in development mode, we're clearing the `core/built/assets` directory, so they don't build up over time as we're now delivering client
assets with cache-busting hash in the filename.
