### PR TITLE
🐛  Fix styles for password forgot link

### DIFF
--- a/app/styles/patterns/buttons.css
+++ b/app/styles/patterns/buttons.css
@@ -303,6 +303,14 @@ fieldset[disabled] .gh-btn {
     fill: #fff;
 }
 
+.gh-btn-icon svg.gh-spinner {
+    left: 5px;
+}
+
+.gh-btn-icon svg.gh-spinner rect {
+    fill: color(var(--midgrey) l(+15%));
+}
+
 .gh-btn-icon-right svg,
 svg.gh-btn-icon-right {
     margin-left: 0.5em;

--- a/app/templates/signin.hbs
+++ b/app/templates/signin.hbs
@@ -46,9 +46,11 @@
                                 class="forgotten-link gh-btn gh-btn-link gh-btn-icon"
                                 tabindex="4"
                                 type="button"
+                                successClass=""
+                                failureClass=""
                                 as |task|
                             }}
-                                <span>{{#if task.isRunning}}{{inline-svg "spinner"}}{{else}}Forgot?{{/if}}</span>
+                                <span>{{#if task.isRunning}}{{inline-svg "spinner" class="gh-spinner"}}{{else}}Forgot?{{/if}}</span>
                             {{/gh-task-button}}
                         </span>
                     {{/gh-form-group}}


### PR DESCRIPTION
closes TryGhost/Ghost#8550

Use no success- and failure-classes for forgot link `gh-task-button`.
Fixes loading spinner fill and positioning.