### PR TITLE
📖 update all support.ghost.org links to docs/help.ghost.org

### DIFF
--- a/app/controllers/setup/three.js
+++ b/app/controllers/setup/three.js
@@ -215,7 +215,7 @@ export default Controller.extend({
             invitationsString = erroredEmails.length > 1 ? ' invitations: ' : ' invitation: ';
             message = `Failed to send ${erroredEmails.length} ${invitationsString}`;
             message += erroredEmails.join(', ');
-            message += ". Please check your email configuration, see <a href=\'http://support.ghost.org/mail\' target=\'_blank\'>http://support.ghost.org/mail</a> for instructions";
+            message += ". Please check your email configuration, see <a href=\'https://docs.ghost.org/v1.0.0/docs/mail-config\' target=\'_blank\'>https://docs.ghost.org/v1.0.0/docs/mail-config</a> for instructions";
 
             message = htmlSafe(message);
             notifications.showAlert(message, {type: 'error', delayed: successCount > 0, key: 'signup.send-invitations.failed'});

--- a/app/templates/about.hbs
+++ b/app/templates/about.hbs
@@ -17,7 +17,7 @@
                 <li><strong>Mail</strong> {{#if model.mail}}{{model.mail}}{{else}}Native{{/if}}</li>
             </ul>
             <div class="gh-env-help">
-                <a class="gh-btn" href="http://support.ghost.org" target="_blank"><span>User Documentation</span></a>
+                <a class="gh-btn" href="https://help.ghost.org" target="_blank"><span>User Documentation</span></a>
                 <a class="gh-btn" href="https://ghost.org/slack/" target="_blank"><span>Get Help With Ghost</span></a>
             </div>
         </section>

--- a/app/templates/components/gh-nav-menu.hbs
+++ b/app/templates/components/gh-nav-menu.hbs
@@ -13,10 +13,10 @@
             <li role="presentation">{{#link-to "about" classNames="gh-nav-menu-about dropdown-item js-nav-item" role="menuitem" tabindex="-1"}}{{inline-svg "store"}} About Ghost{{/link-to}}</li>
             <li class="divider"></li>
             <li role="presentation">{{#link-to "team.user" session.user.slug classNames="dropdown-item user-menu-profile js-nav-item" role="menuitem" tabindex="-1"}}{{inline-svg "user-circle"}} Your Profile{{/link-to}}</li>
-            <li role="presentation"><a class="dropdown-item help-menu-support" role="menuitem" tabindex="-1" href="http://support.ghost.org/" target="_blank">{{inline-svg "ambulance"}} Support Center</a></li>
+            <li role="presentation"><a class="dropdown-item help-menu-support" role="menuitem" tabindex="-1" href="https://help.ghost.org/" target="_blank">{{inline-svg "ambulance"}} Support Center</a></li>
             <li role="presentation"><a class="dropdown-item help-menu-tweet" role="menuitem" tabindex="-1" href="https://twitter.com/intent/tweet?text=%40TryGhost+Hi%21+Can+you+help+me+with+&related=TryGhost" target="_blank" onclick="window.open(this.href, 'twitter-share', 'width=550,height=235');return false;">{{inline-svg "twitter"}} Tweet @TryGhost!</a></li>
             <li class="divider"></li>
-            <li role="presentation"><a class="dropdown-item help-menu-how-to" role="menuitem" tabindex="-1" href="http://support.ghost.org/how-to-use-ghost/" target="_blank">{{inline-svg "book-open"}} How to Use Ghost</a></li>
+            <li role="presentation"><a class="dropdown-item help-menu-how-to" role="menuitem" tabindex="-1" href="https://ghosthelp.zendesk.com/hc/en-us/categories/203268947-Ghost-Pro-" target="_blank">{{inline-svg "book-open"}} How to Use Ghost</a></li>
             <li role="presentation"><a class="dropdown-item help-menu-wishlist" role="menuitem" tabindex="-1" href="http://ideas.ghost.org/" target="_blank">{{inline-svg "idea"}} Wishlist</a></li>
             <li class="divider"></li>
             <li role="presentation">{{#link-to "signout" classNames="dropdown-item user-menu-signout" role="menuitem" tabindex="-1"}}{{inline-svg "signout"}} Sign Out{{/link-to}}</li>

--- a/app/templates/components/modals/markdown-help.hbs
+++ b/app/templates/components/modals/markdown-help.hbs
@@ -76,6 +76,6 @@
             </tr>
             </tbody>
         </table>
-        For further Markdown syntax reference: <a href="http://support.ghost.org/markdown-guide/" target="_blank">Markdown Documentation</a>
+        For further Markdown syntax reference: <a href="https://help.ghost.org/hc/en-us/articles/224410728-Markdown-Guide" target="_blank">Markdown Documentation</a>
     </section>
 </div>

--- a/app/templates/settings/labs.hbs
+++ b/app/templates/settings/labs.hbs
@@ -79,7 +79,7 @@
         <div class="gh-setting">
             <div class="gh-setting-content">
                 <div class="gh-setting-title">Public API</div>
-                <div class="gh-setting-desc">For full instructions, read the <a href="http://support.ghost.org/public-api-beta/">developer guide</a></div>
+                <div class="gh-setting-desc">For full instructions, read the <a href="https://help.ghost.org/hc/en-us/articles/115000301672-Public-API-Beta">developer guide</a></div>
             </div>
             <div class="gh-setting-action">
                 <div class="for-checkbox">{{gh-feature-flag "publicAPI"}}</div>
@@ -97,7 +97,7 @@
         <div class="gh-setting">
             <div class="gh-setting-content">
                 <div class="gh-setting-title">Subscribers</div>
-                <div class="gh-setting-desc">Collect email addresses from your readers, more info in <a href="http://support.ghost.org/subscribers-beta/">the docs</a></div>
+                <div class="gh-setting-desc">Collect email addresses from your readers, more info in <a href="https://help.ghost.org/hc/en-us/articles/224089787-Subscribers-Beta">the docs</a></div>
             </div>
             <div class="gh-setting-action">
                 <div class="for-checkbox">{{gh-feature-flag "subscribers"}}</div>


### PR DESCRIPTION
no issue
- support.ghost.org has gone away, we now have self-host/dev documentation on https://docs.ghost.org and user documentation at https://help.ghost.org