### PR TITLE
🐛 fix errors when navigating after successful import

### DIFF
--- a/app/controllers/settings/labs.js
+++ b/app/controllers/settings/labs.js
@@ -21,6 +21,7 @@ export default Controller.extend({
     ghostPaths: injectService(),
     notifications: injectService(),
     session: injectService(),
+    settings: injectService(),
     ajax: injectService(),
 
     // TODO: convert to ember-concurrency task
@@ -111,8 +112,12 @@ export default Controller.extend({
                 run.schedule('destroy', this, () => {
                     // Reload currentUser and set session
                     this.set('session.user', store.findRecord('user', currentUserId));
+
                     // TODO: keep as notification, add link to view content
                     notifications.showNotification('Import successful.', {key: 'import.upload.success'});
+
+                    // reload settings
+                    return this.get('settings').reload();
                 });
             }).catch((response) => {
                 if (isUnsupportedMediaTypeError(response)) {


### PR DESCRIPTION
no issue
- the synchronous settings service keeps an internal reference to the settings model, when everything in the store is unloaded during an import that reference breaks and will throw errors when accessing areas of the app that read values from it. This change adds an explicit reload of the settings model during import so that later navigation doesn't break.