### PR TITLE
💅🏼  Set width of search input to almost 100%

### DIFF
--- a/app/styles/components/power-select.css
+++ b/app/styles/components/power-select.css
@@ -65,6 +65,7 @@
     margin: 0 1px !important;
     padding: 0 !important;
     min-height: 0 !important;
+    width: calc(100% - 8px) !important;
     max-width: 100% !important;
     max-height: none !important;
     border: 0 none !important;


### PR DESCRIPTION
closes TryGhost/Ghost#8630

Add `width: 100%` to `.ember-power-select-search input` class so the input field is full width.

### Before:
![search_input](https://user-images.githubusercontent.com/8037602/27674263-26c7dca2-5ccf-11e7-8c20-ca98f0d19698.gif)

### After:
![search_input](https://user-images.githubusercontent.com/8037602/27674319-5acfed28-5ccf-11e7-9e7a-431f2d8dd342.gif)
