### PR TITLE
🐛 fix parenthesis in image alt text

### DIFF
--- a/app/utils/ed-image-manager.js
+++ b/app/utils/ed-image-manager.js
@@ -26,8 +26,8 @@ function getSrcRange(content, index) {
             replacement.start = content.indexOf(']', images[index].index) + 1;
             replacement.end = replacement.start;
         } else {
-            replacement.start = content.indexOf('(', images[index].index) + 1;
-            replacement.end = replacement.start + images[index][2].length;
+            replacement.end = images[index].index + images[index][0].length - 1;
+            replacement.start = content.lastIndexOf('(', replacement.end) + 1;
         }
         return replacement;
     }


### PR DESCRIPTION
fixes #8006
- update regex used to insert image filename in markdown after upload so that it doesn't get confused by parenthesis in the alt text