### PR TITLE
🐛  Use new user image properties for image upload

### DIFF
--- a/app/templates/team/user.hbs
+++ b/app/templates/team/user.hbs
@@ -93,7 +93,7 @@
               <button class="gh-btn gh-btn-default user-cover-edit" {{action "toggleUploadCoverModal"}}><span>Change Cover</span></button>
               {{#if showUploadCoverModal}}
                   {{gh-fullscreen-modal "upload-image"
-                                        model=(hash model=user imageProperty="cover")
+                                        model=(hash model=user imageProperty="coverImage")
                                         close=(action "toggleUploadCoverModal")
                                         modifier="action wide"}}
               {{/if}}
@@ -104,7 +104,7 @@
               <button type="button" {{action "toggleUploadImageModal"}} class="edit-user-image">Edit Picture</button>
               {{#if showUploadImageModal}}
                   {{gh-fullscreen-modal "upload-image"
-                                        model=(hash model=user imageProperty="image")
+                                        model=(hash model=user imageProperty="profileImage")
                                         close=(action "toggleUploadImageModal")
                                         modifier="action wide"}}
               {{/if}}


### PR DESCRIPTION
closes TryGhost/Ghost#8521

The image uploader modals in `user.hbs` used the old image properties instead of `coverImage` and `profileImage`.