### PR TITLE
💅🏼  Improve theme activation error messages

### DIFF
--- a/app/components/modals/theme-warnings.js
+++ b/app/components/modals/theme-warnings.js
@@ -5,6 +5,8 @@ export default ModalComponent.extend({
     title: reads('model.title'),
     message: reads('model.message'),
     warnings: reads('model.warnings'),
+    errors: reads('model.errors'),
+    fatalErrors: reads('model.fatalErrors'),
 
     'data-test-theme-warnings-modal': true
 });

--- a/app/templates/components/modals/theme-warnings.hbs
+++ b/app/templates/components/modals/theme-warnings.hbs
@@ -10,9 +10,35 @@
                 <p data-test-theme-warnings-message>{{message}}</p>
             </li>
         {{/if}}
+        {{#if fatalErrors}}
+            <div class="theme-validation-errordescription">
+                <h2 class="theme-validation-errortype fatal">Fatal Errors</h2>
+                <p><em>(Must-fix to activate theme)</em></p>
+            </div>
+        {{/if}}
+        {{#each fatalErrors as |error|}}
+            {{gh-theme-error-li error=error}}
+        {{/each}}
+
+        {{#if errors}}
+            <div class="theme-validation-errordescription">
+                <h2 class="theme-validation-errortype">Errors</h2>
+                <p><em>(Very recommended to fix, functionality <span>could</span> be restricted)</em></p>
+            </div>
+        {{/if}}
+        {{#each errors as |error|}}
+            {{gh-theme-error-li error=error}}
+        {{/each}}
+
+        {{#if warnings}}
+            <div class="theme-validation-errordescription">
+                <h2 class="theme-validation-errortype">Warnings</h2>
+            </div>
+        {{/if}}
         {{#each warnings as |error|}}
             {{gh-theme-error-li error=error}}
         {{/each}}
+
     </ul>
 </div>
 

--- a/app/templates/components/modals/upload-theme.hbs
+++ b/app/templates/components/modals/upload-theme.hbs
@@ -1,7 +1,7 @@
 <header class="modal-header">
     <h1>
         {{#if theme}}
-            {{#if validationWarnings}}
+            {{#if hasWarningsOrErrors}}
                 Upload successful with warnings/errors!
             {{else}}
                 Upload successful!

--- a/app/templates/settings/design.hbs
+++ b/app/templates/settings/design.hbs
@@ -46,8 +46,10 @@
             {{#if showThemeWarningsModal}}
                 {{gh-fullscreen-modal "theme-warnings"
                     model=(hash
-                        title="Theme activated with warnings"
+                        title="Activated successful with warnings/errors!"
                         warnings=themeWarnings
+                        errors=themeErrors
+                        message=message
                     )
                     close=(action "hideThemeWarningsModal")
                     modifier="action wide"}}
@@ -56,8 +58,9 @@
             {{#if showThemeErrorsModal}}
                 {{gh-fullscreen-modal "theme-warnings"
                     model=(hash
-                        title="Theme activation failed"
-                        warnings=themeWarnings
+                        title="Activation failed"
+                        errors=themeErrors
+                        fatalErrors=themeFatalErrors
                     )
                     close=(action "hideThemeWarningsModal")
                     modifier="action wide"}}

--- a/tests/acceptance/settings/design-test.js
+++ b/tests/acceptance/settings/design-test.js
@@ -511,7 +511,7 @@ describe('Acceptance: Settings - Design', function () {
             expect(
                 find(testSelector('theme-warnings-title')).text().trim(),
                 'modal title after activating invalid theme'
-            ).to.equal('Theme activation failed');
+            ).to.equal('Activation failed');
 
             expect(
                 find(testSelector('theme-warnings')).text(),
@@ -570,7 +570,7 @@ describe('Acceptance: Settings - Design', function () {
             expect(
                 find(testSelector('theme-warnings-title')).text().trim(),
                 'modal title after activating theme with warnings'
-            ).to.equal('Theme activated with warnings');
+            ).to.equal('Activated successful with warnings/errors!');
 
             expect(
                 find(testSelector('theme-warnings')).text(),


### PR DESCRIPTION
refs TryGhost/Ghost#8530

This PR takes care that the modals for theme activation gets the same treatment as theme upload modal:
- differentiate between normal and fatal errors
- List headings for each error type (fatal, normal or warning)
- update test

![theme_upload_activation](https://user-images.githubusercontent.com/8037602/27423348-832e707e-575b-11e7-9432-dfaf9cc62011.gif)
