### PR TITLE
💅🏼 Reduce meta description word count font-size

### DIFF
--- a/app/styles/patterns/forms.css
+++ b/app/styles/patterns/forms.css
@@ -65,7 +65,7 @@ input {
 .form-group p {
     margin: 4px 0 0 0;
     color: var(--midgrey);
-    font-size: 1.3rem;
+    font-size: 1.25rem;
 }
 
 .form-group h3 {


### PR DESCRIPTION
closes TryGhost/Ghost#8552

Reduce the `font-size` per `0.5rem` so it'll fit within the `700px` `max-width` of the parent container even with three numbers in word count.

---

Before:

![image](https://user-images.githubusercontent.com/8037602/27427699-16cec12c-576a-11e7-917b-4ae3abfe940a.png)

---

After:
![image](https://user-images.githubusercontent.com/8037602/27427726-340b4e36-576a-11e7-8f68-6f4b477f3a5c.png)

![image](https://user-images.githubusercontent.com/8037602/27427737-3e26152c-576a-11e7-8f11-bd151027060a.png)

![word_count](https://user-images.githubusercontent.com/8037602/27427569-a9499a82-5769-11e7-80b6-328e0bbe789c.gif)
