### PR TITLE
🐛 fix flickering buttons during modal transitions

### DIFF
--- a/app/styles/patterns/buttons.css
+++ b/app/styles/patterns/buttons.css
@@ -14,6 +14,7 @@
     fill: color(var(--lightgrey) l(-27%) blackness(+15%));
     border-radius: 5px;
     transition: all 0.2s ease;
+    transition-property: color, border-color, background, width, height;
 
     -webkit-font-smoothing: subpixel-antialiased;
 }

--- a/app/transitions.js
+++ b/app/transitions.js
@@ -3,12 +3,7 @@ export default function () {
         this.hasClass('fullscreen-modal-container'),
         this.toValue(true),
         this.use('fade', {duration: 150}),
-        this.reverse('explode', {
-            pick: '.fullscreen-modal',
-            use: ['fade', {duration: 80}]
-        }, {
-            use: ['fade', {duration: 150}]
-        })
+        this.reverse('fade', {duration: 150})
     );
 
     this.transition(


### PR DESCRIPTION
no issue
- removes transition on `all` properties in favour of an explicit list, fixes the buttons flickering after the modal appears and the outline/text being visible when the modal disappears
- simplifies the liquid-fire transition so that elements being removed at slightly different times doesn't cause flickering when the modal is removed
