### PR TITLE
🐛 reduce likelihood of "untitled" slugs

### DIFF
--- a/app/mixins/editor-base-controller.js
+++ b/app/mixins/editor-base-controller.js
@@ -55,8 +55,6 @@ export default Mixin.create({
 
     navIsClosed: reads('application.autoNav'),
 
-    _hasChanged: false,
-
     init() {
         this._super(...arguments);
         window.onbeforeunload = () => {
@@ -426,11 +424,13 @@ export default Mixin.create({
     },
 
     updateTitle: task(function* (newTitle) {
-        this.set('model.titleScratch', newTitle);
+        let model = this.get('model');
+
+        model.set('titleScratch', newTitle);
 
         // if model is not new and title is not '(Untitled)', or model is new and
         // has a title, don't generate a slug
-        if ((!this.get('model.isNew') || this.get('model.title')) && newTitle !== '(Untitled)') {
+        if ((!model.get('isNew') || model.get('title')) && newTitle !== '(Untitled)') {
             return;
         }
 
@@ -467,15 +467,6 @@ export default Mixin.create({
     actions: {
         updateScratch(value) {
             this.set('model.scratch', value);
-
-            // save on first change to trigger the new->edit transition
-            if (!this._hasChanged && this.get('model.isNew')) {
-                this._hasChanged = true;
-                this.send('save', {silent: true, backgroundSave: true});
-                return;
-            }
-
-            this._hasChanged = true;
 
             // save 3 seconds after last edit
             this.get('_autosave').perform();
@@ -547,18 +538,15 @@ export default Mixin.create({
             return transition.retry();
         },
 
-        updateTitle() {
+        saveTitle() {
             let currentTitle = this.get('model.title');
             let newTitle = this.get('model.titleScratch').trim();
 
-            if (currentTitle === newTitle) {
+            if (newTitle === currentTitle) {
                 return;
             }
 
-            if (this.get('model.isDraft') && !this.get('model.isNew')) {
-                // this is preferrable to setting hasDirtyAttributes to false manually
-                this.model.set('title', newTitle);
-
+            if (this.get('model.isDraft')) {
                 this.send('save', {
                     silent: true,
                     backgroundSave: true

--- a/app/templates/editor/edit.hbs
+++ b/app/templates/editor/edit.hbs
@@ -56,7 +56,7 @@
                 tabindex="1"
                 shouldFocus=shouldFocusTitle
                 autoExpand=".gh-markdown-editor-pane"
-                focus-out="updateTitle"
+                focusOut=(action "saveTitle")
                 update=(action (perform updateTitle))
                 keyEvents=(hash
                     9=(action markdown.focus 'bottom')


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/8482
- removes "save on first change" behaviour of the post body
- always trigger a background save when title loses focus if the post is a draft
- renames `updateTitle` action to `saveTitle` action to better describe it's purpose and to avoid confusion with the `updateTitle` task