### PR TITLE
⬆️  Trigger image upload when clicking on image

### DIFF
--- a/app/templates/settings/general.hbs
+++ b/app/templates/settings/general.hbs
@@ -71,14 +71,14 @@
             </div>
             <div class="gh-setting-action gh-setting-action-smallimg">
                 {{#if model.icon}}
-                    <img class="blog-icon" src="{{model.icon}}" onClick={{action "triggerFileDialog"}} alt="icon" data-test-icon-img>
+                    <img class="blog-icon" src="{{model.icon}}" onclick={{action "triggerFileDialog"}} alt="icon" data-test-icon-img>
                     <button type="button" class="gh-setting-action-smallimg-delete" {{action "removeImage" "icon"}} data-test-delete-image="icon">
                         <span>delete</span>
                     </button>
                 {{else if uploader.isUploading}}
                     {{uploader.progressBar}}
                 {{else}}
-                    <button type="button" class="gh-btn" onClick={{action "triggerFileDialog"}} data-test-image-upload-btn="icon">
+                    <button type="button" class="gh-btn" onclick={{action "triggerFileDialog"}} data-test-image-upload-btn="icon">
                         <span>Upload Image</span>
                     </button>
                 {{/if}}
@@ -106,14 +106,14 @@
             </div>
             <div class="gh-setting-action gh-setting-action-smallimg">
                 {{#if model.logo}}
-                    <img class="blog-logo" src="{{model.logo}}"  onClick={{action "triggerFileDialog"}} alt="logo" data-test-logo-img>
+                    <img class="blog-logo" src="{{model.logo}}"  onclick={{action "triggerFileDialog"}} alt="logo" data-test-logo-img>
                     <button type="button" class="gh-setting-action-smallimg-delete" {{action "removeImage" "logo"}} data-test-delete-image="logo">
                         <span>delete</span>
                     </button>
                 {{else if uploader.isUploading}}
                     {{uploader.progressBar}}
                 {{else}}
-                    <button type="button" class="gh-btn" onClick={{action "triggerFileDialog"}} data-test-image-upload-btn="logo">
+                    <button type="button" class="gh-btn" onclick={{action "triggerFileDialog"}} data-test-image-upload-btn="logo">
                         <span>Upload Image</span>
                     </button>
                 {{/if}}
@@ -141,14 +141,14 @@
             </div>
             <div class="gh-setting-action gh-setting-action-largeimg">
                 {{#if model.coverImage}}
-                    <img class="blog-cover" src="{{model.coverImage}}"  onClick={{action "triggerFileDialog"}} alt="cover photo" data-test-cover-img>
+                    <img class="blog-cover" src="{{model.coverImage}}"  onclick={{action "triggerFileDialog"}} alt="cover photo" data-test-cover-img>
                     <button type="button" class="gh-setting-action-largeimg-delete" {{action "removeImage" "coverImage"}} data-test-delete-image="coverImage">
                         <span>delete</span>
                     </button>
                 {{else if uploader.isUploading}}
                     {{uploader.progressBar}}
                 {{else}}
-                    <button type="button" class="gh-btn" onClick={{action "triggerFileDialog"}} data-test-image-upload-btn="coverImage">
+                    <button type="button" class="gh-btn" onclick={{action "triggerFileDialog"}} data-test-image-upload-btn="coverImage">
                         <span>Upload Image</span>
                     </button>
                 {{/if}}

--- a/app/templates/settings/general.hbs
+++ b/app/templates/settings/general.hbs
@@ -71,7 +71,7 @@
             </div>
             <div class="gh-setting-action gh-setting-action-smallimg">
                 {{#if model.icon}}
-                    <img class="blog-icon" src="{{model.icon}}" alt="icon" data-test-icon-img>
+                    <img class="blog-icon" src="{{model.icon}}" onClick={{action "triggerFileDialog"}} alt="icon" data-test-icon-img>
                     <button type="button" class="gh-setting-action-smallimg-delete" {{action "removeImage" "icon"}} data-test-delete-image="icon">
                         <span>delete</span>
                     </button>
@@ -106,7 +106,7 @@
             </div>
             <div class="gh-setting-action gh-setting-action-smallimg">
                 {{#if model.logo}}
-                    <img class="blog-logo" src="{{model.logo}}" alt="logo" data-test-logo-img>
+                    <img class="blog-logo" src="{{model.logo}}"  onClick={{action "triggerFileDialog"}} alt="logo" data-test-logo-img>
                     <button type="button" class="gh-setting-action-smallimg-delete" {{action "removeImage" "logo"}} data-test-delete-image="logo">
                         <span>delete</span>
                     </button>
@@ -141,7 +141,7 @@
             </div>
             <div class="gh-setting-action gh-setting-action-largeimg">
                 {{#if model.coverImage}}
-                    <img class="blog-cover" src="{{model.coverImage}}" alt="cover photo" data-test-cover-img>
+                    <img class="blog-cover" src="{{model.coverImage}}"  onClick={{action "triggerFileDialog"}} alt="cover photo" data-test-cover-img>
                     <button type="button" class="gh-setting-action-largeimg-delete" {{action "removeImage" "coverImage"}} data-test-delete-image="coverImage">
                         <span>delete</span>
                     </button>

--- a/app/templates/settings/general.hbs
+++ b/app/templates/settings/general.hbs
@@ -70,13 +70,13 @@
                 {{/if}}
             </div>
             <div class="gh-setting-action gh-setting-action-smallimg">
-                {{#if model.icon}}
+                {{#if uploader.isUploading}}
+                    {{uploader.progressBar}}
+                {{else if model.icon}}
                     <img class="blog-icon" src="{{model.icon}}" onclick={{action "triggerFileDialog"}} alt="icon" data-test-icon-img>
                     <button type="button" class="gh-setting-action-smallimg-delete" {{action "removeImage" "icon"}} data-test-delete-image="icon">
                         <span>delete</span>
                     </button>
-                {{else if uploader.isUploading}}
-                    {{uploader.progressBar}}
                 {{else}}
                     <button type="button" class="gh-btn" onclick={{action "triggerFileDialog"}} data-test-image-upload-btn="icon">
                         <span>Upload Image</span>
@@ -105,13 +105,13 @@
                 {{/if}}
             </div>
             <div class="gh-setting-action gh-setting-action-smallimg">
-                {{#if model.logo}}
+                {{#if uploader.isUploading}}
+                    {{uploader.progressBar}}
+                {{else if model.logo}}
                     <img class="blog-logo" src="{{model.logo}}"  onclick={{action "triggerFileDialog"}} alt="logo" data-test-logo-img>
                     <button type="button" class="gh-setting-action-smallimg-delete" {{action "removeImage" "logo"}} data-test-delete-image="logo">
                         <span>delete</span>
                     </button>
-                {{else if uploader.isUploading}}
-                    {{uploader.progressBar}}
                 {{else}}
                     <button type="button" class="gh-btn" onclick={{action "triggerFileDialog"}} data-test-image-upload-btn="logo">
                         <span>Upload Image</span>
@@ -140,13 +140,13 @@
                 {{/if}}
             </div>
             <div class="gh-setting-action gh-setting-action-largeimg">
-                {{#if model.coverImage}}
+                {{#if uploader.isUploading}}
+                    {{uploader.progressBar}}
+                {{else if model.coverImage}}
                     <img class="blog-cover" src="{{model.coverImage}}"  onclick={{action "triggerFileDialog"}} alt="cover photo" data-test-cover-img>
                     <button type="button" class="gh-setting-action-largeimg-delete" {{action "removeImage" "coverImage"}} data-test-delete-image="coverImage">
                         <span>delete</span>
                     </button>
-                {{else if uploader.isUploading}}
-                    {{uploader.progressBar}}
                 {{else}}
                     <button type="button" class="gh-btn" onclick={{action "triggerFileDialog"}} data-test-image-upload-btn="coverImage">
                         <span>Upload Image</span>


### PR DESCRIPTION
closes TryGhost/Ghost#8544

When clicking on an already uploaded icon, logo or cover in Settings -> General we trigger now the file upload to be able to replace it.

Todo:
- [ ] write tests