### PR TITLE
🐛  Add conditional to fix post scheduling

### DIFF
--- a/app/models/post.js
+++ b/app/models/post.js
@@ -193,7 +193,7 @@ export default Model.extend(Comparable, ValidationEngine, {
              *
              * See https://github.com/TryGhost/Ghost/issues/8603#issuecomment-309538395.
              */
-            if (publishedAtBlog.diff(publishedAtUTC.clone().startOf('minutes')) === 0) {
+            if (publishedAtUTC && publishedAtBlog.diff(publishedAtUTC.clone().startOf('minutes')) === 0) {
                 return publishedAtUTC;
             }
 


### PR DESCRIPTION
refs TryGhost/Ghost#8603
refs https://github.com/TryGhost/Ghost-Admin/pull/753

With https://github.com/TryGhost/Ghost-Admin/commit/68ffa29e31124c327372c74f091c6cff1feb3a15 we introduced a bug, that caused the Ghost Admin to crash when scheduling a blog post. Adding a check in the conditional prevents it from crashing and fixes the functionality.