### PR TITLE
always give editor text area focus by default

### DIFF
--- a/app/mixins/editor-base-controller.js
+++ b/app/mixins/editor-base-controller.js
@@ -3,7 +3,7 @@ import Mixin from 'ember-metal/mixin';
 import PostModel from 'ghost-admin/models/post';
 import RSVP from 'rsvp';
 import boundOneWay from 'ghost-admin/utils/bound-one-way';
-import computed, {alias, mapBy, reads} from 'ember-computed';
+import computed, {mapBy, reads} from 'ember-computed';
 import ghostPaths from 'ghost-admin/utils/ghost-paths';
 import injectController from 'ember-controller/inject';
 import injectService from 'ember-service/inject';
@@ -49,9 +49,6 @@ export default Mixin.create({
     assetPath: ghostPaths().assetRoot,
     editor: null,
     editorMenuIsOpen: false,
-
-    shouldFocusTitle: alias('model.isNew'),
-    shouldFocusEditor: false,
 
     navIsClosed: reads('application.autoNav'),
 

--- a/app/routes/editor/edit.js
+++ b/app/routes/editor/edit.js
@@ -5,12 +5,6 @@ import base from 'ghost-admin/mixins/editor-base-route';
 export default AuthenticatedRoute.extend(base, {
     titleToken: 'Editor',
 
-    beforeModel(transition) {
-        this.set('_transitionedFromNew', transition.data.fromNew);
-
-        this._super(...arguments);
-    },
-
     model(params) {
         /* eslint-disable camelcase */
         let query = {
@@ -40,11 +34,6 @@ export default AuthenticatedRoute.extend(base, {
                 return this.replaceWith('posts.index');
             }
         });
-    },
-
-    setupController(controller) {
-        this._super(...arguments);
-        controller.set('shouldFocusEditor', this.get('_transitionedFromNew'));
     },
 
     actions: {

--- a/app/routes/editor/new.js
+++ b/app/routes/editor/new.js
@@ -17,15 +17,5 @@ export default AuthenticatedRoute.extend(base, {
             controller,
             model
         });
-    },
-
-    actions: {
-        willTransition(transition) {
-            // decorate the transition object so the editor.edit route
-            // knows this was the previous active route
-            transition.data.fromNew = true;
-
-            this._super(...arguments);
-        }
     }
 });

--- a/app/templates/editor/edit.hbs
+++ b/app/templates/editor/edit.hbs
@@ -35,8 +35,8 @@
     --}}
     {{#gh-markdown-editor
         tabindex="2"
-        placeholder="Click here to start..."
-        autofocus=shouldFocusEditor
+        placeholder="Now begin writing your story..."
+        autofocus=true
         uploadedImageUrls=editor.uploadedImageUrls
         mobiledoc=(readonly model.scratch)
         isFullScreen=editor.isFullScreen
@@ -54,7 +54,6 @@
                 class="gh-editor-title"
                 placeholder="Your Post Title"
                 tabindex="1"
-                shouldFocus=shouldFocusTitle
                 autoExpand=".gh-markdown-editor-pane"
                 focusOut=(action "saveTitle")
                 update=(action (perform updateTitle))


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8525
- always give focus to the editor content area by default when loading the editor
- change the editor placeholder text