### PR TITLE
🐛 fix saving users when slug has been changed

### DIFF
--- a/app/controllers/team/user.js
+++ b/app/controllers/team/user.js
@@ -180,10 +180,10 @@ export default Controller.extend({
             // If the user's slug has changed, change the URL and replace
             // the history so refresh and back button still work
             if (slugChanged) {
-                currentPath = window.history.state.path;
+                currentPath = window.location.hash;
 
                 newPath = currentPath.split('/');
-                newPath[newPath.length - 2] = model.get('slug');
+                newPath[newPath.length - 1] = model.get('slug');
                 newPath = newPath.join('/');
 
                 window.history.replaceState({path: newPath}, '', newPath);


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8547
- `window.history.state` is no longer a thing (not sure if it's a recent browser change or because we switched to hash-urls) so the URL change logic after a successful user save needs to use `window.location.hash` instead