### PR TITLE
📖 update all support.ghost.org links to docs/help.ghost.org

### DIFF
--- a/app/controllers/setup/three.js
+++ b/app/controllers/setup/three.js
@@ -201,7 +201,7 @@ export default Controller.extend({
                             invitationsString = erroredEmails.length > 1 ? ' invitations: ' : ' invitation: ';
                             message = `Failed to send ${erroredEmails.length} ${invitationsString}`;
                             message += erroredEmails.join(', ');
-                            message += ". Please check your email configuration, see <a href=\'http://support.ghost.org/mail\' target=\'_blank\'>http://support.ghost.org/mail</a> for instructions";
+                            message += ". Please check your email configuration, see <a href=\'https://docs.ghost.org/v0.11.9/docs/mail-configuration-on-self-hosted-version-of-ghost\' target=\'_blank\'>https://docs.ghost.org/v0.11.9/docs/mail-configuration-on-self-hosted-version-of-ghost</a> for instructions";
 
                             message = htmlSafe(message);
                             notifications.showAlert(message, {type: 'error', delayed: successCount > 0, key: 'signup.send-invitations.failed'});

--- a/app/templates/components/gh-nav-menu.hbs
+++ b/app/templates/components/gh-nav-menu.hbs
@@ -55,10 +55,10 @@
         {{/gh-dropdown-button}}
         {{#gh-dropdown tagName="div" name="help-menu" closeOnClick="true"}}
             <ul class="dropdown-menu dropdown-triangle-bottom" role="menu">
-                <li role="presentation"><a class="dropdown-item help-menu-support" role="menuitem" tabindex="-1" href="http://support.ghost.org/" target="_blank"><i class="icon-ambulance"></i> Support Center</a></li>
+                <li role="presentation"><a class="dropdown-item help-menu-support" role="menuitem" tabindex="-1" href="http://help.ghost.org/" target="_blank"><i class="icon-ambulance"></i> Support Center</a></li>
                 <li role="presentation"><a class="dropdown-item help-menu-tweet" role="menuitem" tabindex="-1" href="https://twitter.com/intent/tweet?text=%40TryGhost+Hi%21+Can+you+help+me+with+&related=TryGhost" target="_blank" onclick="window.open(this.href, 'twitter-share', 'width=550,height=235');return false;"><i class="icon-twitter"></i> Tweet @TryGhost!</a></li>
                 <li class="divider"></li>
-                <li role="presentation"><a class="dropdown-item help-menu-how-to" role="menuitem" tabindex="-1" href="http://support.ghost.org/how-to-use-ghost/" target="_blank"><i class="icon-book"></i> How to Use Ghost</a></li>
+                <li role="presentation"><a class="dropdown-item help-menu-how-to" role="menuitem" tabindex="-1" href="https://help.ghost.org/hc/en-us/categories/203268947-Ghost-Pro-" target="_blank"><i class="icon-book"></i> How to Use Ghost</a></li>
                 <li role="presentation"><a class="dropdown-item help-menu-markdown" role="menuitem" tabindex="-1" href="" {{action "showMarkdownHelp"}}><i class="icon-markdown"></i> Markdown Help</a></li>
                 <li class="divider"></li>
                 <li role="presentation"><a class="dropdown-item help-menu-wishlist" role="menuitem" tabindex="-1" href="http://ideas.ghost.org/" target="_blank"><i class="icon-idea"></i> Wishlist</a></li>

--- a/app/templates/components/modals/markdown-help.hbs
+++ b/app/templates/components/modals/markdown-help.hbs
@@ -76,6 +76,6 @@
             </tr>
             </tbody>
         </table>
-        For further Markdown syntax reference: <a href="http://support.ghost.org/markdown-guide/" target="_blank">Markdown Documentation</a>
+        For further Markdown syntax reference: <a href="https://help.ghost.org/hc/en-us/articles/224410728-Markdown-Guide" target="_blank">Markdown Documentation</a>
     </section>
 </div>

--- a/app/templates/settings/labs.hbs
+++ b/app/templates/settings/labs.hbs
@@ -48,13 +48,13 @@
                 <div class="form-group for-checkbox">
                     <h3>Enable Beta Features</h3>
                     {{#gh-feature-flag "publicAPI"}}
-                        Public API - For full instructions, read the <a href="http://support.ghost.org/public-api-beta/">developer guide</a>.
+                        Public API - For full instructions, read the <a href="https://help.ghost.org/hc/en-us/articles/115000301672-Public-API-Beta">developer guide</a>.
                     {{/gh-feature-flag}}
                     {{#gh-feature-flag "subscribers"}}
-                        Subscribers - Collect email addresses from your readers, more info in <a href="http://support.ghost.org/subscribers-beta/">the docs</a>
+                        Subscribers - Collect email addresses from your readers, more info in <a href="https://help.ghost.org/hc/en-us/articles/224089787-Subscribers-Beta">the docs</a>
                     {{/gh-feature-flag}}
                     {{#gh-feature-flag "internalTags"}}
-                        Internal Tags - tags which don't show up in your theme, more info in <a href="http://support.ghost.org/internal-tags-beta/">the docs</a>.
+                        Internal Tags - tags which don't show up in your theme, more info in <a href="https://help.ghost.org/hc/en-us/articles/224169868-Internal-Tags-Beta">the docs</a>.
                     {{/gh-feature-flag}}
                 </div>
             </fieldset>

--- a/tests/unit/components/gh-upgrade-notification-test.js
+++ b/tests/unit/components/gh-upgrade-notification-test.js
@@ -14,7 +14,7 @@ describeComponent(
     },
     function() {
         beforeEach(function() {
-            let upgradeMessage = {'content': 'Ghost 10.02.91 is available! Hot Damn. <a href="http://support.ghost.org/how-to-upgrade/" target="_blank">Click here</a> to upgrade.'};
+            let upgradeMessage = {'content': 'Ghost 10.02.91 is available! Hot Damn. <a href="https://docs.ghost.org/v0.11.9/docs/how-to-upgrade-ghost" target="_blank">Click here</a> to upgrade.'};
             this.subject().set('upgradeNotification', upgradeMessage);
         });
 
@@ -30,7 +30,7 @@ describeComponent(
             expect(this.$().prop('tagName')).to.equal('SECTION');
             expect(this.$().hasClass('gh-upgrade-notification')).to.be.true;
             // caja tools sanitize target='_blank' attribute
-            expect(this.$().html()).to.contain('Hot Damn. <a href="http://support.ghost.org/how-to-upgrade/">Click here</a>');
+            expect(this.$().html()).to.contain('Hot Damn. <a href="https://docs.ghost.org/v0.11.9/docs/how-to-upgrade-ghost">Click here</a>');
         });
     }
 );


### PR DESCRIPTION
no issue
- support.ghost.org has gone away, we now have self-host/dev documentation on https://docs.ghost.org and user documentation at https://help.ghost.org