### PR TITLE
🐛  Reset publish date in PSM when leaving menu

### DIFF
--- a/app/components/gh-publishmenu-scheduled.js
+++ b/app/components/gh-publishmenu-scheduled.js
@@ -8,6 +8,7 @@ export default Component.extend({
 
     post: null,
     saveType: null,
+    isClosing: null,
 
     // used to set minDate in datepicker
     _minDate: null,
@@ -60,8 +61,10 @@ export default Component.extend({
         setTime(time) {
             let post = this.get('post');
 
-            post.set('publishedAtBlogTime', time);
-            return post.validate();
+            if (!this.get('isClosing')) {
+                post.set('publishedAtBlogTime', time);
+                return post.validate();
+            }
         }
     }
 });

--- a/app/components/gh-publishmenu.js
+++ b/app/components/gh-publishmenu.js
@@ -13,6 +13,8 @@ export default Component.extend({
 
     _publishedAtBlogTZ: null,
 
+    isClosing: null,
+
     forcePublishedMenu: reads('post.pastScheduledTime'),
 
     postState: computed('post.{isPublished,isScheduled}', 'forcePublishedMenu', function () {
@@ -91,6 +93,7 @@ export default Component.extend({
 
         open() {
             this._cachePublishedAtBlogTZ();
+            this.set('isClosing', false);
             this.get('post.errors').clear();
             if (this.get('onOpen')) {
                 this.get('onOpen')();
@@ -113,6 +116,9 @@ export default Component.extend({
             if (this.get('onClose')) {
                 this.get('onClose')();
             }
+
+            this.set('isClosing', true);
+
             return true;
         }
     }

--- a/app/templates/components/gh-publishmenu.hbs
+++ b/app/templates/components/gh-publishmenu.hbs
@@ -13,6 +13,7 @@
         {{gh-publishmenu-scheduled
             post=post
             saveType=saveType
+            isClosing=isClosing
             setSaveType=(action "setSaveType")}}
 
         {{else}}


### PR DESCRIPTION
closes TryGhost/Ghost#8360

When changing the publish time of an already scheduled post in the publish menu and leaving the menu with clicking outside of the menu, the time wouldn't reset properly and be shown in the PSM. With the usage of an `isClosing` property which is passed to the underlying `gh-publishmenu-scheduling` component, we prevent the changed time from being saved and reset it properly instead.