### PR TITLE
Fix enter key doesn't submit sign-in form

### DIFF
--- a/app/mixins/text-input.js
+++ b/app/mixins/text-input.js
@@ -46,15 +46,6 @@ export default Mixin.create({
         this._super(...arguments);
     },
 
-    keyPress(event) {
-        // prevent default ENTER behaviour if we have a keyEvent for it
-        if (event.keyCode === 13 && this.get('keyEvents.13')) {
-            event.preventDefault();
-        }
-
-        this._super(...arguments);
-    },
-
     _focus() {
         // Until mobile safari has better support
         // for focusing, we just ignore it


### PR DESCRIPTION
closes TryGhost/Ghost#8588

As discuss in issue, I removed keyPress hook on text-input mixin. This hook was blocking form submission by pressing ENTER key on text input as it prevents event default when key is ENTER.
