### PR TITLE
🐛  Add CSSNano fix to minify keyframes properly

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -83,7 +83,17 @@ function postcssPlugins() {
 
     if (isProduction) {
         plugins.push({
-            module: require('cssnano')
+            module: require('cssnano'),
+            // cssnano minifies animations sometimes wrong, so they don't work anymore.
+            // See: https://github.com/ben-eb/gulp-cssnano/issues/33#issuecomment-210518957
+            options: {
+                reduceIdents: {
+                    keyframes: false
+                },
+                discardUnused: {
+                    keyframes: false
+                }
+            }
         });
     }
 


### PR DESCRIPTION
closes TryGhost/Ghost#8610

There's an issue in CSSnano, which we're using in production mode to minify our CSS that caused animation frames to not work properly anymore.
See: https://github.com/ben-eb/gulp-cssnano/issues/33#issuecomment-210518957