### PR TITLE
🐛 fix Cmd-S save with cursor in slug field

### DIFF
--- a/app/controllers/post-settings-menu.js
+++ b/app/controllers/post-settings-menu.js
@@ -11,7 +11,6 @@ import observer from 'ember-metal/observer';
 import {parseDateString} from 'ghost-admin/utils/date-formatting';
 import SettingsMenuMixin from 'ghost-admin/mixins/settings-menu-controller';
 import boundOneWay from 'ghost-admin/utils/bound-one-way';
-import isNumber from 'ghost-admin/utils/isNumber';
 
 const {ArrayProxy, Handlebars, PromiseProxyMixin} = Ember;
 
@@ -25,6 +24,11 @@ export default Controller.extend(SettingsMenuMixin, {
     session: injectService(),
     slugGenerator: injectService(),
     timeZone: injectService(),
+
+    // HACK: the edit controller will be different for new/edit so we can't use
+    // injectController. Instead we set this value in the routes so that we can
+    // call the editorControllers tasks. Fixed in 1.0 as the PSM is a component
+    editorController: null,
 
     initializeSelectedAuthor: observer('model', function () {
         return this.get('model.author').then((author) => {
@@ -172,63 +176,12 @@ export default Controller.extend(SettingsMenuMixin, {
          * triggered by user manually changing slug
          */
         updateSlug(newSlug) {
-            let slug = this.get('model.slug');
-
-            newSlug = newSlug || slug;
-            newSlug = newSlug && newSlug.trim();
-
-            // Ignore unchanged slugs or candidate slugs that are empty
-            if (!newSlug || slug === newSlug) {
-                // reset the input to its previous state
-                this.set('slugValue', slug);
-
-                return;
-            }
-
-            this.get('slugGenerator').generateSlug('post', newSlug).then((serverSlug) => {
-                // If after getting the sanitized and unique slug back from the API
-                // we end up with a slug that matches the existing slug, abort the change
-                if (serverSlug === slug) {
-                    return;
-                }
-
-                // Because the server transforms the candidate slug by stripping
-                // certain characters and appending a number onto the end of slugs
-                // to enforce uniqueness, there are cases where we can get back a
-                // candidate slug that is a duplicate of the original except for
-                // the trailing incrementor (e.g., this-is-a-slug and this-is-a-slug-2)
-
-                // get the last token out of the slug candidate and see if it's a number
-                let slugTokens = serverSlug.split('-');
-                let check = Number(slugTokens.pop());
-
-                // if the candidate slug is the same as the existing slug except
-                // for the incrementor then the existing slug should be used
-                if (isNumber(check) && check > 0) {
-                    if (slug === slugTokens.join('-') && serverSlug !== newSlug) {
-                        this.set('slugValue', slug);
-
-                        return;
-                    }
-                }
-
-                this.set('model.slug', serverSlug);
-
-                if (this.hasObserverFor('model.titleScratch')) {
-                    this.removeObserver('model.titleScratch', this, 'titleObserver');
-                }
-
-                // If this is a new post.  Don't save the model.  Defer the save
-                // to the user pressing the save button
-                if (this.get('model.isNew')) {
-                    return;
-                }
-
-                return this.get('model').save();
-            }).catch((error) => {
-                this.showError(error);
-                this.get('model').rollbackAttributes();
-            });
+            return this.get('editorController.updateSlug')
+                .perform(newSlug)
+                .catch((error) => {
+                    this.showError(error);
+                    this.get('model').rollbackAttributes();
+                });
         },
 
         /**

--- a/app/routes/editor/edit.js
+++ b/app/routes/editor/edit.js
@@ -54,6 +54,9 @@ export default AuthenticatedRoute.extend(base, {
         this._super(...arguments);
 
         controller.set('shouldFocusEditor', this.get('_transitionedFromNew'));
+
+        let psm = this.controllerFor('post-settings-menu');
+        psm.set('editorController', controller);
     },
 
     actions: {

--- a/app/routes/editor/new.js
+++ b/app/routes/editor/new.js
@@ -25,12 +25,9 @@ export default AuthenticatedRoute.extend(base, {
         });
     },
 
-    setupController() {
+    setupController(controller) {
         let psm = this.controllerFor('post-settings-menu');
-
-        // make sure there are no titleObserver functions hanging around
-        // from previous posts
-        psm.removeObserver('titleScratch', psm, 'titleObserver');
+        psm.set('editorController', controller);
 
         // Ensure that the PSM Publish Date selector resets
         psm.send('resetPubDate');


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/8551
- renames editor-base-controller.generateSlug to generateSlugFromTitle
- moves `updateSlug` logic from PSM to editor base controller
- moves editor base controller save logic into a `save` task
- adds `updateSlug` and `save` into a `saveTasks` task group so that calls are queued rather than running concurrently
- sets the editor controller on the PSM when accessing the new/edit routes - we use a base controller mixin so the slug/save logic is duplicated on new/edit controllers meaning we need to add a reference manually rather than relying on dependency injection
- remove titleObserver checks for non-existent titleObserver