### PR TITLE
🐛 fix lazy-loading of CodeMirror interfering with editor

### DIFF
--- a/app/components/gh-cm-editor.js
+++ b/app/components/gh-cm-editor.js
@@ -29,7 +29,9 @@ const CmEditorComponent =  Component.extend(InvokeActionMixin, {
         let loader = this.get('lazyLoader');
 
         RSVP.all([
-            loader.loadStyle('codemirror', 'assets/codemirror/codemirror.css'),
+            // NOTE: no need to load the styles because we're already pulling
+            // them in via SimpleMDE and it causes conflicts with the editor
+            // loader.loadStyle('codemirror', 'assets/codemirror/codemirror.css'),
             loader.loadScript('codemirror', 'assets/codemirror/codemirror.js')
         ]).then(() => {
             scheduleOnce('afterRender', this, function () {

--- a/app/styles/patterns/global.css
+++ b/app/styles/patterns/global.css
@@ -329,6 +329,11 @@ pre tt {
     font-size: inherit;
 }
 
+.CodeMirror pre {
+    font-family: var(--font-family-mono);
+    font-size: 0.9em;
+}
+
 kbd {
     display: inline-block;
     margin-bottom: 0.4em;


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8488
- don't lazy-load the CodeMirror styles in `gh-cm-editor` as they are already loaded and overridden