### PR TITLE
💄🐷 sort-imports eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,16 +1,20 @@
+/* eslint-env node */
 module.exports = {
     root: true,
     parserOptions: {
         ecmaVersion: 2017,
         sourceType: 'module'
     },
+    env: {
+        browser: true
+    },
     extends: [
         'eslint:recommended',
         'plugin:ember-suave/recommended'
     ],
-    env: {
-        browser: true
-    },
+    plugins: [
+        'sort-imports-es6-autofix'
+    ],
     rules: {
         indent: ['error', 4],
         'space-before-function-paren': ['error', {anonymous: 'ignore', named: 'never'}],
@@ -20,7 +24,10 @@ module.exports = {
         'keyword-spacing': ['error', {overrides: {
             'catch': {'after': true}
         }}],
-        'ember-suave/require-access-in-comments': 'off'
+        'ember-suave/require-access-in-comments': 'off',
+        'sort-imports-es6-autofix/sort-imports-es6': ['error', {
+            memberSyntaxSortOrder: ['none', 'all', 'single', 'multiple']
+        }]
     },
     globals: {
         validator: false

--- a/app/adapters/base.js
+++ b/app/adapters/base.js
@@ -1,8 +1,8 @@
-import injectService from 'ember-service/inject';
+import AjaxServiceSupport from 'ember-ajax/mixins/ajax-support';
+import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
 import RESTAdapter from 'ember-data/adapters/rest';
 import ghostPaths from 'ghost-admin/utils/ghost-paths';
-import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
-import AjaxServiceSupport from 'ember-ajax/mixins/ajax-support';
+import injectService from 'ember-service/inject';
 
 export default RESTAdapter.extend(DataAdapterMixin, AjaxServiceSupport, {
     authorizer: 'authorizer:oauth2',

--- a/app/adapters/embedded-relation-adapter.js
+++ b/app/adapters/embedded-relation-adapter.js
@@ -1,6 +1,6 @@
+import BaseAdapter from 'ghost-admin/adapters/base';
 import get from 'ember-metal/get';
 import {isNone} from 'ember-utils';
-import BaseAdapter from 'ghost-admin/adapters/base';
 
 // EmbeddedRelationAdapter will augment the query object in calls made to
 // DS.Store#findRecord, findAll, query, and queryRecord with the correct "includes"

--- a/app/app.js
+++ b/app/app.js
@@ -1,11 +1,11 @@
-import Ember from 'ember';
-import Application from 'ember-application';
-import Resolver from './resolver';
-import loadInitializers from 'ember-load-initializers';
-import 'ghost-admin/utils/route';
 import 'ghost-admin/utils/link-component';
+import 'ghost-admin/utils/route';
 import 'ghost-admin/utils/text-field';
+import Application from 'ember-application';
+import Ember from 'ember';
+import Resolver from './resolver';
 import config from './config/environment';
+import loadInitializers from 'ember-load-initializers';
 
 Ember.MODEL_FACTORY_INJECTIONS = true;
 

--- a/app/authenticators/oauth2.js
+++ b/app/authenticators/oauth2.js
@@ -1,11 +1,11 @@
+import Authenticator from 'ember-simple-auth/authenticators/oauth2-password-grant';
+import RSVP from 'rsvp';
 import computed from 'ember-computed';
 import injectService from 'ember-service/inject';
-import Authenticator from 'ember-simple-auth/authenticators/oauth2-password-grant';
 import run from 'ember-runloop';
-import RSVP from 'rsvp';
-import {wrap} from 'ember-array/utils';
-import {isEmpty} from 'ember-utils';
 import {assign} from 'ember-platform';
+import {isEmpty} from 'ember-utils';
+import {wrap} from 'ember-array/utils';
 
 export default Authenticator.extend({
     ajax: injectService(),

--- a/app/components/gh-alerts.js
+++ b/app/components/gh-alerts.js
@@ -1,7 +1,7 @@
 import Component from 'ember-component';
-import {alias} from 'ember-computed';
 import injectService from 'ember-service/inject';
 import observer from 'ember-metal/observer';
+import {alias} from 'ember-computed';
 
 export default Component.extend({
     tagName: 'aside',

--- a/app/components/gh-basic-dropdown.js
+++ b/app/components/gh-basic-dropdown.js
@@ -1,6 +1,6 @@
 import BasicDropdown from 'ember-basic-dropdown/components/basic-dropdown';
-import layout from 'ember-basic-dropdown/templates/components/basic-dropdown';
 import injectService from 'ember-service/inject';
+import layout from 'ember-basic-dropdown/templates/components/basic-dropdown';
 
 export default BasicDropdown.extend({
     dropdown: injectService(),

--- a/app/components/gh-cm-editor.js
+++ b/app/components/gh-cm-editor.js
@@ -1,11 +1,11 @@
 /* global CodeMirror */
 import Component from 'ember-component';
-import {bind, once, scheduleOnce} from 'ember-runloop';
-import injectService from 'ember-service/inject';
 import RSVP from 'rsvp';
-import {assign} from 'ember-platform';
 import boundOneWay from 'ghost-admin/utils/bound-one-way';
+import injectService from 'ember-service/inject';
 import {InvokeActionMixin} from 'ember-invoke-action';
+import {assign} from 'ember-platform';
+import {bind, once, scheduleOnce} from 'ember-runloop';
 
 const CmEditorComponent =  Component.extend(InvokeActionMixin, {
     classNameBindings: ['isFocused:focused'],

--- a/app/components/gh-date-time-picker.js
+++ b/app/components/gh-date-time-picker.js
@@ -1,5 +1,5 @@
 import Component from 'ember-component';
-import computed, {reads, or} from 'ember-computed';
+import computed, {or, reads} from 'ember-computed';
 import injectService from 'ember-service/inject';
 import moment from 'moment';
 import {isBlank, isEmpty} from 'ember-utils';

--- a/app/components/gh-datetime-input.js
+++ b/app/components/gh-datetime-input.js
@@ -1,9 +1,9 @@
 import Component from 'ember-component';
-import injectService from 'ember-service/inject';
 import boundOneWay from 'ghost-admin/utils/bound-one-way';
-import {formatDate} from 'ghost-admin/utils/date-formatting';
-import {InvokeActionMixin} from 'ember-invoke-action';
+import injectService from 'ember-service/inject';
 import moment from 'moment';
+import {InvokeActionMixin} from 'ember-invoke-action';
+import {formatDate} from 'ghost-admin/utils/date-formatting';
 
 export default Component.extend(InvokeActionMixin, {
     tagName: 'span',

--- a/app/components/gh-download-count.js
+++ b/app/components/gh-download-count.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
 import Component from 'ember-component';
+import Ember from 'ember';
 import injectService from 'ember-service/inject';
 import {task, timeout} from 'ember-concurrency';
 

--- a/app/components/gh-dropdown-button.js
+++ b/app/components/gh-dropdown-button.js
@@ -1,6 +1,6 @@
 import Component from 'ember-component';
-import injectService from 'ember-service/inject';
 import DropdownMixin from 'ghost-admin/mixins/dropdown-mixin';
+import injectService from 'ember-service/inject';
 
 export default Component.extend(DropdownMixin, {
     tagName: 'button',

--- a/app/components/gh-dropdown.js
+++ b/app/components/gh-dropdown.js
@@ -1,8 +1,8 @@
 import Component from 'ember-component';
+import DropdownMixin from 'ghost-admin/mixins/dropdown-mixin';
 import computed from 'ember-computed';
 import injectService from 'ember-service/inject';
 import run from 'ember-runloop';
-import DropdownMixin from 'ghost-admin/mixins/dropdown-mixin';
 
 export default Component.extend(DropdownMixin, {
     classNames: 'dropdown',

--- a/app/components/gh-editor-post-status.js
+++ b/app/components/gh-editor-post-status.js
@@ -1,6 +1,6 @@
 import Component from 'ember-component';
-import {task, timeout} from 'ember-concurrency';
 import computed, {reads} from 'ember-computed';
+import {task, timeout} from 'ember-concurrency';
 
 // TODO: reduce when in testing mode
 const SAVE_TIMEOUT_MS = 3000;

--- a/app/components/gh-editor.js
+++ b/app/components/gh-editor.js
@@ -1,8 +1,8 @@
 import Component from 'ember-component';
 import run from 'ember-runloop';
 import {
-    IMAGE_MIME_TYPES,
-    IMAGE_EXTENSIONS
+    IMAGE_EXTENSIONS,
+    IMAGE_MIME_TYPES
 } from 'ghost-admin/components/gh-image-uploader';
 
 const {debounce} = run;

--- a/app/components/gh-file-uploader.js
+++ b/app/components/gh-file-uploader.js
@@ -1,18 +1,17 @@
 import Component from 'ember-component';
-import {htmlSafe} from 'ember-string';
-import injectService from 'ember-service/inject';
 import computed from 'ember-computed';
-import {isBlank} from 'ember-utils';
+import injectService from 'ember-service/inject';
 import run from 'ember-runloop';
-import {isEmberArray} from 'ember-array/utils';
-
-import {invokeAction} from 'ember-invoke-action';
 import {
-    isVersionMismatchError,
+    UnsupportedMediaTypeError,
     isRequestEntityTooLargeError,
     isUnsupportedMediaTypeError,
-    UnsupportedMediaTypeError
+    isVersionMismatchError
 } from 'ghost-admin/services/ajax';
+import {htmlSafe} from 'ember-string';
+import {invokeAction} from 'ember-invoke-action';
+import {isBlank} from 'ember-utils';
+import {isEmberArray} from 'ember-array/utils';
 
 export default Component.extend({
     tagName: 'section',

--- a/app/components/gh-fullscreen-modal.js
+++ b/app/components/gh-fullscreen-modal.js
@@ -1,11 +1,11 @@
-import RSVP from 'rsvp';
-import injectService from 'ember-service/inject';
-import {A as emberA} from 'ember-array/utils';
-import {isBlank} from 'ember-utils';
-import run from 'ember-runloop';
-import {invokeAction} from 'ember-invoke-action';
-import computed from 'ember-computed';
 import Component from 'ember-component';
+import RSVP from 'rsvp';
+import computed from 'ember-computed';
+import injectService from 'ember-service/inject';
+import run from 'ember-runloop';
+import {A as emberA} from 'ember-array/utils';
+import {invokeAction} from 'ember-invoke-action';
+import {isBlank} from 'ember-utils';
 
 const FullScreenModalComponent = Component.extend({
 

--- a/app/components/gh-image-uploader.js
+++ b/app/components/gh-image-uploader.js
@@ -1,18 +1,18 @@
 import Component from 'ember-component';
 import computed from 'ember-computed';
-import injectService from 'ember-service/inject';
-import {htmlSafe} from 'ember-string';
-import {isBlank} from 'ember-utils';
-import {isEmberArray} from 'ember-array/utils';
-import run from 'ember-runloop';
-import {invokeAction} from 'ember-invoke-action';
 import ghostPaths from 'ghost-admin/utils/ghost-paths';
+import injectService from 'ember-service/inject';
+import run from 'ember-runloop';
 import {
+    UnsupportedMediaTypeError,
     isRequestEntityTooLargeError,
     isUnsupportedMediaTypeError,
-    isVersionMismatchError,
-    UnsupportedMediaTypeError
+    isVersionMismatchError
 } from 'ghost-admin/services/ajax';
+import {htmlSafe} from 'ember-string';
+import {invokeAction} from 'ember-invoke-action';
+import {isBlank} from 'ember-utils';
+import {isEmberArray} from 'ember-array/utils';
 
 export const IMAGE_MIME_TYPES = 'image/gif,image/jpg,image/jpeg,image/png,image/svg+xml';
 export const IMAGE_EXTENSIONS = ['gif', 'jpg', 'jpeg', 'png', 'svg'];

--- a/app/components/gh-markdown-editor.js
+++ b/app/components/gh-markdown-editor.js
@@ -1,10 +1,10 @@
 import Component from 'ember-component';
 import computed from 'ember-computed';
+import formatMarkdown from 'ghost-admin/utils/format-markdown';
+import run from 'ember-runloop';
 import {assign} from 'ember-platform';
 import {copy} from 'ember-metal/utils';
 import {isEmpty} from 'ember-utils';
-import run from 'ember-runloop';
-import formatMarkdown from 'ghost-admin/utils/format-markdown';
 
 const MOBILEDOC_VERSION = '0.3.1';
 

--- a/app/components/gh-nav-menu.js
+++ b/app/components/gh-nav-menu.js
@@ -1,7 +1,7 @@
 import Component from 'ember-component';
+import calculatePosition from 'ember-basic-dropdown/utils/calculate-position';
 import injectService from 'ember-service/inject';
 import {htmlSafe} from 'ember-string';
-import calculatePosition from 'ember-basic-dropdown/utils/calculate-position';
 
 export default Component.extend({
     config: injectService(),

--- a/app/components/gh-navitem.js
+++ b/app/components/gh-navitem.js
@@ -1,8 +1,8 @@
 import Component from 'ember-component';
+import SortableItem from 'ember-sortable/mixins/sortable-item';
+import ValidationState from 'ghost-admin/mixins/validation-state';
 import computed, {alias, readOnly} from 'ember-computed';
 import run from 'ember-runloop';
-import ValidationState from 'ghost-admin/mixins/validation-state';
-import SortableItem from 'ember-sortable/mixins/sortable-item';
 
 export default Component.extend(ValidationState, SortableItem, {
     classNames: 'gh-blognav-item',

--- a/app/components/gh-notification.js
+++ b/app/components/gh-notification.js
@@ -1,6 +1,6 @@
 import Component from 'ember-component';
-import injectService from 'ember-service/inject';
 import computed from 'ember-computed';
+import injectService from 'ember-service/inject';
 
 export default Component.extend({
     tagName: 'article',

--- a/app/components/gh-notifications.js
+++ b/app/components/gh-notifications.js
@@ -1,6 +1,6 @@
 import Component from 'ember-component';
-import {alias} from 'ember-computed';
 import injectService from 'ember-service/inject';
+import {alias} from 'ember-computed';
 
 export default Component.extend({
     tagName: 'aside',

--- a/app/components/gh-post-settings-menu.js
+++ b/app/components/gh-post-settings-menu.js
@@ -1,14 +1,14 @@
-import Ember from 'ember';
 import Component from 'ember-component';
-import computed, {alias} from 'ember-computed';
-import {guidFor} from 'ember-metal/utils';
-import injectService from 'ember-service/inject';
-import {htmlSafe} from 'ember-string';
-import {invokeAction} from 'ember-invoke-action';
+import Ember from 'ember';
 import SettingsMenuMixin from 'ghost-admin/mixins/settings-menu-component';
 import boundOneWay from 'ghost-admin/utils/bound-one-way';
+import computed, {alias} from 'ember-computed';
+import injectService from 'ember-service/inject';
 import isNumber from 'ghost-admin/utils/isNumber';
 import moment from 'moment';
+import {guidFor} from 'ember-metal/utils';
+import {htmlSafe} from 'ember-string';
+import {invokeAction} from 'ember-invoke-action';
 
 const {Handlebars} = Ember;
 

--- a/app/components/gh-posts-list-item.js
+++ b/app/components/gh-posts-list-item.js
@@ -1,9 +1,9 @@
-import Ember from 'ember';
+import $ from 'jquery';
 import Component from 'ember-component';
-import {htmlSafe} from 'ember-string';
+import Ember from 'ember';
 import computed, {alias, equal} from 'ember-computed';
 import injectService from 'ember-service/inject';
-import $ from 'jquery';
+import {htmlSafe} from 'ember-string';
 import {isBlank} from 'ember-utils';
 
 // ember-cli-shims doesn't export these

--- a/app/components/gh-profile-image.js
+++ b/app/components/gh-profile-image.js
@@ -1,11 +1,10 @@
+import AjaxService from 'ember-ajax/services/ajax';
 import Component from 'ember-component';
 import computed, {notEmpty} from 'ember-computed';
-import {htmlSafe} from 'ember-string';
 import injectService from 'ember-service/inject';
-import {isBlank} from 'ember-utils';
 import run from 'ember-runloop';
-
-import AjaxService from 'ember-ajax/services/ajax';
+import {htmlSafe} from 'ember-string';
+import {isBlank} from 'ember-utils';
 import {isNotFoundError} from 'ember-ajax/errors';
 
 /**

--- a/app/components/gh-publishmenu-scheduled.js
+++ b/app/components/gh-publishmenu-scheduled.js
@@ -1,7 +1,7 @@
 import Component from 'ember-component';
-import moment from 'moment';
 import computed from 'ember-computed';
 import injectService from 'ember-service/inject';
+import moment from 'moment';
 
 export default Component.extend({
     clock: injectService(),

--- a/app/components/gh-publishmenu.js
+++ b/app/components/gh-publishmenu.js
@@ -1,8 +1,8 @@
+import $ from 'jquery';
 import Component from 'ember-component';
 import computed, {reads} from 'ember-computed';
 import injectService from 'ember-service/inject';
 import {task} from 'ember-concurrency';
-import $ from 'jquery';
 
 export default Component.extend({
     clock: injectService(),

--- a/app/components/gh-search-input.js
+++ b/app/components/gh-search-input.js
@@ -3,8 +3,8 @@
 import Component from 'ember-component';
 import RSVP from 'rsvp';
 import computed from 'ember-computed';
-import run from 'ember-runloop';
 import injectService from 'ember-service/inject';
+import run from 'ember-runloop';
 import {isBlank, isEmpty} from 'ember-utils';
 
 export function computedGroup(category) {

--- a/app/components/gh-search-input/trigger.js
+++ b/app/components/gh-search-input/trigger.js
@@ -1,7 +1,7 @@
-import run from 'ember-runloop';
-import {isBlank} from 'ember-utils';
 import Component from 'ember-component';
+import run from 'ember-runloop';
 import {invokeAction} from 'ember-invoke-action';
+import {isBlank} from 'ember-utils';
 
 export default Component.extend({
     open() {

--- a/app/components/gh-selectize.js
+++ b/app/components/gh-selectize.js
@@ -1,11 +1,10 @@
 /* eslint-disable camelcase */
-import {A as emberA, isEmberArray} from 'ember-array/utils';
+import EmberSelectizeComponent from 'ember-cli-selectize/components/ember-selectize';
 import computed from 'ember-computed';
-import {isBlank} from 'ember-utils';
 import get from 'ember-metal/get';
 import run from 'ember-runloop';
-
-import EmberSelectizeComponent from 'ember-cli-selectize/components/ember-selectize';
+import {A as emberA, isEmberArray} from 'ember-array/utils';
+import {isBlank} from 'ember-utils';
 
 export default EmberSelectizeComponent.extend({
 

--- a/app/components/gh-tag-settings-form.js
+++ b/app/components/gh-tag-settings-form.js
@@ -1,11 +1,10 @@
 /* global key */
 import Component from 'ember-component';
 import Ember from 'ember';
+import boundOneWay from 'ghost-admin/utils/bound-one-way';
 import computed, {reads} from 'ember-computed';
 import injectService from 'ember-service/inject';
 import {htmlSafe} from 'ember-string';
-
-import boundOneWay from 'ghost-admin/utils/bound-one-way';
 import {invokeAction} from 'ember-invoke-action';
 
 // ember-cli-shims doesn't export this

--- a/app/components/gh-tags-management-container.js
+++ b/app/components/gh-tags-management-container.js
@@ -1,9 +1,9 @@
 import Component from 'ember-component';
 import computed, {equal, reads} from 'ember-computed';
 import injectService from 'ember-service/inject';
-import {isBlank} from 'ember-utils';
 import observer from 'ember-metal/observer';
 import run from 'ember-runloop';
+import {isBlank} from 'ember-utils';
 
 export default Component.extend({
     classNames: ['view-container'],

--- a/app/components/gh-task-button.js
+++ b/app/components/gh-task-button.js
@@ -1,8 +1,8 @@
 import Component from 'ember-component';
-import observer from 'ember-metal/observer';
 import computed, {reads} from 'ember-computed';
-import {isBlank} from 'ember-utils';
+import observer from 'ember-metal/observer';
 import {invokeAction} from 'ember-invoke-action';
+import {isBlank} from 'ember-utils';
 import {task, timeout} from 'ember-concurrency';
 
 /**

--- a/app/components/gh-textarea.js
+++ b/app/components/gh-textarea.js
@@ -1,7 +1,7 @@
 import OneWayTextarea from 'ember-one-way-controls/components/one-way-textarea';
 import TextInputMixin from 'ghost-admin/mixins/text-input';
-import run from 'ember-runloop';
 import injectService from 'ember-service/inject';
+import run from 'ember-runloop';
 
 export default OneWayTextarea.extend(TextInputMixin, {
     resizeDetector: injectService(),

--- a/app/components/gh-timezone-select.js
+++ b/app/components/gh-timezone-select.js
@@ -1,8 +1,8 @@
 import Component from 'ember-component';
 import computed, {mapBy} from 'ember-computed';
 import injectService from 'ember-service/inject';
-import {invokeAction} from 'ember-invoke-action';
 import moment from 'moment';
+import {invokeAction} from 'ember-invoke-action';
 
 export default Component.extend({
     classNames: ['form-group', 'for-select'],

--- a/app/components/gh-upgrade-notification.js
+++ b/app/components/gh-upgrade-notification.js
@@ -1,6 +1,6 @@
 import Component from 'ember-component';
-import {alias} from 'ember-computed';
 import injectService from 'ember-service/inject';
+import {alias} from 'ember-computed';
 
 export default Component.extend({
     tagName: 'section',

--- a/app/components/gh-uploader.js
+++ b/app/components/gh-uploader.js
@@ -1,11 +1,11 @@
 import Component from 'ember-component';
-import {isEmberArray} from 'ember-array/utils';
-import injectService from 'ember-service/inject';
-import {isEmpty} from 'ember-utils';
-import {task, all} from 'ember-concurrency';
-import ghostPaths from 'ghost-admin/utils/ghost-paths';
 import EmberObject from 'ember-object';
+import ghostPaths from 'ghost-admin/utils/ghost-paths';
+import injectService from 'ember-service/inject';
 import run from 'ember-runloop';
+import {all, task} from 'ember-concurrency';
+import {isEmberArray} from 'ember-array/utils';
+import {isEmpty} from 'ember-utils';
 
 // TODO: this is designed to be a more re-usable/composable upload component, it
 // should be able to replace the duplicated upload logic in:

--- a/app/components/gh-user-active.js
+++ b/app/components/gh-user-active.js
@@ -1,9 +1,9 @@
-import Ember from 'ember';
 import Component from 'ember-component';
+import Ember from 'ember';
 import computed from 'ember-computed';
 import injectService from 'ember-service/inject';
-import {htmlSafe} from 'ember-string';
 import moment from 'moment';
+import {htmlSafe} from 'ember-string';
 
 // ember-cli-shims doesn't export these
 const {Handlebars} = Ember;

--- a/app/components/gh-user-invited.js
+++ b/app/components/gh-user-invited.js
@@ -1,8 +1,8 @@
 import Component from 'ember-component';
 import computed from 'ember-computed';
+import moment from 'moment';
 import service from 'ember-service/inject';
 import {isNotFoundError} from 'ember-ajax/errors';
-import moment from 'moment';
 
 export default Component.extend({
     tagName: '',

--- a/app/components/gh-validation-status-container.js
+++ b/app/components/gh-validation-status-container.js
@@ -1,6 +1,6 @@
 import Component from 'ember-component';
-import computed from 'ember-computed';
 import ValidationStateMixin from 'ghost-admin/mixins/validation-state';
+import computed from 'ember-computed';
 
 /**
  * Handles the CSS necessary to show a specific property state. When passed a

--- a/app/components/modals/copy-html.js
+++ b/app/components/modals/copy-html.js
@@ -1,5 +1,5 @@
-import {alias} from 'ember-computed';
 import ModalComponent from 'ghost-admin/components/modals/base';
+import {alias} from 'ember-computed';
 
 export default ModalComponent.extend({
     generatedHtml: alias('model')

--- a/app/components/modals/delete-all.js
+++ b/app/components/modals/delete-all.js
@@ -1,5 +1,5 @@
-import injectService from 'ember-service/inject';
 import ModalComponent from 'ghost-admin/components/modals/base';
+import injectService from 'ember-service/inject';
 import {task} from 'ember-concurrency';
 
 export default ModalComponent.extend({

--- a/app/components/modals/delete-post.js
+++ b/app/components/modals/delete-post.js
@@ -1,6 +1,6 @@
-import {alias} from 'ember-computed';
-import injectService from 'ember-service/inject';
 import ModalComponent from 'ghost-admin/components/modals/base';
+import injectService from 'ember-service/inject';
+import {alias} from 'ember-computed';
 import {task} from 'ember-concurrency';
 
 export default ModalComponent.extend({

--- a/app/components/modals/delete-subscriber.js
+++ b/app/components/modals/delete-subscriber.js
@@ -1,5 +1,5 @@
-import {alias} from 'ember-computed';
 import ModalComponent from 'ghost-admin/components/modals/base';
+import {alias} from 'ember-computed';
 import {invokeAction} from 'ember-invoke-action';
 import {task} from 'ember-concurrency';
 

--- a/app/components/modals/delete-tag.js
+++ b/app/components/modals/delete-tag.js
@@ -1,5 +1,5 @@
-import computed, {alias} from 'ember-computed';
 import ModalComponent from 'ghost-admin/components/modals/base';
+import computed, {alias} from 'ember-computed';
 import {invokeAction} from 'ember-invoke-action';
 import {task} from 'ember-concurrency';
 

--- a/app/components/modals/delete-user.js
+++ b/app/components/modals/delete-user.js
@@ -1,6 +1,6 @@
 import ModalComponent from 'ghost-admin/components/modals/base';
-import {invokeAction} from 'ember-invoke-action';
 import {alias} from 'ember-computed';
+import {invokeAction} from 'ember-invoke-action';
 import {task} from 'ember-concurrency';
 
 export default ModalComponent.extend({

--- a/app/components/modals/import-subscribers.js
+++ b/app/components/modals/import-subscribers.js
@@ -1,7 +1,7 @@
-import computed from 'ember-computed';
-import {invokeAction} from 'ember-invoke-action';
 import ModalComponent from 'ghost-admin/components/modals/base';
+import computed from 'ember-computed';
 import ghostPaths from 'ghost-admin/utils/ghost-paths';
+import {invokeAction} from 'ember-invoke-action';
 
 export default ModalComponent.extend({
     labelText: 'Select or drag-and-drop a CSV File',

--- a/app/components/modals/invite-new-user.js
+++ b/app/components/modals/invite-new-user.js
@@ -1,9 +1,9 @@
-import RSVP from 'rsvp';
-import injectService from 'ember-service/inject';
-import {A as emberA} from 'ember-array/utils';
-import run from 'ember-runloop';
 import ModalComponent from 'ghost-admin/components/modals/base';
+import RSVP from 'rsvp';
 import ValidationEngine from 'ghost-admin/mixins/validation-engine';
+import injectService from 'ember-service/inject';
+import run from 'ember-runloop';
+import {A as emberA} from 'ember-array/utils';
 import {task} from 'ember-concurrency';
 
 const {Promise} = RSVP;

--- a/app/components/modals/new-subscriber.js
+++ b/app/components/modals/new-subscriber.js
@@ -1,5 +1,5 @@
-import {A as emberA} from 'ember-array/utils';
 import ModalComponent from 'ghost-admin/components/modals/base';
+import {A as emberA} from 'ember-array/utils';
 import {isInvalidError} from 'ember-ajax/errors';
 import {task} from 'ember-concurrency';
 

--- a/app/components/modals/re-authenticate.js
+++ b/app/components/modals/re-authenticate.js
@@ -1,9 +1,9 @@
 import $ from 'jquery';
+import ModalComponent from 'ghost-admin/components/modals/base';
+import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 import computed from 'ember-computed';
 import injectService from 'ember-service/inject';
 import {htmlSafe} from 'ember-string';
-import ModalComponent from 'ghost-admin/components/modals/base';
-import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 import {isVersionMismatchError} from 'ghost-admin/services/ajax';
 import {task} from 'ember-concurrency';
 

--- a/app/components/modals/suspend-user.js
+++ b/app/components/modals/suspend-user.js
@@ -1,6 +1,6 @@
 import ModalComponent from 'ghost-admin/components/modals/base';
-import {invokeAction} from 'ember-invoke-action';
 import {alias} from 'ember-computed';
+import {invokeAction} from 'ember-invoke-action';
 import {task} from 'ember-concurrency';
 
 export default ModalComponent.extend({

--- a/app/components/modals/unsuspend-user.js
+++ b/app/components/modals/unsuspend-user.js
@@ -1,6 +1,6 @@
 import ModalComponent from 'ghost-admin/components/modals/base';
-import {invokeAction} from 'ember-invoke-action';
 import {alias} from 'ember-computed';
+import {invokeAction} from 'ember-invoke-action';
 import {task} from 'ember-concurrency';
 
 export default ModalComponent.extend({

--- a/app/components/modals/upload-image.js
+++ b/app/components/modals/upload-image.js
@@ -1,8 +1,8 @@
+import ModalComponent from 'ghost-admin/components/modals/base';
+import cajaSanitizers from 'ghost-admin/utils/caja-sanitizers';
 import computed from 'ember-computed';
 import injectService from 'ember-service/inject';
 import {isEmpty} from 'ember-utils';
-import ModalComponent from 'ghost-admin/components/modals/base';
-import cajaSanitizers from 'ghost-admin/utils/caja-sanitizers';
 import {task} from 'ember-concurrency';
 
 export default ModalComponent.extend({

--- a/app/components/modals/upload-theme.js
+++ b/app/components/modals/upload-theme.js
@@ -1,14 +1,14 @@
 import ModalComponent from 'ghost-admin/components/modals/base';
 import computed, {mapBy, or} from 'ember-computed';
-import {invokeAction} from 'ember-invoke-action';
+import get from 'ember-metal/get';
 import ghostPaths from 'ghost-admin/utils/ghost-paths';
+import injectService from 'ember-service/inject';
+import run from 'ember-runloop';
 import {
     UnsupportedMediaTypeError,
     isThemeValidationError
 } from 'ghost-admin/services/ajax';
-import run from 'ember-runloop';
-import injectService from 'ember-service/inject';
-import get from 'ember-metal/get';
+import {invokeAction} from 'ember-invoke-action';
 
 export default ModalComponent.extend({
 

--- a/app/controllers/posts-loading.js
+++ b/app/controllers/posts-loading.js
@@ -1,7 +1,7 @@
 import Controller from 'ember-controller';
-import {readOnly} from 'ember-computed';
 import injectController from 'ember-controller/inject';
 import injectService from 'ember-service/inject';
+import {readOnly} from 'ember-computed';
 
 export default Controller.extend({
 

--- a/app/controllers/posts.js
+++ b/app/controllers/posts.js
@@ -1,7 +1,7 @@
 import Controller from 'ember-controller';
 import computed from 'ember-computed';
-import injectService from 'ember-service/inject';
 import get from 'ember-metal/get';
+import injectService from 'ember-service/inject';
 
 export default Controller.extend({
 

--- a/app/controllers/reset.js
+++ b/app/controllers/reset.js
@@ -1,7 +1,7 @@
 import Controller from 'ember-controller';
+import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 import computed from 'ember-computed';
 import injectService from 'ember-service/inject';
-import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 import {task} from 'ember-concurrency';
 
 export default Controller.extend(ValidationEngine, {

--- a/app/controllers/settings/apps/amp.js
+++ b/app/controllers/settings/apps/amp.js
@@ -1,7 +1,7 @@
 import Controller from 'ember-controller';
 import injectService from 'ember-service/inject';
-import {task} from 'ember-concurrency';
 import {alias} from 'ember-computed';
+import {task} from 'ember-concurrency';
 
 export default Controller.extend({
     notifications: injectService(),

--- a/app/controllers/settings/apps/slack.js
+++ b/app/controllers/settings/apps/slack.js
@@ -1,9 +1,9 @@
 import Controller from 'ember-controller';
-import {empty} from 'ember-computed';
 import injectService from 'ember-service/inject';
-import {task} from 'ember-concurrency';
-import {isInvalidError} from 'ember-ajax/errors';
 import {alias} from 'ember-computed';
+import {empty} from 'ember-computed';
+import {isInvalidError} from 'ember-ajax/errors';
+import {task} from 'ember-concurrency';
 
 export default Controller.extend({
     ghostPaths: injectService(),

--- a/app/controllers/settings/design.js
+++ b/app/controllers/settings/design.js
@@ -1,12 +1,12 @@
-import RSVP from 'rsvp';
-import Controller from 'ember-controller';
-import computed, {notEmpty} from 'ember-computed';
-import {isEmpty} from 'ember-utils';
-import injectService from 'ember-service/inject';
-import {task} from 'ember-concurrency';
-import NavigationItem from 'ghost-admin/models/navigation-item';
-import {isThemeValidationError} from 'ghost-admin/services/ajax';
 import $ from 'jquery';
+import Controller from 'ember-controller';
+import NavigationItem from 'ghost-admin/models/navigation-item';
+import RSVP from 'rsvp';
+import computed, {notEmpty} from 'ember-computed';
+import injectService from 'ember-service/inject';
+import {isEmpty} from 'ember-utils';
+import {isThemeValidationError} from 'ghost-admin/services/ajax';
+import {task} from 'ember-concurrency';
 
 export default Controller.extend({
     config: injectService(),

--- a/app/controllers/settings/general.js
+++ b/app/controllers/settings/general.js
@@ -2,13 +2,13 @@ import Controller from 'ember-controller';
 import computed from 'ember-computed';
 import injectService from 'ember-service/inject';
 import observer from 'ember-metal/observer';
-import run from 'ember-runloop';
 import randomPassword from 'ghost-admin/utils/random-password';
-import {task} from 'ember-concurrency';
+import run from 'ember-runloop';
 import {
-    IMAGE_MIME_TYPES,
-    IMAGE_EXTENSIONS
+    IMAGE_EXTENSIONS,
+    IMAGE_MIME_TYPES
 } from 'ghost-admin/components/gh-image-uploader';
+import {task} from 'ember-concurrency';
 
 export default Controller.extend({
     config: injectService(),

--- a/app/controllers/settings/labs.js
+++ b/app/controllers/settings/labs.js
@@ -1,12 +1,15 @@
 import $ from 'jquery';
-import RSVP from 'rsvp';
 import Controller from 'ember-controller';
+import RSVP from 'rsvp';
 import injectService from 'ember-service/inject';
+import run from 'ember-runloop';
+import {
+    UnsupportedMediaTypeError,
+    isUnsupportedMediaTypeError
+} from 'ghost-admin/services/ajax';
 import {isBlank} from 'ember-utils';
 import {isEmberArray} from 'ember-array/utils';
 import {task} from 'ember-concurrency';
-import {UnsupportedMediaTypeError, isUnsupportedMediaTypeError} from 'ghost-admin/services/ajax';
-import run from 'ember-runloop';
 
 const {Promise} = RSVP;
 

--- a/app/controllers/settings/tags/tag.js
+++ b/app/controllers/settings/tags/tag.js
@@ -1,7 +1,7 @@
 import Controller from 'ember-controller';
-import {alias} from 'ember-computed';
-import injectService from 'ember-service/inject';
 import injectController from 'ember-controller/inject';
+import injectService from 'ember-service/inject';
+import {alias} from 'ember-computed';
 
 export default Controller.extend({
 

--- a/app/controllers/setup.js
+++ b/app/controllers/setup.js
@@ -1,7 +1,7 @@
 import Controller from 'ember-controller';
 import computed, {match} from 'ember-computed';
-import injectService from 'ember-service/inject';
 import injectController from 'ember-controller/inject';
+import injectService from 'ember-service/inject';
 
 export default Controller.extend({
     appController: injectController('application'),

--- a/app/controllers/setup/three.js
+++ b/app/controllers/setup/three.js
@@ -1,12 +1,12 @@
 import Controller from 'ember-controller';
+import DS from 'ember-data';
 import RSVP from 'rsvp';
 import computed, {alias} from 'ember-computed';
-import {A as emberA} from 'ember-array/utils';
-import injectService from 'ember-service/inject';
 import injectController from 'ember-controller/inject';
-import {htmlSafe} from 'ember-string';
+import injectService from 'ember-service/inject';
 import run from 'ember-runloop';
-import DS from 'ember-data';
+import {A as emberA} from 'ember-array/utils';
+import {htmlSafe} from 'ember-string';
 import {task, timeout} from 'ember-concurrency';
 
 const {Errors} = DS;

--- a/app/controllers/signup.js
+++ b/app/controllers/signup.js
@@ -1,14 +1,14 @@
 import Controller from 'ember-controller';
 import RSVP from 'rsvp';
-import injectService from 'ember-service/inject';
-import {isEmberArray} from 'ember-array/utils';
-import {task} from 'ember-concurrency';
 import ValidationEngine from 'ghost-admin/mixins/validation-engine';
+import injectService from 'ember-service/inject';
 import {
     VersionMismatchError,
     isVersionMismatchError
 } from 'ghost-admin/services/ajax';
 import {assign} from 'ember-platform';
+import {isEmberArray} from 'ember-array/utils';
+import {task} from 'ember-concurrency';
 
 const {Promise} = RSVP;
 

--- a/app/controllers/subscribers.js
+++ b/app/controllers/subscribers.js
@@ -1,12 +1,11 @@
 import $ from 'jquery';
-import {assign} from 'ember-platform';
-import computed from 'ember-computed';
-import injectService from 'ember-service/inject';
 import Controller from 'ember-controller';
-
-import Table from 'ember-light-table';
 import PaginationMixin from 'ghost-admin/mixins/pagination';
+import Table from 'ember-light-table';
+import computed from 'ember-computed';
 import ghostPaths from 'ghost-admin/utils/ghost-paths';
+import injectService from 'ember-service/inject';
+import {assign} from 'ember-platform';
 
 export default Controller.extend(PaginationMixin, {
 

--- a/app/controllers/team/user.js
+++ b/app/controllers/team/user.js
@@ -1,15 +1,13 @@
-import Ember from 'ember';
 import Controller from 'ember-controller';
+import Ember from 'ember';
+import boundOneWay from 'ghost-admin/utils/bound-one-way';
 import computed, {alias, and, not, or, readOnly} from 'ember-computed';
 import injectService from 'ember-service/inject';
-import {htmlSafe} from 'ember-string';
-import run from 'ember-runloop';
-import {isEmberArray} from 'ember-array/utils';
-
-import {task, taskGroup} from 'ember-concurrency';
-
 import isNumber from 'ghost-admin/utils/isNumber';
-import boundOneWay from 'ghost-admin/utils/bound-one-way';
+import run from 'ember-runloop';
+import {htmlSafe} from 'ember-string';
+import {isEmberArray} from 'ember-array/utils';
+import {task, taskGroup} from 'ember-concurrency';
 
 // ember-cli-shims doesn't export this
 const {Handlebars} = Ember;

--- a/app/helpers/gh-count-words.js
+++ b/app/helpers/gh-count-words.js
@@ -1,5 +1,5 @@
-import {helper} from 'ember-helper';
 import counter from 'ghost-admin/utils/word-count';
+import {helper} from 'ember-helper';
 
 export default helper(function (params) {
     if (!params || !params.length) {

--- a/app/helpers/gh-format-html.js
+++ b/app/helpers/gh-format-html.js
@@ -1,7 +1,7 @@
 /* global html_sanitize*/
+import cajaSanitizers from 'ghost-admin/utils/caja-sanitizers';
 import {helper} from 'ember-helper';
 import {htmlSafe} from 'ember-string';
-import cajaSanitizers from 'ghost-admin/utils/caja-sanitizers';
 
 export default helper(function (params) {
     if (!params || !params.length) {

--- a/app/helpers/gh-format-timeago.js
+++ b/app/helpers/gh-format-timeago.js
@@ -1,5 +1,5 @@
-import {helper} from 'ember-helper';
 import moment from 'moment';
+import {helper} from 'ember-helper';
 
 export function timeAgo(params) {
     if (!params || !params.length) {

--- a/app/helpers/gh-path.js
+++ b/app/helpers/gh-path.js
@@ -1,6 +1,6 @@
+import ghostPaths from 'ghost-admin/utils/ghost-paths';
 import {helper} from 'ember-helper';
 import {htmlSafe} from 'ember-string';
-import ghostPaths from 'ghost-admin/utils/ghost-paths';
 
 // Handlebars Helper {{gh-path}}
 // Usage: Assume 'http://www.myghostblog.org/myblog/'

--- a/app/initializers/ember-simple-auth.js
+++ b/app/initializers/ember-simple-auth.js
@@ -1,6 +1,6 @@
+import Configuration from 'ember-simple-auth/configuration';
 import ENV from '../config/environment';
 import ghostPaths from '../utils/ghost-paths';
-import Configuration from 'ember-simple-auth/configuration';
 import setupSession from 'ember-simple-auth/initializers/setup-session';
 import setupSessionService from 'ember-simple-auth/initializers/setup-session-service';
 

--- a/app/mixins/body-event-listener.js
+++ b/app/mixins/body-event-listener.js
@@ -1,6 +1,6 @@
 import $ from 'jquery';
-import run from 'ember-runloop';
 import Mixin from 'ember-metal/mixin';
+import run from 'ember-runloop';
 
 function K() {
     return this;

--- a/app/mixins/dropdown-mixin.js
+++ b/app/mixins/dropdown-mixin.js
@@ -1,5 +1,5 @@
-import Mixin from 'ember-metal/mixin';
 import Evented from 'ember-evented';
+import Mixin from 'ember-metal/mixin';
 
 /*
   Dropdowns and their buttons are evented and do not propagate clicks.

--- a/app/mixins/editor-base-controller.js
+++ b/app/mixins/editor-base-controller.js
@@ -1,20 +1,19 @@
 import Ember from 'ember';
 import Mixin from 'ember-metal/mixin';
-import RSVP from 'rsvp';
-import computed, {alias, mapBy, reads} from 'ember-computed';
-import injectService from 'ember-service/inject';
-import injectController from 'ember-controller/inject';
-import {htmlSafe} from 'ember-string';
-import {isEmberArray} from 'ember-array/utils';
-import {isBlank} from 'ember-utils';
-import {task, timeout} from 'ember-concurrency';
 import PostModel from 'ghost-admin/models/post';
+import RSVP from 'rsvp';
 import boundOneWay from 'ghost-admin/utils/bound-one-way';
-import {isVersionMismatchError} from 'ghost-admin/services/ajax';
-import {isInvalidError} from 'ember-ajax/errors';
-
+import computed, {alias, mapBy, reads} from 'ember-computed';
 import ghostPaths from 'ghost-admin/utils/ghost-paths';
+import injectController from 'ember-controller/inject';
+import injectService from 'ember-service/inject';
 import moment from 'moment';
+import {htmlSafe} from 'ember-string';
+import {isBlank} from 'ember-utils';
+import {isEmberArray} from 'ember-array/utils';
+import {isInvalidError} from 'ember-ajax/errors';
+import {isVersionMismatchError} from 'ghost-admin/services/ajax';
+import {task, timeout} from 'ember-concurrency';
 
 const {resolve} = RSVP;
 

--- a/app/mixins/editor-base-route.js
+++ b/app/mixins/editor-base-route.js
@@ -1,10 +1,9 @@
 import $ from 'jquery';
 import Mixin from 'ember-metal/mixin';
-import run from 'ember-runloop';
-
 import ShortcutsRoute from 'ghost-admin/mixins/shortcuts-route';
-import styleBody from 'ghost-admin/mixins/style-body';
 import ctrlOrCmd from 'ghost-admin/utils/ctrl-or-cmd';
+import run from 'ember-runloop';
+import styleBody from 'ghost-admin/mixins/style-body';
 
 let generalShortcuts = {};
 generalShortcuts[`${ctrlOrCmd}+alt+p`] = 'publish';

--- a/app/mixins/pagination.js
+++ b/app/mixins/pagination.js
@@ -1,8 +1,8 @@
 import Mixin from 'ember-metal/mixin';
-import {assign} from 'ember-platform';
-import computed from 'ember-computed';
 import RSVP from 'rsvp';
+import computed from 'ember-computed';
 import injectService from 'ember-service/inject';
+import {assign} from 'ember-platform';
 
 let defaultPaginationSettings = {
     page: 1,

--- a/app/mixins/validation-engine.js
+++ b/app/mixins/validation-engine.js
@@ -1,12 +1,10 @@
-import Mixin from 'ember-metal/mixin';
-import RSVP from 'rsvp';
-import {A as emberA, isEmberArray} from 'ember-array/utils';
 import DS from 'ember-data';
-import Model from 'ember-data/model';
-
 import InviteUserValidator from 'ghost-admin/validators/invite-user';
+import Mixin from 'ember-metal/mixin';
+import Model from 'ember-data/model';
 import NavItemValidator from 'ghost-admin/validators/nav-item';
 import PostValidator from 'ghost-admin/validators/post';
+import RSVP from 'rsvp';
 import ResetValidator from 'ghost-admin/validators/reset';
 import SettingValidator from 'ghost-admin/validators/setting';
 import SetupValidator from 'ghost-admin/validators/setup';
@@ -16,8 +14,8 @@ import SlackIntegrationValidator from 'ghost-admin/validators/slack-integration'
 import SubscriberValidator from 'ghost-admin/validators/subscriber';
 import TagSettingsValidator from 'ghost-admin/validators/tag-settings';
 import UserValidator from 'ghost-admin/validators/user';
-
 import ValidatorExtensions from 'ghost-admin/utils/validator-extensions';
+import {A as emberA, isEmberArray} from 'ember-array/utils';
 
 const {Errors} = DS;
 

--- a/app/mixins/validation-state.js
+++ b/app/mixins/validation-state.js
@@ -1,8 +1,8 @@
 import Mixin from 'ember-metal/mixin';
-import {isEmpty} from 'ember-utils';
-import {A as emberA} from 'ember-array/utils';
 import observer from 'ember-metal/observer';
 import run from 'ember-runloop';
+import {A as emberA} from 'ember-array/utils';
+import {isEmpty} from 'ember-utils';
 
 export default Mixin.create({
 

--- a/app/models/invite.js
+++ b/app/models/invite.js
@@ -1,8 +1,8 @@
 /* eslint camelcase: [2, {properties: "never"}] */
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
-import {belongsTo} from 'ember-data/relationships';
 import injectService from 'ember-service/inject';
+import {belongsTo} from 'ember-data/relationships';
 
 export default Model.extend({
     token: attr('string'),

--- a/app/models/navigation-item.js
+++ b/app/models/navigation-item.js
@@ -1,8 +1,7 @@
+import EmberObject from 'ember-object';
+import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 import computed from 'ember-computed';
 import {isBlank} from 'ember-utils';
-import EmberObject from 'ember-object';
-
-import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 
 export default EmberObject.extend(ValidationEngine, {
     label: '',

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -1,17 +1,15 @@
 import Ember from 'ember';
+import Model from 'ember-data/model';
+import ValidationEngine from 'ghost-admin/mixins/validation-engine';
+import attr from 'ember-data/attr';
+import boundOneWay from 'ghost-admin/utils/bound-one-way';
 import computed, {equal, filterBy} from 'ember-computed';
 import injectService from 'ember-service/inject';
 import moment from 'moment';
 import observer from 'ember-metal/observer';
-import Model from 'ember-data/model';
-import attr from 'ember-data/attr';
-import {belongsTo, hasMany} from 'ember-data/relationships';
-import ValidationEngine from 'ghost-admin/mixins/validation-engine';
-import boundOneWay from 'ghost-admin/utils/bound-one-way';
-import {isBlank} from 'ember-utils';
-
-// a blank mobile doc containing a single markdown card
 import {BLANK_DOC} from 'ghost-admin/components/gh-markdown-editor';
+import {belongsTo, hasMany} from 'ember-data/relationships';
+import {isBlank} from 'ember-utils';
 
 // ember-cli-shims doesn't export these so we must get them manually
 const {Comparable, compare} = Ember;

--- a/app/models/role.js
+++ b/app/models/role.js
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
-import computed from 'ember-computed';
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
+import computed from 'ember-computed';
 
 export default Model.extend({
     name: attr('string'),

--- a/app/models/setting.js
+++ b/app/models/setting.js
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 import Model from 'ember-data/model';
-import attr from 'ember-data/attr';
 import ValidationEngine from 'ghost-admin/mixins/validation-engine';
+import attr from 'ember-data/attr';
 
 export default Model.extend(ValidationEngine, {
     validationType: 'setting',

--- a/app/models/slack-integration.js
+++ b/app/models/slack-integration.js
@@ -1,7 +1,7 @@
-import computed from 'ember-computed';
-import {isBlank} from 'ember-utils';
 import EmberObject from 'ember-object';
 import ValidationEngine from 'ghost-admin/mixins/validation-engine';
+import computed from 'ember-computed';
+import {isBlank} from 'ember-utils';
 
 export default EmberObject.extend(ValidationEngine, {
     // values entered here will act as defaults

--- a/app/models/subscriber.js
+++ b/app/models/subscriber.js
@@ -1,7 +1,7 @@
 import Model from 'ember-data/model';
+import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 import attr from 'ember-data/attr';
 import {belongsTo} from 'ember-data/relationships';
-import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 
 export default Model.extend(ValidationEngine, {
     validationType: 'subscriber',

--- a/app/models/tag.js
+++ b/app/models/tag.js
@@ -1,12 +1,11 @@
 /* eslint-disable camelcase */
-import computed, {equal} from 'ember-computed';
-import observer from 'ember-metal/observer';
-import injectService from 'ember-service/inject';
-import {guidFor} from 'ember-metal/utils';
-
 import Model from 'ember-data/model';
-import attr from 'ember-data/attr';
 import ValidationEngine from 'ghost-admin/mixins/validation-engine';
+import attr from 'ember-data/attr';
+import computed, {equal} from 'ember-computed';
+import injectService from 'ember-service/inject';
+import observer from 'ember-metal/observer';
+import {guidFor} from 'ember-metal/utils';
 
 export default Model.extend(ValidationEngine, {
     validationType: 'tag',

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -1,12 +1,11 @@
 /* eslint-disable camelcase */
 import Model from 'ember-data/model';
+import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 import attr from 'ember-data/attr';
-import {hasMany} from 'ember-data/relationships';
 import computed, {equal} from 'ember-computed';
 import injectService from 'ember-service/inject';
-
+import {hasMany} from 'ember-data/relationships';
 import {task} from 'ember-concurrency';
-import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 
 export default Model.extend(ValidationEngine, {
     validationType: 'user',

--- a/app/router.js
+++ b/app/router.js
@@ -1,9 +1,9 @@
 import Router from 'ember-router';
+import config from './config/environment';
+import documentTitle from 'ghost-admin/utils/document-title';
+import ghostPaths from 'ghost-admin/utils/ghost-paths';
 import injectService from 'ember-service/inject';
 import on from 'ember-evented/on';
-import ghostPaths from 'ghost-admin/utils/ghost-paths';
-import documentTitle from 'ghost-admin/utils/document-title';
-import config from './config/environment';
 
 const GhostRouter = Router.extend({
     location: config.locationType, // use HTML5 History API instead of hash-tag based URLs

--- a/app/routes/about.js
+++ b/app/routes/about.js
@@ -1,5 +1,5 @@
-import injectService from 'ember-service/inject';
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
+import injectService from 'ember-service/inject';
 import styleBody from 'ghost-admin/mixins/style-body';
 
 export default AuthenticatedRoute.extend(styleBody, {

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,17 +1,17 @@
-import Route from 'ember-route';
-import {htmlSafe} from 'ember-string';
-import injectService from 'ember-service/inject';
-import run from 'ember-runloop';
-import {isEmberArray} from 'ember-array/utils';
-import observer from 'ember-metal/observer';
 import $ from 'jquery';
-import {isUnauthorizedError} from 'ember-ajax/errors';
-import AuthConfiguration from 'ember-simple-auth/configuration';
 import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
+import AuthConfiguration from 'ember-simple-auth/configuration';
+import RSVP from 'rsvp';
+import Route from 'ember-route';
 import ShortcutsRoute from 'ghost-admin/mixins/shortcuts-route';
 import ctrlOrCmd from 'ghost-admin/utils/ctrl-or-cmd';
+import injectService from 'ember-service/inject';
+import observer from 'ember-metal/observer';
+import run from 'ember-runloop';
 import windowProxy from 'ghost-admin/utils/window-proxy';
-import RSVP from 'rsvp';
+import {htmlSafe} from 'ember-string';
+import {isEmberArray} from 'ember-array/utils';
+import {isUnauthorizedError} from 'ember-ajax/errors';
 
 function K() {
     return this;

--- a/app/routes/authenticated.js
+++ b/app/routes/authenticated.js
@@ -1,5 +1,5 @@
-import Route from 'ember-route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import Route from 'ember-route';
 
 export default Route.extend(AuthenticatedRouteMixin, {
     authenticationRoute: 'signin'

--- a/app/routes/posts.js
+++ b/app/routes/posts.js
@@ -1,9 +1,9 @@
+import $ from 'jquery';
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
-import ShortcutsRoute from 'ghost-admin/mixins/shortcuts-route';
 import InfinityRoute from 'ember-infinity/mixins/route';
+import ShortcutsRoute from 'ghost-admin/mixins/shortcuts-route';
 import {assign} from 'ember-platform';
 import {isBlank} from 'ember-utils';
-import $ from 'jquery';
 
 export default AuthenticatedRoute.extend(InfinityRoute, ShortcutsRoute, {
     titleToken: 'Content',

--- a/app/routes/reset.js
+++ b/app/routes/reset.js
@@ -1,6 +1,6 @@
 import Route from 'ember-route';
-import injectService from 'ember-service/inject';
 import UnauthenticatedRouteMixin from 'ghost-admin/mixins/unauthenticated-route-mixin';
+import injectService from 'ember-service/inject';
 import styleBody from 'ghost-admin/mixins/style-body';
 
 export default Route.extend(styleBody, UnauthenticatedRouteMixin, {

--- a/app/routes/settings/apps.js
+++ b/app/routes/settings/apps.js
@@ -1,7 +1,7 @@
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 import CurrentUserSettings from 'ghost-admin/mixins/current-user-settings';
-import styleBody from 'ghost-admin/mixins/style-body';
 import injectService from 'ember-service/inject';
+import styleBody from 'ghost-admin/mixins/style-body';
 
 export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
     settings: injectService(),

--- a/app/routes/settings/code-injection.js
+++ b/app/routes/settings/code-injection.js
@@ -1,7 +1,7 @@
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 import CurrentUserSettings from 'ghost-admin/mixins/current-user-settings';
-import styleBody from 'ghost-admin/mixins/style-body';
 import injectService from 'ember-service/inject';
+import styleBody from 'ghost-admin/mixins/style-body';
 
 export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
     titleToken: 'Settings - Code injection',

--- a/app/routes/settings/design.js
+++ b/app/routes/settings/design.js
@@ -1,9 +1,9 @@
 import $ from 'jquery';
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 import CurrentUserSettings from 'ghost-admin/mixins/current-user-settings';
-import styleBody from 'ghost-admin/mixins/style-body';
 import RSVP from 'rsvp';
 import injectService from 'ember-service/inject';
+import styleBody from 'ghost-admin/mixins/style-body';
 
 export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
     settings: injectService(),

--- a/app/routes/settings/general.js
+++ b/app/routes/settings/general.js
@@ -1,7 +1,7 @@
-import RSVP from 'rsvp';
-import injectService from 'ember-service/inject';
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 import CurrentUserSettings from 'ghost-admin/mixins/current-user-settings';
+import RSVP from 'rsvp';
+import injectService from 'ember-service/inject';
 import styleBody from 'ghost-admin/mixins/style-body';
 
 export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {

--- a/app/routes/settings/labs.js
+++ b/app/routes/settings/labs.js
@@ -1,7 +1,7 @@
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
-import styleBody from 'ghost-admin/mixins/style-body';
 import CurrentUserSettings from 'ghost-admin/mixins/current-user-settings';
 import injectService from 'ember-service/inject';
+import styleBody from 'ghost-admin/mixins/style-body';
 
 export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
     settings: injectService(),

--- a/app/routes/settings/tags.js
+++ b/app/routes/settings/tags.js
@@ -2,8 +2,8 @@
 import $ from 'jquery';
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 import CurrentUserSettings from 'ghost-admin/mixins/current-user-settings';
-import ShortcutsRoute from 'ghost-admin/mixins/shortcuts-route';
 import PaginationMixin from 'ghost-admin/mixins/pagination';
+import ShortcutsRoute from 'ghost-admin/mixins/shortcuts-route';
 
 export default AuthenticatedRoute.extend(CurrentUserSettings, PaginationMixin, ShortcutsRoute, {
     titleToken: 'Settings - Tags',

--- a/app/routes/settings/tags/index.js
+++ b/app/routes/settings/tags/index.js
@@ -1,5 +1,5 @@
-import injectService from 'ember-service/inject';
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
+import injectService from 'ember-service/inject';
 
 export default AuthenticatedRoute.extend({
     mediaQueries: injectService(),

--- a/app/routes/signin.js
+++ b/app/routes/signin.js
@@ -1,8 +1,8 @@
-import Route from 'ember-route';
-import EmberObject from 'ember-object';
-import styleBody from 'ghost-admin/mixins/style-body';
 import DS from 'ember-data';
+import EmberObject from 'ember-object';
+import Route from 'ember-route';
 import UnauthenticatedRouteMixin from 'ghost-admin/mixins/unauthenticated-route-mixin';
+import styleBody from 'ghost-admin/mixins/style-body';
 
 const {Errors} = DS;
 

--- a/app/routes/signout.js
+++ b/app/routes/signout.js
@@ -1,6 +1,6 @@
+import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 import Ember from 'ember';
 import injectService from 'ember-service/inject';
-import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 import styleBody from 'ghost-admin/mixins/style-body';
 
 // ember-cli-shims doesn't export canInvoke

--- a/app/routes/signup.js
+++ b/app/routes/signup.js
@@ -1,9 +1,9 @@
-import Route from 'ember-route';
-import RSVP from 'rsvp';
-import injectService from 'ember-service/inject';
-import EmberObject from 'ember-object';
 import DS from 'ember-data';
+import EmberObject from 'ember-object';
+import RSVP from 'rsvp';
+import Route from 'ember-route';
 import UnauthenticatedRouteMixin from 'ghost-admin/mixins/unauthenticated-route-mixin';
+import injectService from 'ember-service/inject';
 import styleBody from 'ghost-admin/mixins/style-body';
 
 const {Promise} = RSVP;

--- a/app/routes/subscribers.js
+++ b/app/routes/subscribers.js
@@ -1,6 +1,6 @@
+import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 import RSVP from 'rsvp';
 import injectService from 'ember-service/inject';
-import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 
 export default AuthenticatedRoute.extend({
     titleToken: 'Subscribers',

--- a/app/routes/team/index.js
+++ b/app/routes/team/index.js
@@ -1,8 +1,8 @@
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 import CurrentUserSettings from 'ghost-admin/mixins/current-user-settings';
 import PaginationMixin from 'ghost-admin/mixins/pagination';
-import styleBody from 'ghost-admin/mixins/style-body';
 import RSVP from 'rsvp';
+import styleBody from 'ghost-admin/mixins/style-body';
 
 export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, PaginationMixin, {
     titleToken: 'Team',

--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
-import {decamelize} from 'ember-string';
 import RESTSerializer from 'ember-data/serializers/rest';
+import {decamelize} from 'ember-string';
 
 const {String: {pluralize}} = Ember;
 

--- a/app/serializers/post.js
+++ b/app/serializers/post.js
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
-import Ember from 'ember';
 import ApplicationSerializer from 'ghost-admin/serializers/application';
 import EmbeddedRecordsMixin from 'ember-data/serializers/embedded-records-mixin';
+import Ember from 'ember';
 
 const {String: {pluralize}} = Ember;
 

--- a/app/serializers/setting.js
+++ b/app/serializers/setting.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
 import ApplicationSerializer from 'ghost-admin/serializers/application';
+import Ember from 'ember';
 
 const {String: {pluralize}} = Ember;
 

--- a/app/serializers/tag.js
+++ b/app/serializers/tag.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
-import Ember from 'ember';
 import ApplicationSerializer from 'ghost-admin/serializers/application';
+import Ember from 'ember';
 
 const {String: {pluralize}} = Ember;
 

--- a/app/serializers/user.js
+++ b/app/serializers/user.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
 import ApplicationSerializer from 'ghost-admin/serializers/application';
 import EmbeddedRecordsMixin from 'ember-data/serializers/embedded-records-mixin';
+import Ember from 'ember';
 
 const {String: {pluralize}} = Ember;
 

--- a/app/services/ajax.js
+++ b/app/services/ajax.js
@@ -1,11 +1,11 @@
-import get from 'ember-metal/get';
+import AjaxService from 'ember-ajax/services/ajax';
 import computed from 'ember-computed';
+import config from 'ghost-admin/config/environment';
+import get from 'ember-metal/get';
 import injectService from 'ember-service/inject';
+import {AjaxError, isAjaxError} from 'ember-ajax/errors';
 import {isEmberArray} from 'ember-array/utils';
 import {isNone} from 'ember-utils';
-import AjaxService from 'ember-ajax/services/ajax';
-import {AjaxError, isAjaxError} from 'ember-ajax/errors';
-import config from 'ghost-admin/config/environment';
 
 const JSONContentType = 'application/json';
 

--- a/app/services/clock.js
+++ b/app/services/clock.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import Service from 'ember-service';
-import run from 'ember-runloop';
 import moment from 'moment';
+import run from 'ember-runloop';
 
 // ember-cli-shims doesn't export Ember.testing
 const {testing} = Ember;

--- a/app/services/dropdown.js
+++ b/app/services/dropdown.js
@@ -1,8 +1,8 @@
-import Service from 'ember-service';
-import Evented from 'ember-evented';
+import $ from 'jquery';
 // This is used by the dropdown initializer to manage closing & toggling
 import BodyEventListener from 'ghost-admin/mixins/body-event-listener';
-import $ from 'jquery';
+import Evented from 'ember-evented';
+import Service from 'ember-service';
 
 export default Service.extend(Evented, BodyEventListener, {
     bodyClick(event) {

--- a/app/services/event-bus.js
+++ b/app/services/event-bus.js
@@ -1,5 +1,5 @@
-import Service from 'ember-service';
 import Evented from 'ember-evented';
+import Service from 'ember-service';
 
 export default Service.extend(Evented, {
     publish() {

--- a/app/services/feature.js
+++ b/app/services/feature.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
+import RSVP from 'rsvp';
 import Service from 'ember-service';
 import computed from 'ember-computed';
 import injectService from 'ember-service/inject';
 import set from 'ember-metal/set';
-import RSVP from 'rsvp';
 
 // ember-cli-shims doesn't export Error
 const {Error: EmberError} = Ember;

--- a/app/services/notifications.js
+++ b/app/services/notifications.js
@@ -1,11 +1,11 @@
 import Service from 'ember-service';
-import {filter} from 'ember-computed';
-import {A as emberA, isEmberArray} from 'ember-array/utils';
 import get from 'ember-metal/get';
-import set from 'ember-metal/set';
 import injectService from 'ember-service/inject';
-import {isBlank} from 'ember-utils';
+import set from 'ember-metal/set';
 import {dasherize} from 'ember-string';
+import {A as emberA, isEmberArray} from 'ember-array/utils';
+import {filter} from 'ember-computed';
+import {isBlank} from 'ember-utils';
 import {
     isMaintenanceError,
     isVersionMismatchError

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -1,6 +1,6 @@
+import SessionService from 'ember-simple-auth/services/session';
 import computed from 'ember-computed';
 import injectService from 'ember-service/inject';
-import SessionService from 'ember-simple-auth/services/session';
 
 export default SessionService.extend({
     store: injectService(),

--- a/app/services/settings.js
+++ b/app/services/settings.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
-import Service from 'ember-service';
-import injectService from 'ember-service/inject';
 import RSVP from 'rsvp';
+import Service from 'ember-service';
 import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 import get from 'ember-metal/get';
+import injectService from 'ember-service/inject';
 
 // ember-cli-shims doesn't export _ProxyMixin
 const {_ProxyMixin} = Ember;

--- a/app/services/slug-generator.js
+++ b/app/services/slug-generator.js
@@ -1,5 +1,5 @@
-import Service from 'ember-service';
 import RSVP from 'rsvp';
+import Service from 'ember-service';
 import injectService from 'ember-service/inject';
 
 const {resolve} = RSVP;

--- a/app/torii-providers/ghost-oauth2.js
+++ b/app/torii-providers/ghost-oauth2.js
@@ -1,7 +1,7 @@
 import Oauth2 from 'torii/providers/oauth2-code';
-import injectService from 'ember-service/inject';
 import computed from 'ember-computed';
 import ghostPaths from 'ghost-admin/utils/ghost-paths';
+import injectService from 'ember-service/inject';
 
 let GhostOauth2 = Oauth2.extend({
 

--- a/app/transforms/moment-date.js
+++ b/app/transforms/moment-date.js
@@ -1,5 +1,5 @@
-import moment from 'moment';
 import Transform from 'ember-data/transform';
+import moment from 'moment';
 
 export default Transform.extend({
     deserialize(serialized) {

--- a/app/transforms/moment-utc.js
+++ b/app/transforms/moment-utc.js
@@ -1,5 +1,5 @@
-import moment from 'moment';
 import Transform from 'ember-data/transform';
+import moment from 'moment';
 
 export default Transform.extend({
     deserialize(serialized) {

--- a/app/transforms/navigation-settings.js
+++ b/app/transforms/navigation-settings.js
@@ -1,6 +1,6 @@
-import {A as emberA, isEmberArray} from 'ember-array/utils';
-import Transform from 'ember-data/transform';
 import NavigationItem from 'ghost-admin/models/navigation-item';
+import Transform from 'ember-data/transform';
+import {A as emberA, isEmberArray} from 'ember-array/utils';
 
 export default Transform.extend({
     deserialize(serialized) {

--- a/app/transforms/slack-settings.js
+++ b/app/transforms/slack-settings.js
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
-import {A as emberA, isEmberArray} from 'ember-array/utils';
-import Transform from 'ember-data/transform';
 import SlackObject from 'ghost-admin/models/slack-integration';
+import Transform from 'ember-data/transform';
+import {A as emberA, isEmberArray} from 'ember-array/utils';
 
 export default Transform.extend({
     deserialize(serialized) {

--- a/app/utils/document-title.js
+++ b/app/utils/document-title.js
@@ -1,7 +1,7 @@
 import Route from 'ember-route';
 import Router from 'ember-router';
-import {isEmberArray} from 'ember-array/utils';
 import on from 'ember-evented/on';
+import {isEmberArray} from 'ember-array/utils';
 
 export default function () {
     Route.reopen({

--- a/mirage/config/authentication.js
+++ b/mirage/config/authentication.js
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
+import $ from 'jquery';
 import {Response} from 'ember-cli-mirage';
 import {isBlank} from 'ember-utils';
-import $ from 'jquery';
 
 export default function mockAuthentication(server) {
     server.post('/authentication/token', function ({roles, users}, {requestBody}) {

--- a/mirage/config/invites.js
+++ b/mirage/config/invites.js
@@ -1,6 +1,6 @@
+import moment from 'moment';
 import {Response} from 'ember-cli-mirage';
 import {paginatedResponse} from '../utils';
-import moment from 'moment';
 
 export default function mockInvites(server) {
     server.get('/invites/', paginatedResponse('invites'));

--- a/mirage/config/posts.js
+++ b/mirage/config/posts.js
@@ -1,7 +1,7 @@
 import {Response} from 'ember-cli-mirage';
+import {dasherize} from 'ember-string';
 import {isBlank} from 'ember-utils';
 import {paginateModelArray} from '../utils';
-import {dasherize} from 'ember-string';
 
 export default function mockPosts(server) {
     server.post('/posts', function ({posts}) {

--- a/mirage/factories/invite.js
+++ b/mirage/factories/invite.js
@@ -1,5 +1,5 @@
-import {Factory} from 'ember-cli-mirage';
 import moment from 'moment';
+import {Factory} from 'ember-cli-mirage';
 
 export default Factory.extend({
     token(i) { return `${i}-token`; },

--- a/mirage/factories/subscriber.js
+++ b/mirage/factories/subscriber.js
@@ -1,5 +1,5 @@
-import {Factory, faker} from 'ember-cli-mirage';
 import moment from 'moment';
+import {Factory, faker} from 'ember-cli-mirage';
 
 let randomDate = function randomDate(start = moment().subtract(30, 'days').toDate(), end = new Date()) {
     return new Date(start.getTime() + Math.random() * (end.getTime() - start.getTime()));

--- a/mirage/serializers/application.js
+++ b/mirage/serializers/application.js
@@ -1,4 +1,4 @@
-import {RestSerializer, Collection} from 'ember-cli-mirage';
+import {Collection, RestSerializer} from 'ember-cli-mirage';
 import {pluralize} from 'ember-cli-mirage/utils/inflector';
 import {underscore} from 'ember-string';
 

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "ember-wormhole": "0.5.1",
     "emberx-file-input": "1.1.2",
     "eslint-plugin-ember-suave": "1.0.0",
+    "eslint-plugin-sort-imports-es6-autofix": "https://github.com/kevinansfield/eslint-plugin-sort-imports-es6-autofix.git#node-4-compat",
     "fs-extra": "3.0.1",
     "glob": "7.1.1",
     "grunt": "1.0.1",

--- a/tests/acceptance/authentication-test.js
+++ b/tests/acceptance/authentication-test.js
@@ -1,20 +1,15 @@
 /* jshint expr:true */
-import {
-    describe,
-    it,
-    beforeEach,
-    afterEach
-} from 'mocha';
-import {expect} from 'chai';
 import $ from 'jquery';
+import OAuth2Authenticator from 'ghost-admin/authenticators/oauth2';
+import destroyApp from '../helpers/destroy-app';
+import ghostPaths from 'ghost-admin/utils/ghost-paths';
 import run from 'ember-runloop';
 import startApp from '../helpers/start-app';
-import destroyApp from '../helpers/destroy-app';
-import {authenticateSession, invalidateSession} from 'ghost-admin/tests/helpers/ember-simple-auth';
-import {Response} from 'ember-cli-mirage';
 import windowProxy from 'ghost-admin/utils/window-proxy';
-import ghostPaths from 'ghost-admin/utils/ghost-paths';
-import OAuth2Authenticator from 'ghost-admin/authenticators/oauth2';
+import {Response} from 'ember-cli-mirage';
+import {afterEach, beforeEach, describe, it} from 'mocha';
+import {authenticateSession, invalidateSession} from 'ghost-admin/tests/helpers/ember-simple-auth';
+import {expect} from 'chai';
 
 const Ghost = ghostPaths();
 

--- a/tests/acceptance/content-test.js
+++ b/tests/acceptance/content-test.js
@@ -1,12 +1,12 @@
-import {describe, it, beforeEach, afterEach} from 'mocha';
-import {expect} from 'chai';
-import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
-import {
-    invalidateSession,
-    authenticateSession
-} from 'ghost-admin/tests/helpers/ember-simple-auth';
+import startApp from '../helpers/start-app';
 import testSelector from 'ember-test-selectors';
+import {afterEach, beforeEach, describe, it} from 'mocha';
+import {
+    authenticateSession,
+    invalidateSession
+} from 'ghost-admin/tests/helpers/ember-simple-auth';
+import {expect} from 'chai';
 
 describe('Acceptance: Content', function() {
     let application;

--- a/tests/acceptance/editor-test.js
+++ b/tests/acceptance/editor-test.js
@@ -1,18 +1,13 @@
 /* jshint expr:true */
-import {
-    describe,
-    it,
-    beforeEach,
-    afterEach
-} from 'mocha';
-import {expect} from 'chai';
-import startApp from '../helpers/start-app';
-import destroyApp from '../helpers/destroy-app';
-import {invalidateSession, authenticateSession} from 'ghost-admin/tests/helpers/ember-simple-auth';
 import Mirage from 'ember-cli-mirage';
-import sinon from 'sinon';
-import testSelector from 'ember-test-selectors';
+import destroyApp from '../helpers/destroy-app';
 import moment from 'moment';
+import sinon from 'sinon';
+import startApp from '../helpers/start-app';
+import testSelector from 'ember-test-selectors';
+import {afterEach, beforeEach, describe, it} from 'mocha';
+import {authenticateSession, invalidateSession} from 'ghost-admin/tests/helpers/ember-simple-auth';
+import {expect} from 'chai';
 
 describe('Acceptance: Editor', function() {
     let application;

--- a/tests/acceptance/ghost-desktop-test.js
+++ b/tests/acceptance/ghost-desktop-test.js
@@ -1,14 +1,9 @@
 /* jshint expr:true */
-import {
-    describe,
-    it,
-    beforeEach,
-    afterEach
-} from 'mocha';
-import {expect} from 'chai';
-import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
+import startApp from '../helpers/start-app';
+import {afterEach, beforeEach, describe, it} from 'mocha';
 import {authenticateSession} from 'ghost-admin/tests/helpers/ember-simple-auth';
+import {expect} from 'chai';
 
 const originalAgent = window.navigator.userAgent;
 

--- a/tests/acceptance/password-reset-test.js
+++ b/tests/acceptance/password-reset-test.js
@@ -1,13 +1,8 @@
 /* jshint expr:true */
-import {
-    describe,
-    it,
-    beforeEach,
-    afterEach
-} from 'mocha';
-import {expect} from 'chai';
-import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
+import startApp from '../helpers/start-app';
+import {afterEach, beforeEach, describe, it} from 'mocha';
+import {expect} from 'chai';
 
 describe('Acceptance: Password Reset', function() {
     let application;

--- a/tests/acceptance/settings/amp-test.js
+++ b/tests/acceptance/settings/amp-test.js
@@ -1,16 +1,16 @@
 /* jshint expr:true */
-import {
-    describe,
-    it,
-    beforeEach,
-    afterEach
-} from 'mocha';
-import {expect} from 'chai';
-import startApp from '../../helpers/start-app';
-import destroyApp from '../../helpers/destroy-app';
-import {invalidateSession, authenticateSession} from 'ghost-admin/tests/helpers/ember-simple-auth';
-import testSelector from 'ember-test-selectors';
 import ctrlOrCmd from 'ghost-admin/utils/ctrl-or-cmd';
+import destroyApp from '../../helpers/destroy-app';
+import startApp from '../../helpers/start-app';
+import testSelector from 'ember-test-selectors';
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    it
+} from 'mocha';
+import {authenticateSession, invalidateSession} from 'ghost-admin/tests/helpers/ember-simple-auth';
+import {expect} from 'chai';
 
 describe('Acceptance: Settings - Apps - AMP', function () {
     let application;

--- a/tests/acceptance/settings/apps-test.js
+++ b/tests/acceptance/settings/apps-test.js
@@ -1,14 +1,14 @@
 /* jshint expr:true */
-import {
-    describe,
-    it,
-    beforeEach,
-    afterEach
-} from 'mocha';
-import {expect} from 'chai';
-import startApp from '../../helpers/start-app';
 import destroyApp from '../../helpers/destroy-app';
-import {invalidateSession, authenticateSession} from 'ghost-admin/tests/helpers/ember-simple-auth';
+import startApp from '../../helpers/start-app';
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    it
+} from 'mocha';
+import {authenticateSession, invalidateSession} from 'ghost-admin/tests/helpers/ember-simple-auth';
+import {expect} from 'chai';
 
 describe('Acceptance: Settings - Apps', function () {
     let application;

--- a/tests/acceptance/settings/code-injection-test.js
+++ b/tests/acceptance/settings/code-injection-test.js
@@ -1,17 +1,17 @@
 /* jshint expr:true */
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach
-} from 'mocha';
-import {expect} from 'chai';
 import $ from 'jquery';
-import startApp from '../../helpers/start-app';
-import destroyApp from '../../helpers/destroy-app';
-import {invalidateSession, authenticateSession} from 'ghost-admin/tests/helpers/ember-simple-auth';
-import testSelector from 'ember-test-selectors';
 import ctrlOrCmd from 'ghost-admin/utils/ctrl-or-cmd';
+import destroyApp from '../../helpers/destroy-app';
+import startApp from '../../helpers/start-app';
+import testSelector from 'ember-test-selectors';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  it
+} from 'mocha';
+import {authenticateSession, invalidateSession} from 'ghost-admin/tests/helpers/ember-simple-auth';
+import {expect} from 'chai';
 
 describe('Acceptance: Settings - Code-Injection', function() {
     let application;

--- a/tests/acceptance/settings/design-test.js
+++ b/tests/acceptance/settings/design-test.js
@@ -1,19 +1,14 @@
 /* jshint expr:true */
 /* eslint-disable camelcase */
-import {
-    describe,
-    it,
-    beforeEach,
-    afterEach
-} from 'mocha';
-import {expect} from 'chai';
-import startApp from '../../helpers/start-app';
-import destroyApp from '../../helpers/destroy-app';
-import {invalidateSession, authenticateSession} from 'ghost-admin/tests/helpers/ember-simple-auth';
 import Mirage from 'ember-cli-mirage';
-import mockThemes from 'ghost-admin/mirage/config/themes';
-import testSelector from 'ember-test-selectors';
 import ctrlOrCmd from 'ghost-admin/utils/ctrl-or-cmd';
+import destroyApp from '../../helpers/destroy-app';
+import mockThemes from 'ghost-admin/mirage/config/themes';
+import startApp from '../../helpers/start-app';
+import testSelector from 'ember-test-selectors';
+import {afterEach, beforeEach, describe, it} from 'mocha';
+import {authenticateSession, invalidateSession} from 'ghost-admin/tests/helpers/ember-simple-auth';
+import {expect} from 'chai';
 
 describe('Acceptance: Settings - Design', function () {
     let application;

--- a/tests/acceptance/settings/general-test.js
+++ b/tests/acceptance/settings/general-test.js
@@ -1,20 +1,15 @@
 /* jshint expr:true */
-import {
-    describe,
-    it,
-    beforeEach,
-    afterEach
-} from 'mocha';
-import {expect} from 'chai';
-import testSelector from 'ember-test-selectors';
 import $ from 'jquery';
-import startApp from '../../helpers/start-app';
-import destroyApp from '../../helpers/destroy-app';
-import {invalidateSession, authenticateSession} from 'ghost-admin/tests/helpers/ember-simple-auth';
 import ctrlOrCmd from 'ghost-admin/utils/ctrl-or-cmd';
-import wait from 'ember-test-helpers/wait';
-import run from 'ember-runloop';
+import destroyApp from '../../helpers/destroy-app';
 import mockUploads from '../../../mirage/config/uploads';
+import run from 'ember-runloop';
+import startApp from '../../helpers/start-app';
+import testSelector from 'ember-test-selectors';
+import wait from 'ember-test-helpers/wait';
+import {afterEach, beforeEach, describe, it} from 'mocha';
+import {authenticateSession, invalidateSession} from 'ghost-admin/tests/helpers/ember-simple-auth';
+import {expect} from 'chai';
 
 describe('Acceptance: Settings - General', function () {
     let application;

--- a/tests/acceptance/settings/labs-test.js
+++ b/tests/acceptance/settings/labs-test.js
@@ -1,15 +1,10 @@
 /* jshint expr:true */
-import {
-    describe,
-    it,
-    beforeEach,
-    afterEach
-} from 'mocha';
-import {expect} from 'chai';
 import $ from 'jquery';
-import startApp from '../../helpers/start-app';
 import destroyApp from '../../helpers/destroy-app';
-import {invalidateSession, authenticateSession} from 'ghost-admin/tests/helpers/ember-simple-auth';
+import startApp from '../../helpers/start-app';
+import {afterEach, beforeEach, describe, it} from 'mocha';
+import {authenticateSession, invalidateSession} from 'ghost-admin/tests/helpers/ember-simple-auth';
+import {expect} from 'chai';
 
 describe('Acceptance: Settings - Labs', function() {
     let application;

--- a/tests/acceptance/settings/slack-test.js
+++ b/tests/acceptance/settings/slack-test.js
@@ -1,17 +1,12 @@
 /* jshint expr:true */
-import {
-    describe,
-    it,
-    beforeEach,
-    afterEach
-} from 'mocha';
-import {expect} from 'chai';
-import startApp from '../../helpers/start-app';
-import destroyApp from '../../helpers/destroy-app';
 import Mirage from 'ember-cli-mirage';
-import {invalidateSession, authenticateSession} from 'ghost-admin/tests/helpers/ember-simple-auth';
-import testSelector from 'ember-test-selectors';
 import ctrlOrCmd from 'ghost-admin/utils/ctrl-or-cmd';
+import destroyApp from '../../helpers/destroy-app';
+import startApp from '../../helpers/start-app';
+import testSelector from 'ember-test-selectors';
+import {afterEach, beforeEach, describe, it} from 'mocha';
+import {authenticateSession, invalidateSession} from 'ghost-admin/tests/helpers/ember-simple-auth';
+import {expect} from 'chai';
 
 describe('Acceptance: Settings - Apps - Slack', function () {
     let application;

--- a/tests/acceptance/settings/tags-test.js
+++ b/tests/acceptance/settings/tags-test.js
@@ -1,19 +1,14 @@
 /* jshint expr:true */
 /* eslint-disable camelcase */
-import {
-    describe,
-    it,
-    beforeEach,
-    afterEach
-} from 'mocha';
-import {expect} from 'chai';
 import $ from 'jquery';
+import destroyApp from '../../helpers/destroy-app';
 import run from 'ember-runloop';
 import startApp from '../../helpers/start-app';
-import destroyApp from '../../helpers/destroy-app';
-import {invalidateSession, authenticateSession} from 'ghost-admin/tests/helpers/ember-simple-auth';
-import {errorOverride, errorReset} from 'ghost-admin/tests/helpers/adapter-error';
 import {Response} from 'ember-cli-mirage';
+import {afterEach, beforeEach, describe, it} from 'mocha';
+import {authenticateSession, invalidateSession} from 'ghost-admin/tests/helpers/ember-simple-auth';
+import {errorOverride, errorReset} from 'ghost-admin/tests/helpers/adapter-error';
+import {expect} from 'chai';
 
 // Grabbed from keymaster's testing code because Ember's `keyEvent` helper
 // is for some reason not triggering the events in a way that keymaster detects:

--- a/tests/acceptance/setup-test.js
+++ b/tests/acceptance/setup-test.js
@@ -1,22 +1,17 @@
 /* jshint expr:true */
-import {
-    describe,
-    it,
-    beforeEach,
-    afterEach
-} from 'mocha';
-import {expect} from 'chai';
-import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
-import {invalidateSession, authenticateSession} from '../helpers/ember-simple-auth';
-import {enableGhostOAuth} from '../helpers/configuration';
-import {Response} from 'ember-cli-mirage';
-import {
-    stubSuccessfulOAuthConnect,
-    stubFailedOAuthConnect
-} from '../helpers/oauth';
 import moment from 'moment';
+import startApp from '../helpers/start-app';
 import testSelector from 'ember-test-selectors';
+import {Response} from 'ember-cli-mirage';
+import {afterEach, beforeEach, describe, it} from 'mocha';
+import {authenticateSession, invalidateSession} from '../helpers/ember-simple-auth';
+import {enableGhostOAuth} from '../helpers/configuration';
+import {expect} from 'chai';
+import {
+    stubFailedOAuthConnect,
+    stubSuccessfulOAuthConnect
+} from '../helpers/oauth';
 
 describe('Acceptance: Setup', function () {
     let application;

--- a/tests/acceptance/signin-test.js
+++ b/tests/acceptance/signin-test.js
@@ -1,20 +1,20 @@
 /* jshint expr:true */
-import {
-    describe,
-    it,
-    beforeEach,
-    afterEach
-} from 'mocha';
 import $ from 'jquery';
-import {expect} from 'chai';
-import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
-import {invalidateSession, authenticateSession} from '../helpers/ember-simple-auth';
-import {enableGhostOAuth} from '../helpers/configuration';
+import startApp from '../helpers/start-app';
 import {Response} from 'ember-cli-mirage';
 import {
-    stubSuccessfulOAuthConnect,
-    stubFailedOAuthConnect
+    afterEach,
+    beforeEach,
+    describe,
+    it
+} from 'mocha';
+import {authenticateSession, invalidateSession} from '../helpers/ember-simple-auth';
+import {enableGhostOAuth} from '../helpers/configuration';
+import {expect} from 'chai';
+import {
+    stubFailedOAuthConnect,
+    stubSuccessfulOAuthConnect
 } from '../helpers/oauth';
 
 describe('Acceptance: Signin', function() {

--- a/tests/acceptance/signup-test.js
+++ b/tests/acceptance/signup-test.js
@@ -1,17 +1,17 @@
 /* jshint expr:true */
-import {
-    describe,
-    it,
-    beforeEach,
-    afterEach
-} from 'mocha';
-import {expect} from 'chai';
-import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
-import {enableGhostOAuth} from '../helpers/configuration';
+import startApp from '../helpers/start-app';
 import {
-    stubSuccessfulOAuthConnect,
-    stubFailedOAuthConnect
+    afterEach,
+    beforeEach,
+    describe,
+    it
+} from 'mocha';
+import {enableGhostOAuth} from '../helpers/configuration';
+import {expect} from 'chai';
+import {
+    stubFailedOAuthConnect,
+    stubSuccessfulOAuthConnect
 } from '../helpers/oauth';
 
 describe('Acceptance: Signup', function() {

--- a/tests/acceptance/subscribers-test.js
+++ b/tests/acceptance/subscribers-test.js
@@ -1,15 +1,10 @@
 /* jshint expr:true */
-import {
-    describe,
-    it,
-    beforeEach,
-    afterEach
-} from 'mocha';
-import {expect} from 'chai';
-import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
-import {invalidateSession, authenticateSession} from 'ghost-admin/tests/helpers/ember-simple-auth';
+import startApp from '../helpers/start-app';
 import testSelector from 'ember-test-selectors';
+import {afterEach, beforeEach, describe, it} from 'mocha';
+import {authenticateSession, invalidateSession} from 'ghost-admin/tests/helpers/ember-simple-auth';
+import {expect} from 'chai';
 
 describe('Acceptance: Subscribers', function() {
     let application;

--- a/tests/acceptance/team-test.js
+++ b/tests/acceptance/team-test.js
@@ -1,20 +1,15 @@
 /* jshint expr:true */
-import {
-  describe,
-  it,
-  beforeEach,
-  afterEach
-} from 'mocha';
-import {expect} from 'chai';
-import startApp from '../helpers/start-app';
-import destroyApp from '../helpers/destroy-app';
-import {invalidateSession, authenticateSession} from '../helpers/ember-simple-auth';
-import {errorOverride, errorReset} from '../helpers/adapter-error';
-import {enableGhostOAuth} from '../helpers/configuration';
-import {Response} from 'ember-cli-mirage';
-import testSelector from 'ember-test-selectors';
-import moment from 'moment';
 import ctrlOrCmd from 'ghost-admin/utils/ctrl-or-cmd';
+import destroyApp from '../helpers/destroy-app';
+import moment from 'moment';
+import startApp from '../helpers/start-app';
+import testSelector from 'ember-test-selectors';
+import {Response} from 'ember-cli-mirage';
+import {afterEach, beforeEach, describe, it} from 'mocha';
+import {authenticateSession, invalidateSession} from '../helpers/ember-simple-auth';
+import {enableGhostOAuth} from '../helpers/configuration';
+import {errorOverride, errorReset} from '../helpers/adapter-error';
+import {expect} from 'chai';
 
 describe('Acceptance: Team', function () {
     let application;

--- a/tests/acceptance/version-mismatch-test.js
+++ b/tests/acceptance/version-mismatch-test.js
@@ -1,16 +1,11 @@
 /* jshint expr:true */
-import {
-    describe,
-    it,
-    beforeEach,
-    afterEach
-} from 'mocha';
-import {expect} from 'chai';
-import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
-import {authenticateSession} from 'ghost-admin/tests/helpers/ember-simple-auth';
-import {versionMismatchResponse} from 'ghost-admin/mirage/utils';
+import startApp from '../helpers/start-app';
 import testSelector from 'ember-test-selectors';
+import {afterEach, beforeEach, describe, it} from 'mocha';
+import {authenticateSession} from 'ghost-admin/tests/helpers/ember-simple-auth';
+import {expect} from 'chai';
+import {versionMismatchResponse} from 'ghost-admin/mirage/utils';
 
 describe('Acceptance: Version Mismatch', function() {
     let application;

--- a/tests/helpers/editor-helpers.js
+++ b/tests/helpers/editor-helpers.js
@@ -1,10 +1,10 @@
-import Ember from 'ember';
 import $ from 'jquery';
+import Ember from 'ember';
 import run from 'ember-runloop';
 import wait from 'ember-test-helpers/wait';
-import {find, findWithAssert, waitUntil} from 'ember-native-dom-helpers';
 import {MOBILEDOC_VERSION} from 'mobiledoc-kit/renderers/mobiledoc';
 import {TESTING_EXPANDO_PROPERTY} from 'gh-koenig/components/gh-koenig';
+import {find, findWithAssert, waitUntil} from 'ember-native-dom-helpers';
 
 export const EMPTY_DOC = {
     version: MOBILEDOC_VERSION,

--- a/tests/helpers/oauth.js
+++ b/tests/helpers/oauth.js
@@ -1,5 +1,5 @@
-import {faker} from 'ember-cli-mirage';
 import RSVP from 'rsvp';
+import {faker} from 'ember-cli-mirage';
 
 let generateCode = function generateCode() {
     return faker.internet.password(32, false, /[a-zA-Z0-9]/);

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,11 +1,10 @@
-import {assign} from 'ember-platform';
-import run from 'ember-runloop';
 import Application from '../../app';
 import config from '../../config/environment';
-import registerPowerSelectHelpers from '../../tests/helpers/ember-power-select';
+import fileUpload from './file-upload'; // eslint-disable-line
 import registerPowerDatepickerHelpers from '../../tests/helpers/ember-power-datepicker';
-// eslint-disable-next-line no-unused-vars
-import fileUpload from './file-upload';
+import registerPowerSelectHelpers from '../../tests/helpers/ember-power-select';
+import run from 'ember-runloop';
+import {assign} from 'ember-platform';
 
 registerPowerSelectHelpers();
 registerPowerDatepickerHelpers();

--- a/tests/integration/adapters/tag-test.js
+++ b/tests/integration/adapters/tag-test.js
@@ -1,8 +1,8 @@
 /* jshint expr:true */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupTest} from 'ember-mocha';
 import Pretender from 'pretender';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupTest} from 'ember-mocha';
 
 describe('Integration: Adapter: tag', function () {
     setupTest('adapter:tag', {

--- a/tests/integration/adapters/user-test.js
+++ b/tests/integration/adapters/user-test.js
@@ -1,8 +1,8 @@
 /* jshint expr:true */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupTest} from 'ember-mocha';
 import Pretender from 'pretender';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupTest} from 'ember-mocha';
 
 describe('Integration: Adapter: user', function () {
     setupTest('adapter:user', {

--- a/tests/integration/components/gh-alert-test.js
+++ b/tests/integration/components/gh-alert-test.js
@@ -1,8 +1,8 @@
 /* jshint expr:true */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 describe('Integration: Component: gh-alert', function () {
     setupComponentTest('gh-alert', {

--- a/tests/integration/components/gh-alerts-test.js
+++ b/tests/integration/components/gh-alerts-test.js
@@ -1,10 +1,10 @@
 /* jshint expr:true */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
-import hbs from 'htmlbars-inline-precompile';
 import Service from 'ember-service';
+import hbs from 'htmlbars-inline-precompile';
+import {describe, it} from 'mocha';
 import {A as emberA} from 'ember-array/utils';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 let notificationsStub = Service.extend({
     alerts: emberA()

--- a/tests/integration/components/gh-basic-dropdown-test.js
+++ b/tests/integration/components/gh-basic-dropdown-test.js
@@ -1,11 +1,11 @@
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
-import hbs from 'htmlbars-inline-precompile';
-import {clickTrigger} from '../../helpers/ember-basic-dropdown';
-import {find} from 'ember-native-dom-helpers';
 import $ from 'jquery';
+import hbs from 'htmlbars-inline-precompile';
 import run from 'ember-runloop';
+import {clickTrigger} from '../../helpers/ember-basic-dropdown';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {find} from 'ember-native-dom-helpers';
+import {setupComponentTest} from 'ember-mocha';
 
 describe('Integration: Component: gh-basic-dropdown', function() {
     setupComponentTest('gh-basic-dropdown', {

--- a/tests/integration/components/gh-cm-editor-test.js
+++ b/tests/integration/components/gh-cm-editor-test.js
@@ -1,11 +1,11 @@
 /* jshint expr:true */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
+import $ from 'jquery';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 import {click, find, triggerEvent} from 'ember-native-dom-helpers';
-import $ from 'jquery';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 // NOTE: If the browser window is not focused/visible CodeMirror (or Chrome?) will
 // take longer to respond to/fire events so it's possible that some of these tests

--- a/tests/integration/components/gh-date-time-picker-test.js
+++ b/tests/integration/components/gh-date-time-picker-test.js
@@ -1,7 +1,7 @@
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 describe('Integration: Component: gh-date-time-picker', function() {
     setupComponentTest('gh-date-time-picker', {

--- a/tests/integration/components/gh-download-count-test.js
+++ b/tests/integration/components/gh-download-count-test.js
@@ -1,9 +1,9 @@
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
-import hbs from 'htmlbars-inline-precompile';
 import Pretender from 'pretender';
+import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 describe('Integration: Component: gh-download-count', function() {
     setupComponentTest('gh-download-count', {

--- a/tests/integration/components/gh-editor-post-status-test.js
+++ b/tests/integration/components/gh-editor-post-status-test.js
@@ -1,7 +1,7 @@
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 describe('Integration: Component: gh-editor-post-status', function() {
     setupComponentTest('gh-editor-post-status', {

--- a/tests/integration/components/gh-feature-flag-test.js
+++ b/tests/integration/components/gh-feature-flag-test.js
@@ -1,8 +1,8 @@
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
-import hbs from 'htmlbars-inline-precompile';
 import Service from 'ember-service';
+import hbs from 'htmlbars-inline-precompile';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 const featureStub = Service.extend({
     testFlag: true

--- a/tests/integration/components/gh-file-uploader-test.js
+++ b/tests/integration/components/gh-file-uploader-test.js
@@ -1,16 +1,16 @@
 /* jshint expr:true */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
-import hbs from 'htmlbars-inline-precompile';
 import $ from 'jquery';
-import run from 'ember-runloop';
 import Pretender from 'pretender';
-import wait from 'ember-test-helpers/wait';
-import sinon from 'sinon';
-import {createFile, fileUpload} from '../../helpers/file-upload';
 import Service from 'ember-service';
+import hbs from 'htmlbars-inline-precompile';
+import run from 'ember-runloop';
+import sinon from 'sinon';
+import wait from 'ember-test-helpers/wait';
 import {UnsupportedMediaTypeError} from 'ghost-admin/services/ajax';
+import {createFile, fileUpload} from '../../helpers/file-upload';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 const notificationsStub = Service.extend({
     showAPIError() {

--- a/tests/integration/components/gh-image-uploader-test.js
+++ b/tests/integration/components/gh-image-uploader-test.js
@@ -1,17 +1,17 @@
 /* jshint expr:true */
-import sinon from 'sinon';
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
-import hbs from 'htmlbars-inline-precompile';
-import Pretender from 'pretender';
-import wait from 'ember-test-helpers/wait';
-import {createFile, fileUpload} from '../../helpers/file-upload';
 import $ from 'jquery';
-import run from 'ember-runloop';
+import Pretender from 'pretender';
 import Service from 'ember-service';
-import {UnsupportedMediaTypeError} from 'ghost-admin/services/ajax';
+import hbs from 'htmlbars-inline-precompile';
+import run from 'ember-runloop';
+import sinon from 'sinon';
 import testSelector from 'ember-test-selectors';
+import wait from 'ember-test-helpers/wait';
+import {UnsupportedMediaTypeError} from 'ghost-admin/services/ajax';
+import {createFile, fileUpload} from '../../helpers/file-upload';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 const notificationsStub = Service.extend({
     showAPIError(/* error, options */) {

--- a/tests/integration/components/gh-image-uploader-with-preview-test.js
+++ b/tests/integration/components/gh-image-uploader-with-preview-test.js
@@ -1,10 +1,10 @@
 /* jshint expr:true */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
 import run from 'ember-runloop';
 import sinon from 'sinon';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 describe('Integration: Component: gh-image-uploader-with-preview', function() {
     setupComponentTest('gh-image-uploader-with-preview', {

--- a/tests/integration/components/gh-markdown-editor-test.js
+++ b/tests/integration/components/gh-markdown-editor-test.js
@@ -1,7 +1,7 @@
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 describe('Integration: Component: gh-markdown-editor', function() {
     setupComponentTest('gh-markdown-editor', {

--- a/tests/integration/components/gh-navigation-test.js
+++ b/tests/integration/components/gh-navigation-test.js
@@ -1,12 +1,12 @@
 /* jshint expr:true */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
-import hbs from 'htmlbars-inline-precompile';
 import $ from 'jquery';
-import run from 'ember-runloop';
 import NavItem from 'ghost-admin/models/navigation-item';
+import hbs from 'htmlbars-inline-precompile';
+import run from 'ember-runloop';
 import wait from 'ember-test-helpers/wait';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 describe('Integration: Component: gh-navigation', function () {
     setupComponentTest('gh-navigation', {

--- a/tests/integration/components/gh-navitem-test.js
+++ b/tests/integration/components/gh-navitem-test.js
@@ -1,10 +1,10 @@
 /* jshint expr:true */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
-import hbs from 'htmlbars-inline-precompile';
 import NavItem from 'ghost-admin/models/navigation-item';
+import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 describe('Integration: Component: gh-navitem', function () {
     setupComponentTest('gh-navitem', {

--- a/tests/integration/components/gh-navitem-url-input-test.js
+++ b/tests/integration/components/gh-navitem-url-input-test.js
@@ -1,9 +1,9 @@
 /* jshint scripturl:true */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
-import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 const {$, run} = Ember;
 

--- a/tests/integration/components/gh-notification-test.js
+++ b/tests/integration/components/gh-notification-test.js
@@ -1,8 +1,8 @@
 /* jshint expr:true */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 describe('Integration: Component: gh-notification', function () {
     setupComponentTest('gh-notification', {

--- a/tests/integration/components/gh-notifications-test.js
+++ b/tests/integration/components/gh-notifications-test.js
@@ -1,10 +1,10 @@
 /* jshint expr:true */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
-import hbs from 'htmlbars-inline-precompile';
 import Service from 'ember-service';
+import hbs from 'htmlbars-inline-precompile';
+import {describe, it} from 'mocha';
 import {A as emberA} from 'ember-array/utils';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 let notificationsStub = Service.extend({
     notifications: emberA()

--- a/tests/integration/components/gh-profile-image-test.js
+++ b/tests/integration/components/gh-profile-image-test.js
@@ -1,13 +1,13 @@
 /* jshint expr:true */
 /* global md5 */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
-import hbs from 'htmlbars-inline-precompile';
-import Service from 'ember-service';
-import run from 'ember-runloop';
 import Pretender from 'pretender';
+import Service from 'ember-service';
+import hbs from 'htmlbars-inline-precompile';
+import run from 'ember-runloop';
 import wait from 'ember-test-helpers/wait';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 let pathsStub = Service.extend({
     url: {

--- a/tests/integration/components/gh-progress-bar-test.js
+++ b/tests/integration/components/gh-progress-bar-test.js
@@ -1,7 +1,7 @@
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 describe('Integration: Component: gh-progress-bar', function() {
     setupComponentTest('gh-progress-bar', {

--- a/tests/integration/components/gh-publishmenu-draft-test.js
+++ b/tests/integration/components/gh-publishmenu-draft-test.js
@@ -1,7 +1,7 @@
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 describe('Integration: Component: gh-publishmenu-draft', function() {
     setupComponentTest('gh-publishmenu-draft', {

--- a/tests/integration/components/gh-publishmenu-published-test.js
+++ b/tests/integration/components/gh-publishmenu-published-test.js
@@ -1,7 +1,7 @@
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 describe('Integration: Component: gh-publishmenu-published', function() {
     setupComponentTest('gh-publishmenu-published', {

--- a/tests/integration/components/gh-publishmenu-scheduled-test.js
+++ b/tests/integration/components/gh-publishmenu-scheduled-test.js
@@ -1,7 +1,7 @@
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 describe('Integration: Component: gh-publishmenu-scheduled', function() {
     setupComponentTest('gh-publishmenu-scheduled', {

--- a/tests/integration/components/gh-publishmenu-test.js
+++ b/tests/integration/components/gh-publishmenu-test.js
@@ -1,7 +1,7 @@
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 import {startMirage} from 'ghost-admin/initializers/ember-cli-mirage';
 
 describe('Integration: Component: gh-publishmenu', function() {

--- a/tests/integration/components/gh-search-input-test.js
+++ b/tests/integration/components/gh-search-input-test.js
@@ -1,11 +1,11 @@
 /* jshint expr:true */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
+import Pretender from 'pretender';
 import hbs from 'htmlbars-inline-precompile';
 import run from 'ember-runloop';
-import Pretender from 'pretender';
 import wait from 'ember-test-helpers/wait';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 describe('Integration: Component: gh-search-input', function () {
     setupComponentTest('gh-search-input', {

--- a/tests/integration/components/gh-simplemde-test.js
+++ b/tests/integration/components/gh-simplemde-test.js
@@ -1,7 +1,7 @@
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 describe('Integration: Component: gh-simplemde', function() {
     setupComponentTest('gh-simplemde', {

--- a/tests/integration/components/gh-subscribers-table-test.js
+++ b/tests/integration/components/gh-subscribers-table-test.js
@@ -1,9 +1,9 @@
 /* jshint expr:true */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
-import hbs from 'htmlbars-inline-precompile';
 import Table from 'ember-light-table';
+import hbs from 'htmlbars-inline-precompile';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 describe('Integration: Component: gh-subscribers-table', function() {
     setupComponentTest('gh-subscribers-table', {

--- a/tests/integration/components/gh-tag-settings-form-test.js
+++ b/tests/integration/components/gh-tag-settings-form-test.js
@@ -1,13 +1,13 @@
 /* jshint expr:true */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
-import hbs from 'htmlbars-inline-precompile';
-import Service from 'ember-service';
-import EmberObject from 'ember-object';
-import run from 'ember-runloop';
 import DS from 'ember-data';
+import EmberObject from 'ember-object';
+import Service from 'ember-service';
+import hbs from 'htmlbars-inline-precompile';
+import run from 'ember-runloop';
 import wait from 'ember-test-helpers/wait';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 const {Errors} = DS;
 

--- a/tests/integration/components/gh-tags-management-container-test.js
+++ b/tests/integration/components/gh-tags-management-container-test.js
@@ -1,8 +1,8 @@
 /* jshint expr:true */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 describe('Integration: Component: gh-tags-management-container', function () {
     setupComponentTest('gh-tags-management-container', {

--- a/tests/integration/components/gh-task-button-test.js
+++ b/tests/integration/components/gh-task-button-test.js
@@ -1,11 +1,11 @@
 /* jshint expr:true */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
-import {task, timeout} from 'ember-concurrency';
 import run from 'ember-runloop';
 import wait from 'ember-test-helpers/wait';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
+import {task, timeout} from 'ember-concurrency';
 
 describe('Integration: Component: gh-task-button', function() {
     setupComponentTest('gh-task-button', {

--- a/tests/integration/components/gh-theme-table-test.js
+++ b/tests/integration/components/gh-theme-table-test.js
@@ -1,12 +1,12 @@
 /* jshint expr:true */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
-import hbs from 'htmlbars-inline-precompile';
 import $ from 'jquery';
-import sinon from 'sinon';
+import hbs from 'htmlbars-inline-precompile';
 import run from 'ember-runloop';
+import sinon from 'sinon';
 import testSelector from 'ember-test-selectors';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 describe('Integration: Component: gh-theme-table', function() {
     setupComponentTest('gh-theme-table', {

--- a/tests/integration/components/gh-timezone-select-test.js
+++ b/tests/integration/components/gh-timezone-select-test.js
@@ -1,11 +1,11 @@
 /* jshint expr:true */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
 import run from 'ember-runloop';
-import wait from 'ember-test-helpers/wait';
 import sinon from 'sinon';
+import wait from 'ember-test-helpers/wait';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 describe('Integration: Component: gh-timezone-select', function() {
     setupComponentTest('gh-timezone-select', {

--- a/tests/integration/components/gh-trim-focus-input-test.js
+++ b/tests/integration/components/gh-trim-focus-input-test.js
@@ -1,8 +1,8 @@
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
-import run from 'ember-runloop';
 import hbs from 'htmlbars-inline-precompile';
+import run from 'ember-runloop';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 describe('Integration: Component: gh-trim-focus-input', function () {
     setupComponentTest('gh-trim-focus-input', {

--- a/tests/integration/components/gh-uploader-test.js
+++ b/tests/integration/components/gh-uploader-test.js
@@ -1,14 +1,14 @@
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
-import hbs from 'htmlbars-inline-precompile';
-import {createFile} from '../../helpers/file-upload';
 import Pretender from 'pretender';
-import sinon from 'sinon';
-import wait from 'ember-test-helpers/wait';
+import hbs from 'htmlbars-inline-precompile';
 import run from 'ember-runloop';
-import {click, find, findAll} from 'ember-native-dom-helpers';
+import sinon from 'sinon';
 import testSelector from 'ember-test-selectors';
+import wait from 'ember-test-helpers/wait';
+import {click, find, findAll} from 'ember-native-dom-helpers';
+import {createFile} from '../../helpers/file-upload';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 const stubSuccessfulUpload = function (server, delay = 0) {
     server.post('/ghost/api/v0.1/uploads/', function () {

--- a/tests/integration/components/gh-validation-status-container-test.js
+++ b/tests/integration/components/gh-validation-status-container-test.js
@@ -1,11 +1,11 @@
 /* jshint expr:true */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
-import hbs from 'htmlbars-inline-precompile';
-import EmberObject from 'ember-object';
 import DS from 'ember-data';
+import EmberObject from 'ember-object';
+import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 const {Errors} = DS;
 

--- a/tests/integration/components/modals/delete-subscriber-test.js
+++ b/tests/integration/components/modals/delete-subscriber-test.js
@@ -1,8 +1,8 @@
 /* jshint expr:true */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 describe('Integration: Component: modals/delete-subscriber', function() {
     setupComponentTest('modals/delete-subscriber', {

--- a/tests/integration/components/modals/import-subscribers-test.js
+++ b/tests/integration/components/modals/import-subscribers-test.js
@@ -1,8 +1,8 @@
 /* jshint expr:true */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 describe('Integration: Component: modals/import-subscribers', function() {
     setupComponentTest('modals/import-subscribers', {

--- a/tests/integration/components/modals/new-subscriber-test.js
+++ b/tests/integration/components/modals/new-subscriber-test.js
@@ -1,8 +1,8 @@
 /* jshint expr:true */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 describe('Integration: Component: modals/new-subscriber', function() {
     setupComponentTest('modals/new-subscriber', {

--- a/tests/integration/components/modals/upload-theme-test.js
+++ b/tests/integration/components/modals/upload-theme-test.js
@@ -1,8 +1,8 @@
 /* jshint expr:true */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 describe('Integration: Component: modals/upload-theme', function() {
     setupComponentTest('modals/upload-theme', {

--- a/tests/integration/components/transfer-owner-test.js
+++ b/tests/integration/components/transfer-owner-test.js
@@ -1,11 +1,11 @@
 /* jshint expr:true */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
+import RSVP from 'rsvp';
 import hbs from 'htmlbars-inline-precompile';
 import run from 'ember-runloop';
-import RSVP from 'rsvp';
 import sinon from 'sinon';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 describe('Integration: Component: modals/transfer-owner', function() {
     setupComponentTest('transfer-owner', {

--- a/tests/integration/services/ajax-test.js
+++ b/tests/integration/services/ajax-test.js
@@ -1,19 +1,19 @@
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupTest} from 'ember-mocha';
 import Pretender from 'pretender';
+import RSVP from 'rsvp';
+import Service from 'ember-service';
+import config from 'ghost-admin/config/environment';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
 import {
     isAjaxError,
     isUnauthorizedError
 } from 'ember-ajax/errors';
 import {
-    isVersionMismatchError,
     isRequestEntityTooLargeError,
-    isUnsupportedMediaTypeError
+    isUnsupportedMediaTypeError,
+    isVersionMismatchError
 } from 'ghost-admin/services/ajax';
-import config from 'ghost-admin/config/environment';
-import Service from 'ember-service';
-import RSVP from 'rsvp';
+import {setupTest} from 'ember-mocha';
 
 function stubAjaxEndpoint(server, response = {}, code = 200) {
     server.get('/test/', function () {

--- a/tests/integration/services/config-test.js
+++ b/tests/integration/services/config-test.js
@@ -1,8 +1,8 @@
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupTest} from 'ember-mocha';
 import Pretender from 'pretender';
 import wait from 'ember-test-helpers/wait';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupTest} from 'ember-mocha';
 
 function stubAvailableTimezonesEndpoint(server) {
     server.get('/ghost/api/v0.1/configuration/timezones', function () {

--- a/tests/integration/services/feature-test.js
+++ b/tests/integration/services/feature-test.js
@@ -1,10 +1,10 @@
+import Ember from 'ember';
+import FeatureService, {feature} from 'ghost-admin/services/feature';
+import Pretender from 'pretender';
+import run from 'ember-runloop';
+import wait from 'ember-test-helpers/wait';
 import {describe, it} from 'mocha';
 import {setupTest} from 'ember-mocha';
-import Pretender from 'pretender';
-import wait from 'ember-test-helpers/wait';
-import FeatureService, {feature} from 'ghost-admin/services/feature';
-import Ember from 'ember';
-import run from 'ember-runloop';
 
 const {Error: EmberError} = Ember;
 

--- a/tests/integration/services/lazy-loader-test.js
+++ b/tests/integration/services/lazy-loader-test.js
@@ -1,9 +1,9 @@
 /* jshint expr:true */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupTest} from 'ember-mocha';
-import Pretender from 'pretender';
 import $ from 'jquery';
+import Pretender from 'pretender';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupTest} from 'ember-mocha';
 
 describe('Integration: Service: lazy-loader', function() {
     setupTest('service:lazy-loader', {integration: true});

--- a/tests/integration/services/slug-generator-test.js
+++ b/tests/integration/services/slug-generator-test.js
@@ -1,8 +1,8 @@
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupTest} from 'ember-mocha';
 import Pretender from 'pretender';
 import {dasherize} from 'ember-string';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupTest} from 'ember-mocha';
 
 function stubSlugEndpoint(server, type, slug) {
     server.get('/ghost/api/v0.1/slugs/:type/:slug/', function (request) {

--- a/tests/integration/services/store-test.js
+++ b/tests/integration/services/store-test.js
@@ -1,8 +1,8 @@
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupTest} from 'ember-mocha';
 import Pretender from 'pretender';
 import config from 'ghost-admin/config/environment';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupTest} from 'ember-mocha';
 
 describe('Integration: Service: store', function () {
     setupTest('service:store', {

--- a/tests/unit/components/gh-alert-test.js
+++ b/tests/unit/components/gh-alert-test.js
@@ -1,8 +1,8 @@
 /* jshint expr:true */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
 import sinon from 'sinon';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 describe('Unit: Component: gh-alert', function () {
     setupComponentTest('gh-alert', {

--- a/tests/unit/components/gh-app-test.js
+++ b/tests/unit/components/gh-app-test.js
@@ -1,6 +1,6 @@
 /* jshint expr:true */
-import {expect} from 'chai';
 import {describe, it} from 'mocha';
+import {expect} from 'chai';
 import {setupComponentTest} from 'ember-mocha';
 
 describe('Unit: Component: gh-app', function () {

--- a/tests/unit/components/gh-infinite-scroll-test.js
+++ b/tests/unit/components/gh-infinite-scroll-test.js
@@ -1,6 +1,6 @@
 /* jshint expr:true */
-import {expect} from 'chai';
 import {describe, it} from 'mocha';
+import {expect} from 'chai';
 import {setupComponentTest} from 'ember-mocha';
 
 describe('Unit: Component: gh-infinite-scroll', function () {

--- a/tests/unit/components/gh-navitem-url-input-test.js
+++ b/tests/unit/components/gh-navitem-url-input-test.js
@@ -1,7 +1,7 @@
 /* jshint expr:true */
 import run from 'ember-runloop';
-import {expect} from 'chai';
 import {describe, it} from 'mocha';
+import {expect} from 'chai';
 import {setupComponentTest} from 'ember-mocha';
 
 describe('Unit: Component: gh-navitem-url-input', function () {

--- a/tests/unit/components/gh-notification-test.js
+++ b/tests/unit/components/gh-notification-test.js
@@ -1,8 +1,8 @@
 /* jshint expr:true */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
 import sinon from 'sinon';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 describe('Unit: Component: gh-notification', function () {
     setupComponentTest('gh-notification', {

--- a/tests/unit/components/gh-post-settings-menu-test.js
+++ b/tests/unit/components/gh-post-settings-menu-test.js
@@ -1,11 +1,11 @@
 /* eslint-disable camelcase */
-import run from 'ember-runloop';
-import RSVP from 'rsvp';
 import EmberObject from 'ember-object';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
-
+import RSVP from 'rsvp';
 import boundOneWay from 'ghost-admin/utils/bound-one-way';
+import run from 'ember-runloop';
+import {describe, it} from 'mocha';
+
+import {setupComponentTest} from 'ember-mocha';
 
 function K() {
     return this;

--- a/tests/unit/components/gh-selectize-test.js
+++ b/tests/unit/components/gh-selectize-test.js
@@ -1,9 +1,9 @@
 /* jshint expr:true */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupComponentTest} from 'ember-mocha';
-import {A as emberA} from 'ember-array/utils';
 import run from 'ember-runloop';
+import {describe, it} from 'mocha';
+import {A as emberA} from 'ember-array/utils';
+import {expect} from 'chai';
+import {setupComponentTest} from 'ember-mocha';
 
 describe('Unit: Component: gh-selectize', function () {
     setupComponentTest('gh-selectize', {

--- a/tests/unit/components/gh-upgrade-notification-test.js
+++ b/tests/unit/components/gh-upgrade-notification-test.js
@@ -1,6 +1,6 @@
 /* jshint expr:true */
-import {expect} from 'chai';
 import {describe, it} from 'mocha';
+import {expect} from 'chai';
 import {setupComponentTest} from 'ember-mocha';
 
 describe('Unit: Component: gh-upgrade-notification', function() {

--- a/tests/unit/components/gh-user-active-test.js
+++ b/tests/unit/components/gh-user-active-test.js
@@ -1,6 +1,6 @@
 /* jshint expr:true */
-import {expect} from 'chai';
 import {describe, it} from 'mocha';
+import {expect} from 'chai';
 import {setupComponentTest} from 'ember-mocha';
 
 describe('Unit: Component: gh-user-active', function () {

--- a/tests/unit/components/gh-user-invited-test.js
+++ b/tests/unit/components/gh-user-invited-test.js
@@ -1,6 +1,6 @@
 /* jshint expr:true */
-import {expect} from 'chai';
 import {describe, it} from 'mocha';
+import {expect} from 'chai';
 import {setupComponentTest} from 'ember-mocha';
 
 describe('Unit: Component: gh-user-invited', function () {

--- a/tests/unit/controllers/settings/design-test.js
+++ b/tests/unit/controllers/settings/design-test.js
@@ -1,9 +1,9 @@
 /* jshint expr:true */
-import {expect, assert} from 'chai';
-import {describe, it} from 'mocha';
-import {setupTest} from 'ember-mocha';
 import Ember from 'ember';
 import NavItem from 'ghost-admin/models/navigation-item';
+import {assert, expect} from 'chai';
+import {describe, it} from 'mocha';
+import {setupTest} from 'ember-mocha';
 
 const {
     run,

--- a/tests/unit/controllers/subscribers-test.js
+++ b/tests/unit/controllers/subscribers-test.js
@@ -1,6 +1,6 @@
 /* jshint expr:true */
-import {expect} from 'chai';
 import {describe, it} from 'mocha';
+import {expect} from 'chai';
 import {setupTest} from 'ember-mocha';
 
 describe('Unit: Controller: subscribers', function() {

--- a/tests/unit/helpers/gh-count-characters-test.js
+++ b/tests/unit/helpers/gh-count-characters-test.js
@@ -1,6 +1,6 @@
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
 import {countCharacters} from 'ghost-admin/helpers/gh-count-characters';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
 
 describe('Unit: Helper: gh-count-characters', function() {
     let defaultStyle = 'color: rgb(115, 138, 148);';

--- a/tests/unit/helpers/gh-count-down-characters-test.js
+++ b/tests/unit/helpers/gh-count-down-characters-test.js
@@ -1,6 +1,6 @@
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
 import {countDownCharacters} from 'ghost-admin/helpers/gh-count-down-characters';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
 
 describe('Unit: Helper: gh-count-down-characters', function() {
     let validStyle = 'color: rgb(159, 187, 88);';

--- a/tests/unit/helpers/gh-format-timeago-test.js
+++ b/tests/unit/helpers/gh-format-timeago-test.js
@@ -1,14 +1,14 @@
 /* jshint expr:true */
-import {expect} from 'chai';
+import moment from 'moment';
+import sinon from 'sinon';
 import {
     describe,
     it
 } from 'mocha';
+import {expect} from 'chai';
 import {
     timeAgo
 } from 'ghost-admin/helpers/gh-format-timeago';
-import sinon from 'sinon';
-import moment from 'moment';
 
 describe('Unit: Helper: gh-format-timeago', function () {
     // eslint-disable-next-line no-unused-vars

--- a/tests/unit/helpers/gh-user-can-admin-test.js
+++ b/tests/unit/helpers/gh-user-can-admin-test.js
@@ -1,5 +1,5 @@
-import {it} from 'mocha';
 import {ghUserCanAdmin} from 'ghost-admin/helpers/gh-user-can-admin';
+import {it} from 'mocha';
 
 describe('Unit: Helper: gh-user-can-admin', function () {
     // Mock up roles and test for truthy

--- a/tests/unit/helpers/highlighted-text-test.js
+++ b/tests/unit/helpers/highlighted-text-test.js
@@ -1,9 +1,9 @@
 /* jshint expr:true */
-import {expect} from 'chai';
 import {
   describe,
   it
 } from 'mocha';
+import {expect} from 'chai';
 import {
   highlightedText
 } from 'ghost-admin/helpers/highlighted-text';

--- a/tests/unit/helpers/is-equal-test.js
+++ b/tests/unit/helpers/is-equal-test.js
@@ -1,9 +1,9 @@
 /* jshint expr:true */
-import {expect} from 'chai';
 import {
     describe,
     it
 } from 'mocha';
+import {expect} from 'chai';
 import {
     isEqual
 } from 'ghost-admin/helpers/is-equal';

--- a/tests/unit/helpers/is-not-test.js
+++ b/tests/unit/helpers/is-not-test.js
@@ -1,9 +1,9 @@
 /* jshint expr:true */
-import {expect} from 'chai';
 import {
     describe,
     it
 } from 'mocha';
+import {expect} from 'chai';
 import {
     isNot
 } from 'ghost-admin/helpers/is-not';

--- a/tests/unit/mixins/editor-base-controller-test.js
+++ b/tests/unit/mixins/editor-base-controller-test.js
@@ -1,15 +1,15 @@
 /* jshint expr:true */
-import {expect} from 'chai';
+import EditorBaseControllerMixin from 'ghost-admin/mixins/editor-base-controller';
+import EmberObject from 'ember-object';
+import RSVP from 'rsvp';
+import run from 'ember-runloop';
+import wait from 'ember-test-helpers/wait';
 import {
     describe,
     it
 } from 'mocha';
-import EmberObject from 'ember-object';
-import RSVP from 'rsvp';
-import run from 'ember-runloop';
+import {expect} from 'chai';
 import {task} from 'ember-concurrency';
-import EditorBaseControllerMixin from 'ghost-admin/mixins/editor-base-controller';
-import wait from 'ember-test-helpers/wait';
 
 describe('Unit: Mixin: editor-base-controller', function() {
     describe('generateSlug', function () {

--- a/tests/unit/mixins/infinite-scroll-test.js
+++ b/tests/unit/mixins/infinite-scroll-test.js
@@ -1,11 +1,11 @@
 /* jshint expr:true */
-import {expect} from 'chai';
+import EmberObject from 'ember-object';
+import InfiniteScrollMixin from 'ghost-admin/mixins/infinite-scroll';
 import {
     describe,
     it
 } from 'mocha';
-import EmberObject from 'ember-object';
-import InfiniteScrollMixin from 'ghost-admin/mixins/infinite-scroll';
+import {expect} from 'chai';
 
 describe('Unit: Mixin: infinite-scroll', function () {
     // Replace this with your real tests.

--- a/tests/unit/models/invite-test.js
+++ b/tests/unit/models/invite-test.js
@@ -1,8 +1,8 @@
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupModelTest} from 'ember-mocha';
-import run from 'ember-runloop';
 import Pretender from 'pretender';
+import run from 'ember-runloop';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupModelTest} from 'ember-mocha';
 
 describe('Unit: Model: invite', function() {
     setupModelTest('invite', {

--- a/tests/unit/models/navigation-item-test.js
+++ b/tests/unit/models/navigation-item-test.js
@@ -1,6 +1,6 @@
 /* jshint expr:true */
-import {expect} from 'chai';
 import {describe, it} from 'mocha';
+import {expect} from 'chai';
 import {setupTest} from 'ember-mocha';
 
 describe('Unit: Model: navigation-item', function() {

--- a/tests/unit/models/post-test.js
+++ b/tests/unit/models/post-test.js
@@ -1,5 +1,5 @@
-import run from 'ember-runloop';
 import EmberObject from 'ember-object';
+import run from 'ember-runloop';
 import {describe, it} from 'mocha';
 import {setupModelTest} from 'ember-mocha';
 

--- a/tests/unit/models/subscriber-test.js
+++ b/tests/unit/models/subscriber-test.js
@@ -1,6 +1,6 @@
 /* jshint expr:true */
-import {expect} from 'chai';
 import {describe, it} from 'mocha';
+import {expect} from 'chai';
 import {setupModelTest} from 'ember-mocha';
 
 describe('Unit: Model: subscriber', function() {

--- a/tests/unit/routes/subscribers-test.js
+++ b/tests/unit/routes/subscribers-test.js
@@ -1,6 +1,6 @@
 /* jshint expr:true */
-import {expect} from 'chai';
 import {describe, it} from 'mocha';
+import {expect} from 'chai';
 import {setupTest} from 'ember-mocha';
 
 describe('Unit: Route: subscribers', function() {

--- a/tests/unit/routes/subscribers/import-test.js
+++ b/tests/unit/routes/subscribers/import-test.js
@@ -1,6 +1,6 @@
 /* jshint expr:true */
-import {expect} from 'chai';
 import {describe, it} from 'mocha';
+import {expect} from 'chai';
 import {setupTest} from 'ember-mocha';
 
 describe('Unit: Route: subscribers/import', function() {

--- a/tests/unit/routes/subscribers/new-test.js
+++ b/tests/unit/routes/subscribers/new-test.js
@@ -1,6 +1,6 @@
 /* jshint expr:true */
-import {expect} from 'chai';
 import {describe, it} from 'mocha';
+import {expect} from 'chai';
 import {setupTest} from 'ember-mocha';
 
 describe('Unit: Route: subscribers/new', function() {

--- a/tests/unit/serializers/notification-test.js
+++ b/tests/unit/serializers/notification-test.js
@@ -1,7 +1,7 @@
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupModelTest} from 'ember-mocha';
 import Pretender from 'pretender';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupModelTest} from 'ember-mocha';
 
 describe('Unit: Serializer: notification', function () {
     setupModelTest('notification', {

--- a/tests/unit/serializers/post-test.js
+++ b/tests/unit/serializers/post-test.js
@@ -1,6 +1,6 @@
 /* jshint expr:true */
-import {expect} from 'chai';
 import {describe, it} from 'mocha';
+import {expect} from 'chai';
 import {setupModelTest} from 'ember-mocha';
 
 describe('Unit: Serializer: post', function() {

--- a/tests/unit/serializers/role-test.js
+++ b/tests/unit/serializers/role-test.js
@@ -1,6 +1,6 @@
 /* jshint expr:true */
-import {expect} from 'chai';
 import {describe, it} from 'mocha';
+import {expect} from 'chai';
 import {setupModelTest} from 'ember-mocha';
 
 describe('Unit:Serializer: role', function() {

--- a/tests/unit/serializers/setting-test.js
+++ b/tests/unit/serializers/setting-test.js
@@ -1,6 +1,6 @@
 /* jshint expr:true */
-import {expect} from 'chai';
 import {describe, it} from 'mocha';
+import {expect} from 'chai';
 import {setupModelTest} from 'ember-mocha';
 
 describe('Unit:Serializer: setting', function() {

--- a/tests/unit/serializers/subscriber-test.js
+++ b/tests/unit/serializers/subscriber-test.js
@@ -1,6 +1,6 @@
 /* jshint expr:true */
-import {expect} from 'chai';
 import {describe, it} from 'mocha';
+import {expect} from 'chai';
 import {setupModelTest} from 'ember-mocha';
 
 describe('Unit:Serializer: subscriber', function() {

--- a/tests/unit/serializers/tag-test.js
+++ b/tests/unit/serializers/tag-test.js
@@ -1,6 +1,6 @@
 /* jshint expr:true */
-import {expect} from 'chai';
 import {describe, it} from 'mocha';
+import {expect} from 'chai';
 import {setupModelTest} from 'ember-mocha';
 
 describe('Unit: Serializer: tag', function() {

--- a/tests/unit/serializers/user-test.js
+++ b/tests/unit/serializers/user-test.js
@@ -1,6 +1,6 @@
 /* jshint expr:true */
-import {expect} from 'chai';
 import {describe, it} from 'mocha';
+import {expect} from 'chai';
 import {setupModelTest} from 'ember-mocha';
 
 describe('Unit: Serializer: user', function() {

--- a/tests/unit/services/config-test.js
+++ b/tests/unit/services/config-test.js
@@ -1,6 +1,6 @@
 /* jshint expr:true */
-import {expect} from 'chai';
 import {describe, it} from 'mocha';
+import {expect} from 'chai';
 import {setupTest} from 'ember-mocha';
 
 describe('Unit: Service: config', function () {

--- a/tests/unit/services/event-bus-test.js
+++ b/tests/unit/services/event-bus-test.js
@@ -1,8 +1,8 @@
 /* jshint expr:true */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupTest} from 'ember-mocha';
 import sinon from 'sinon';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupTest} from 'ember-mocha';
 
 describe('Unit: Service: event-bus', function() {
     setupTest('service:event-bus', {});

--- a/tests/unit/services/notifications-test.js
+++ b/tests/unit/services/notifications-test.js
@@ -1,14 +1,14 @@
 /* jshint expr:true */
-import run from 'ember-runloop';
-import get from 'ember-metal/get';
-import {A as emberA} from 'ember-array/utils';
 import EmberObject from 'ember-object';
+import get from 'ember-metal/get';
+import run from 'ember-runloop';
 import sinon from 'sinon';
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupTest} from 'ember-mocha';
 import {AjaxError, InvalidError} from 'ember-ajax/errors';
 import {ServerUnreachableError} from 'ghost-admin/services/ajax';
+import {describe, it} from 'mocha';
+import {A as emberA} from 'ember-array/utils';
+import {expect} from 'chai';
+import {setupTest} from 'ember-mocha';
 
 describe('Unit: Service: notifications', function () {
     setupTest('service:notifications', {

--- a/tests/unit/services/upgrade-status-test.js
+++ b/tests/unit/services/upgrade-status-test.js
@@ -1,6 +1,6 @@
 /* jshint expr:true */
-import {expect} from 'chai';
 import {describe, it} from 'mocha';
+import {expect} from 'chai';
 import {setupTest} from 'ember-mocha';
 
 describe('Unit: Service: upgrade-status', function() {

--- a/tests/unit/transforms/facebook-url-user-test.js
+++ b/tests/unit/transforms/facebook-url-user-test.js
@@ -1,6 +1,6 @@
 /* jshint expr:true */
-import {expect} from 'chai';
 import {describe, it} from 'mocha';
+import {expect} from 'chai';
 import {setupTest} from 'ember-mocha';
 
 describe('Unit: Transform: facebook-url-user', function() {

--- a/tests/unit/transforms/json-string-test.js
+++ b/tests/unit/transforms/json-string-test.js
@@ -1,5 +1,5 @@
-import {expect} from 'chai';
 import {describe, it} from 'mocha';
+import {expect} from 'chai';
 import {setupTest} from 'ember-mocha';
 
 describe('Unit: Transform: json-string', function() {

--- a/tests/unit/transforms/navigation-settings-test.js
+++ b/tests/unit/transforms/navigation-settings-test.js
@@ -1,9 +1,9 @@
 /* jshint expr:true */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupTest} from 'ember-mocha';
-import {A as emberA} from 'ember-array/utils';
 import NavigationItem from 'ghost-admin/models/navigation-item';
+import {describe, it} from 'mocha';
+import {A as emberA} from 'ember-array/utils';
+import {expect} from 'chai';
+import {setupTest} from 'ember-mocha';
 
 describe('Unit: Transform: navigation-settings', function() {
     setupTest('transform:navigation-settings', {});

--- a/tests/unit/transforms/slack-settings-test.js
+++ b/tests/unit/transforms/slack-settings-test.js
@@ -1,9 +1,9 @@
 /* jshint expr:true */
-import {expect} from 'chai';
-import {describe, it} from 'mocha';
-import {setupTest} from 'ember-mocha';
-import {A as emberA} from 'ember-array/utils';
 import SlackIntegration from 'ghost-admin/models/slack-integration';
+import {describe, it} from 'mocha';
+import {A as emberA} from 'ember-array/utils';
+import {expect} from 'chai';
+import {setupTest} from 'ember-mocha';
 
 describe('Unit: Transform: slack-settings', function() {
     setupTest('transform:slack-settings', {});

--- a/tests/unit/transforms/twitter-url-user-test.js
+++ b/tests/unit/transforms/twitter-url-user-test.js
@@ -1,6 +1,6 @@
 /* jshint expr:true */
-import {expect} from 'chai';
 import {describe, it} from 'mocha';
+import {expect} from 'chai';
 import {setupTest} from 'ember-mocha';
 
 describe('Unit: Transform: twitter-url-user', function() {

--- a/tests/unit/validators/nav-item-test.js
+++ b/tests/unit/validators/nav-item-test.js
@@ -1,11 +1,11 @@
 /* jshint expr:true */
-import {expect} from 'chai';
+import NavItem from 'ghost-admin/models/navigation-item';
+import validator from 'ghost-admin/validators/nav-item';
 import {
     describe,
     it
 } from 'mocha';
-import validator from 'ghost-admin/validators/nav-item';
-import NavItem from 'ghost-admin/models/navigation-item';
+import {expect} from 'chai';
 
 const testInvalidUrl = function (url) {
     let navItem = NavItem.create({url});

--- a/tests/unit/validators/slack-integration-test.js
+++ b/tests/unit/validators/slack-integration-test.js
@@ -1,11 +1,11 @@
 /* jshint expr:true */
-import {expect} from 'chai';
+import SlackObject from 'ghost-admin/models/slack-integration';
+import validator from 'ghost-admin/validators/slack-integration';
 import {
     describe,
     it
 } from 'mocha';
-import validator from 'ghost-admin/validators/slack-integration';
-import SlackObject from 'ghost-admin/models/slack-integration';
+import {expect} from 'chai';
 
 const testInvalidUrl = function (url) {
     let slackObject = SlackObject.create({url});

--- a/tests/unit/validators/subscriber-test.js
+++ b/tests/unit/validators/subscriber-test.js
@@ -1,11 +1,11 @@
 /* jshint expr:true */
-import {expect} from 'chai';
+import Ember from 'ember';
+import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 import {
     describe,
     it
 } from 'mocha';
-import Ember from 'ember';
-import ValidationEngine from 'ghost-admin/mixins/validation-engine';
+import {expect} from 'chai';
 
 const {
     run,

--- a/tests/unit/validators/tag-settings-test.js
+++ b/tests/unit/validators/tag-settings-test.js
@@ -1,13 +1,13 @@
 /* jshint expr:true */
-import {expect} from 'chai';
+import EmberObject from 'ember-object';
+import ValidationEngine from 'ghost-admin/mixins/validation-engine';
+import run from 'ember-runloop';
 import {
     describe,
     it
 } from 'mocha';
-import run from 'ember-runloop';
-import EmberObject from 'ember-object';
 // import validator from 'ghost-admin/validators/tag-settings';
-import ValidationEngine from 'ghost-admin/mixins/validation-engine';
+import {expect} from 'chai';
 
 const Tag = EmberObject.extend(ValidationEngine, {
     validationType: 'tag',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3831,7 +3831,13 @@ eslint-plugin-ember-suave@1.0.0:
   dependencies:
     requireindex "~1.1.0"
 
-eslint@^3.0.0:
+"eslint-plugin-sort-imports-es6-autofix@https://github.com/kevinansfield/eslint-plugin-sort-imports-es6-autofix.git#node-4-compat":
+  version "0.1.1"
+  resolved "https://github.com/kevinansfield/eslint-plugin-sort-imports-es6-autofix.git#8dc6b689903c9363ade94e2e4d21c94813bbbe98"
+  dependencies:
+    eslint "^3.15.0"
+
+eslint@^3.0.0, eslint@^3.15.0:
   version "3.19.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.19.0.tgz#c8fc6201c7f40dd08941b87c085767386a679acc"
   dependencies:


### PR DESCRIPTION
no issue
- adds `eslint-plugin-sort-imports-es6-autofix` dependency
  - implements ESLint's base `sort-imports` rule but has a distinction in that `import {foo} from 'bar';` is considered `multiple` rather than `single`
  - fixes ESLint's autofix behaviour so `eslint --fix` will actually fix the sort order
- updates all unordered import rules by using `eslint --fix`

With the increased number of `import` statements since Ember+ecosystem started moving towards es6 modules I've found it frustrating at times trying to search through randomly ordered import statements. Recently I've been sorting imports manually when I've added new code or touched old code so I thought I'd add an ESLint rule to codify and automate it.