### PR TITLE
🎨 fix title placeholder styles

### DIFF
--- a/app/styles/layouts/editor.css
+++ b/app/styles/layouts/editor.css
@@ -237,7 +237,7 @@
     padding: 0;
 }
 
-.gh-editor-title:placeholder {
+.gh-editor-title::placeholder {
     font-weight: bold;
 }
 


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8516
- placeholders are pseudo elements so need to use `::` rather than `:` in their CSS selectors