### PR TITLE
💄  Give suspended user badge a little room

### DIFF
--- a/app/styles/layouts/users.css
+++ b/app/styles/layouts/users.css
@@ -81,6 +81,15 @@
     background: #fff;
 }
 
+.gh-badge.suspended {
+    margin-left: 15px;
+    border: color(var(--red) blackness(+8%)) 1px solid;
+    background: linear-gradient(
+    color(var(--red) whiteness(+10%)),
+    color(var(--red) blackness(+4%))
+    );
+}
+
 
 /* User invitation modal
 /* ---------------------------------------------------------- */

--- a/app/templates/team/user.hbs
+++ b/app/templates/team/user.hbs
@@ -6,7 +6,7 @@
             {{user.name}}
 
             {{#if user.isSuspended}}
-            <span class="gh-badge administrator" data-test-suspended-badge>Suspended</span>
+            <span class="gh-badge suspended" data-test-suspended-badge>Suspended</span>
             {{/if}}
         </h2>
 


### PR DESCRIPTION
closes #8546

Creates new `suspended` class as a copy of `administrator` for better naming and add `15px` of `margin-left` to it.

![image](https://user-images.githubusercontent.com/8037602/27031836-1a9bf44e-4f9c-11e7-861d-171928a914a7.png)