### PR TITLE
Update post save button texts

### DIFF
--- a/app/components/gh-publishmenu.js
+++ b/app/components/gh-publishmenu.js
@@ -39,13 +39,48 @@ export default Component.extend({
         }
     }),
 
-    buttonText: computed('postState', function () {
-        let state = this.get('postState');
+    buttonText:  computed('postState', 'saveType', function() {
+        let postState = this.get('postState');
+        let saveType = this.get('saveType');
+        let buttonText;
 
-        return state === 'draft' ? 'Publish' : 'Update';
+        if (postState === 'draft') {
+            buttonText = saveType === 'publish' ? 'Publish' : 'Schedule';
+        }
+
+        if (postState === 'published') {
+            buttonText = saveType === 'publish' ? 'Update' : 'Un-publish';
+        }
+
+        if (postState === 'scheduled') {
+            buttonText = saveType === 'schedule' ? 'Re-schedule' : 'Un-schedule';
+        }
+
+        return buttonText || 'Publish';
+    }),
+
+    successText: computed('_previousStatus', 'postState', function() {
+        let postState = this.get('postState');
+        let previousStatus = this.get('_previousStatus');
+        let buttonText;
+
+        if (previousStatus === 'draft') {
+            buttonText = postState === 'published' ? 'Published' : 'Scheduled';
+        }
+
+        if (previousStatus === 'published') {
+            buttonText = postState === 'draft' ? 'Un-published' : 'Updated';
+        }
+
+        if (previousStatus === 'scheduled') {
+            buttonText = postState === 'draft' ? 'Un-scheduled' : 'Re-scheduled';
+        }
+
+        return buttonText;
     }),
 
     save: task(function* () {
+        this.set('_previousStatus', this.get('post.status'));
         this.get('setSaveType')(this.get('saveType'));
 
         try {
@@ -65,6 +100,8 @@ export default Component.extend({
             }
         }
     }),
+
+    _previousStatus: null,
 
     _cachePublishedAtBlogTZ() {
         this._publishedAtBlogTZ = this.get('post.publishedAtBlogTZ');

--- a/app/templates/components/gh-publishmenu.hbs
+++ b/app/templates/components/gh-publishmenu.hbs
@@ -33,6 +33,7 @@
             </button>
             {{gh-task-button buttonText
                 task=save
+                successText=successText
                 class="gh-btn gh-btn-blue gh-publishmenu-button gh-btn-icon"
                 data-test-publishmenu-save=true}}
         </footer>

--- a/tests/acceptance/editor-test.js
+++ b/tests/acceptance/editor-test.js
@@ -149,8 +149,27 @@ describe('Acceptance: Editor', function() {
                 'draft publish menu is shown'
             ).to.exist;
 
+            await click(testSelector('publishmenu-scheduled-option'));
+
+            expect(
+                find(testSelector('publishmenu-save')).text().trim(),
+                'draft post schedule button text'
+            ).to.equal('Schedule');
+
+            await click(testSelector('publishmenu-published-option'));
+
+            expect(
+                find(testSelector('publishmenu-save')).text().trim(),
+                'draft post publish button text'
+            ).to.equal('Publish');
+
             // Publish the post
             await click(testSelector('publishmenu-save'));
+
+            expect(
+                find(testSelector('publishmenu-save')).text().trim(),
+                'publish menu save button updated after draft is published'
+            ).to.equal('Published');
 
             expect(
                 find(testSelector('publishmenu-published')),
@@ -161,6 +180,15 @@ describe('Acceptance: Editor', function() {
                 find(testSelector('editor-post-status')).text().trim(),
                 'post status updated after draft published'
             ).to.equal('Published');
+
+            await click(testSelector('publishmenu-cancel'));
+            await click(testSelector('publishmenu-trigger'));
+            await click(testSelector('publishmenu-unpublished-option'));
+
+            expect(
+                find(testSelector('publishmenu-save')).text().trim(),
+                'published post unpublish button text'
+            ).to.equal('Un-publish');
 
             // post id 2 is a published post, checking for published post behaviour now
             await visit('/editor/2');
@@ -175,7 +203,18 @@ describe('Acceptance: Editor', function() {
             await triggerEvent(testSelector('date-time-picker-time-input'), 'blur');
             // saving
             await click(testSelector('publishmenu-trigger'));
+
+            expect(
+                find(testSelector('publishmenu-save')).text().trim(),
+                'published button text'
+            ).to.equal('Update');
+
             await click(testSelector('publishmenu-save'));
+
+            expect(
+                find(testSelector('publishmenu-save')).text().trim(),
+                'publish menu save button updated after published post is updated'
+            ).to.equal('Updated');
 
             // go to settings to change the timezone
             await visit('/settings/general');
@@ -215,7 +254,18 @@ describe('Acceptance: Editor', function() {
             // unpublish
             await click(testSelector('publishmenu-trigger'));
             await click(testSelector('publishmenu-unpublished-option'));
+
+            expect(
+                find(testSelector('publishmenu-save')).text().trim(),
+                'published post unpublish button text'
+            ).to.equal('Un-publish');
+
             await click(testSelector('publishmenu-save'));
+
+            expect(
+                find(testSelector('publishmenu-save')).text().trim(),
+                'publish menu save button updated after published post is unpublished'
+            ).to.equal('Un-published');
 
             expect(
                 find(testSelector('publishmenu-draft')),
@@ -233,14 +283,30 @@ describe('Acceptance: Editor', function() {
 
             let newFutureTime = moment.tz('Pacific/Kwajalein').add(10, 'minutes');
             await click(testSelector('publishmenu-scheduled-option'));
+
+            expect(
+                find(testSelector('publishmenu-save')).text().trim(),
+                'draft post, schedule button text'
+            ).to.equal('Schedule');
+
             await datepickerSelect(`${testSelector('publishmenu-draft')} ${testSelector('date-time-picker-datepicker')}`, newFutureTime);
             await click(testSelector('publishmenu-save'));
+
+            expect(
+                find(testSelector('publishmenu-save')).text().trim(),
+                'publish menu save button updated after draft is scheduled'
+            ).to.equal('Scheduled');
+
             await click(testSelector('publishmenu-cancel'));
 
             expect(
                 find(testSelector('publishmenu-scheduled')),
                 'publish menu is not shown after closed'
             ).to.not.exist;
+
+            // expect countdown to show warning, that post will be published in x minutes
+            expect(find(testSelector('schedule-countdown')).text().trim(), 'notification countdown')
+                .to.contain('Post will be published in');
 
             expect(
                 find(testSelector('publishmenu-trigger')).text().trim(),
@@ -249,17 +315,52 @@ describe('Acceptance: Editor', function() {
 
             expect(
                 find(testSelector('editor-post-status')).text().trim(),
-                'scheduled status text'
+                'scheduled post status'
             ).to.equal('Scheduled');
 
-            // expect countdown to show warning, that post will be published in x minutes
-            expect(find(testSelector('schedule-countdown')).text().trim(), 'notification countdown')
-                .to.contain('Post will be published in');
+            // Re-schedule
+            await click(testSelector('publishmenu-trigger'));
+            await click(testSelector('publishmenu-scheduled-option'));
+            expect(
+                find(testSelector('publishmenu-save')).text().trim(),
+                'scheduled post button reschedule text'
+            ).to.equal('Re-schedule');
+
+            await click(testSelector('publishmenu-save'));
+
+            expect(
+                find(testSelector('publishmenu-save')).text().trim(),
+                'publish menu save button text for a rescheduled post'
+            ).to.equal('Re-scheduled');
+
+            await click(testSelector('publishmenu-cancel'));
+
+            expect(
+                find(testSelector('publishmenu-scheduled')),
+                'publish menu is not shown after closed'
+            ).to.not.exist;
+
+            expect(
+                find(testSelector('editor-post-status')).text().trim(),
+                'scheduled status text'
+            ).to.equal('Scheduled');
 
             // unschedule
             await click(testSelector('publishmenu-trigger'));
             await click(testSelector('publishmenu-draft-option'));
+
+            expect(
+                find(testSelector('publishmenu-save')).text().trim(),
+                'publish menu save button updated after scheduled post is unscheduled'
+            ).to.equal('Un-schedule');
+
             await click(testSelector('publishmenu-save'));
+
+            expect(
+                find(testSelector('publishmenu-save')).text().trim(),
+                'publish menu save button updated after scheduled post is unscheduled'
+            ).to.equal('Un-scheduled');
+
             await click(testSelector('publishmenu-cancel'));
 
             expect(


### PR DESCRIPTION
The save button text now represents the state of change for a post and includes a more suitable success message.

closes https://github.com/TryGhost/Ghost/issues/8536, closes https://github.com/TryGhost/Ghost/issues/8500

- Post save button will now display publish/un-publish/schedule/un-schedule/re-schedule/update
- On successful save button will display published/un-published/scheduled/un-scheduled/re-scheduled/updated
