### PR TITLE
💄  Consistent layout for about page

### DIFF
--- a/app/templates/about.hbs
+++ b/app/templates/about.hbs
@@ -1,12 +1,8 @@
-<section class="gh-view js-settings-content">
-    <header class="view-header">
-        {{#gh-view-title openMobileMenu="openMobileMenu"}}<span>About Ghost</span>{{/gh-view-title}}
+<section class="gh-canvas js-settings-content">
+    <header class="gh-canvas-header">
+        <img class="gh-logo" src="assets/img/ghost-logo.png" alt="Ghost" />
     </header>
-    <section class="view-content">
-        <header class="gh-about-header">
-            <img class="gh-logo" src="assets/img/ghost-logo.png" alt="Ghost" />
-        </header>
-
+    <section class="view-container">
         {{gh-upgrade-notification}}
 
         <section class="gh-env-details">
@@ -18,7 +14,7 @@
             </ul>
             <div class="gh-env-help">
                 <a class="gh-btn" href="https://help.ghost.org" target="_blank"><span>User Documentation</span></a>
-                <a class="gh-btn" href="https://ghost.org/slack/" target="_blank"><span>Get Help With Ghost</span></a>
+                <a class="gh-btn" href="https://slack.ghost.org/" target="_blank"><span>Get Help With Ghost</span></a>
             </div>
         </section>
 
@@ -31,7 +27,7 @@
 
             <p>Ghost is built by an incredible group of contributors from all over the world. Here are just a few of the people who helped create the version you’re using right now.</p>
 
-            <a class="gh-btn gh-btn-blue" href="https://ghost.org/about/contribute/" target="_blank"><span>Find out how you can get involved</span></a>
+            <a class="gh-btn gh-btn-blue" href="https://ghost.org/developers/" target="_blank"><span>Find out how you can get involved</span></a>
 
         </section>
 


### PR DESCRIPTION
closes TryGhost/Ghost#8623

Uses the same classes as the other pages for more consistency and sexiness. Also updated the links to slack and contributers to be correct.

![image](https://user-images.githubusercontent.com/8037602/27632267-680a6f5e-5c25-11e7-91cf-bb2a77ed4846.png)
