### PR TITLE
🎨  use `formats` query param

### DIFF
--- a/app/components/gh-posts-list-item.js
+++ b/app/components/gh-posts-list-item.js
@@ -40,19 +40,14 @@ export default Component.extend({
 
     // HACK: this is intentionally awful due to time constraints
     // TODO: find a better way to get an excerpt! :)
-    subText: computed('post.{html,metaDescription}', function () {
-        let html = this.get('post.html');
+    subText: computed('post.{plaintext,metaDescription}', function () {
+        let text = this.get('post.plaintext');
         let metaDescription = this.get('post.metaDescription');
-        let text;
 
         if (!isBlank(metaDescription)) {
             text = metaDescription;
-        } else {
-            let $html = $(`<div>${html}</div>`);
-            text = $html.text();
         }
-
-        return htmlSafe(`${text.slice(0, 80)}&hellip;`);
+        return `${text.slice(0, 80)}...`;
     }),
 
     didReceiveAttrs() {

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -84,6 +84,7 @@ export default Model.extend(Comparable, ValidationEngine, {
     featureImage: attr('string'),
     featured: attr('boolean', {defaultValue: false}),
     page: attr('boolean', {defaultValue: false}),
+    plaintext: attr('string'),
     status: attr('string', {defaultValue: 'draft'}),
     language: attr('string', {defaultValue: 'en_US'}),
     metaTitle: attr('string'),

--- a/app/routes/editor/edit.js
+++ b/app/routes/editor/edit.js
@@ -16,7 +16,8 @@ export default AuthenticatedRoute.extend(base, {
         let query = {
             id: params.post_id,
             status: 'all',
-            staticPages: 'all'
+            staticPages: 'all',
+            formats: 'mobiledoc,plaintext'
         };
         /* eslint-enable camelcase */
 

--- a/app/routes/posts.js
+++ b/app/routes/posts.js
@@ -55,6 +55,8 @@ export default AuthenticatedRoute.extend(InfinityRoute, ShortcutsRoute, {
                 queryParams.order = params.order;
             }
 
+            queryParams.formats = 'mobiledoc,plaintext';
+
             let perPage = this.get('perPage');
             let paginationSettings = assign({perPage, startingPage: 1}, queryParams);
 

--- a/mirage/factories/post.js
+++ b/mirage/factories/post.js
@@ -7,6 +7,7 @@ export default Factory.extend({
     slug(i) { return  `post-${i}`; },
     markdown(i) { return  `Markdown for post ${i}.`; },
     html(i) { return  `<p>HTML for post ${i}.</p>`; },
+    plaintext(i) { return `Plaintext for post ${i}.`; },
     featureImage(i) { return  `/content/images/2015/10/post-${i}.jpg`; },
     featured: false,
     page: false,


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/8275

- ask Ghost for `mobiledoc` and `plaintext`
- Ghost returns `html` by default
- use plaintext for {{subText}} for posts overview

This probably needs a change in the tests, will discuss with @kevinansfield before i start.