### PR TITLE
Disable simpleMDE image shortcut

### DIFF
--- a/app/components/gh-markdown-editor.js
+++ b/app/components/gh-markdown-editor.js
@@ -124,7 +124,8 @@ export default Component.extend(ShortcutsMixin, {
             shortcuts: {
                 toggleFullScreen: null,
                 togglePreview: null,
-                toggleSideBySide: null
+                toggleSideBySide: null,
+                drawImage: null
             },
 
             // only include the number of words in the status bar


### PR DESCRIPTION
No Issue

- disables simpleMDE image shortcut when using Cmd+alt+i