### PR TITLE
🐛 Disable Table support

### DIFF
--- a/app/utils/format-markdown.js
+++ b/app/utils/format-markdown.js
@@ -12,6 +12,7 @@ let md = markdownit({
     breaks: true,
     linkify: true
 })
+.disable(['table'])
 .use(markdownitFootnote)
 .use(markdownitLazyHeaders)
 .use(markdownitMark)


### PR DESCRIPTION
- this was never meant to be enabled!
- we don't ever want to support tables via markdown, instead we want to offer a different solution in future

Documentation on how to manage rules: https://github.com/markdown-it/markdown-it#manage-rules
List of rules: https://github.com/markdown-it/markdown-it/issues/289

Ghost has always deliberately not supported markdown tables because it's a compatibility nightmare, and we intend to offer something better in future.
