### PR TITLE
🎨 fully fix Code Injection styles

### DIFF
--- a/app/components/gh-cm-editor.js
+++ b/app/components/gh-cm-editor.js
@@ -8,7 +8,7 @@ import {assign} from 'ember-platform';
 import {bind, once, scheduleOnce} from 'ember-runloop';
 
 const CmEditorComponent =  Component.extend(InvokeActionMixin, {
-    classNameBindings: ['isFocused:focused'],
+    classNameBindings: ['isFocused:focus'],
 
     _value: boundOneWay('value'), // make sure a value exists
     isFocused: false,
@@ -29,9 +29,7 @@ const CmEditorComponent =  Component.extend(InvokeActionMixin, {
         let loader = this.get('lazyLoader');
 
         RSVP.all([
-            // NOTE: no need to load the styles because we're already pulling
-            // them in via SimpleMDE and it causes conflicts with the editor
-            // loader.loadStyle('codemirror', 'assets/codemirror/codemirror.css'),
+            loader.loadStyle('codemirror', 'assets/codemirror/codemirror.css'),
             loader.loadScript('codemirror', 'assets/codemirror/codemirror.js')
         ]).then(() => {
             scheduleOnce('afterRender', this, function () {

--- a/app/styles/layouts/settings.css
+++ b/app/styles/layouts/settings.css
@@ -267,17 +267,7 @@
     max-width: 680px;
     width: 100%;
     height: auto;
-    border: 1px solid #e0dfd7;
-    border-radius: var(--border-radius);
     line-height: 22px;
-    transition: border-color 0.15s linear;
-
-    -webkit-appearance: none;
-}
-
-.settings-code-editor.focused {
-    outline: 0;
-    border-color: color(var(--lightgrey) l(-15%) s(-10%));
 }
 
 .settings-code-editor .CodeMirror {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -19,7 +19,7 @@ assetLocation = function (fileName) {
 
 codemirrorAssets = function () {
     let codemirrorFiles = [
-        'lib/codemirror.css',
+        // 'lib/codemirror.css',
         'theme/xq-light.css',
         'lib/codemirror.js',
         'mode/htmlmixed/htmlmixed.js',

--- a/tests/integration/components/gh-cm-editor-test.js
+++ b/tests/integration/components/gh-cm-editor-test.js
@@ -37,7 +37,7 @@ describe('Integration: Component: gh-cm-editor', function () {
         let onFocus = () => {
             // wait for runloop to finish so that the new class has been rendered
             wait().then(() => {
-                expect($(find('.gh-input')).hasClass('focused'), 'has focused class on first render with autofocus')
+                expect($(find('.gh-input')).hasClass('focus'), 'has focused class on first render with autofocus')
                     .to.be.true;
 
                 done();
@@ -58,16 +58,16 @@ describe('Integration: Component: gh-cm-editor', function () {
         this.set('text', '');
         this.render(hbs`{{gh-cm-editor text class="gh-input" update=(action (mut text))}}`);
 
-        expect($(find('.gh-input')).hasClass('focused')).to.be.false;
+        expect($(find('.gh-input')).hasClass('focus')).to.be.false;
 
         await click('textarea');
         await triggerEvent('textarea', 'focus');
 
-        expect($(find('.gh-input')).hasClass('focused')).to.be.true;
+        expect($(find('.gh-input')).hasClass('focus')).to.be.true;
 
         await triggerEvent('textarea', 'blur');
 
-        expect($(find('.gh-input')).hasClass('focused')).to.be.false;
+        expect($(find('.gh-input')).hasClass('focus')).to.be.false;
     });
 
     it('can autofocus', function (done) {
@@ -77,7 +77,7 @@ describe('Integration: Component: gh-cm-editor', function () {
         let onFocus = () => {
             // wait for runloop to finish so that the new class has been rendered
             wait().then(() => {
-                expect(this.$('.gh-input').hasClass('focused'), 'has focused class on first render with autofocus')
+                expect(this.$('.gh-input').hasClass('focus'), 'has focused class on first render with autofocus')
                     .to.be.true;
 
                 done();


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8504
- allow `.settings-code-editor` to inherit from `.gh-input` - fixes border colours
- change `gh-cm-editor`'s "focused" class from `.focused` to `.focus` so it can inherit `.gh-input` styles
- add lazy loading of CM styles back in `gh-cm-editor` but prevent `lib/codemirror.css` from being compiled into the codemirror styles so that we get the theme colours without causing conflicts with the main editor