### PR TITLE
Fix for broken image upload button

### DIFF
--- a/app/components/gh-markdown-editor.js
+++ b/app/components/gh-markdown-editor.js
@@ -311,7 +311,7 @@ export default Component.extend(ShortcutsMixin, {
         delete this._onEditorPaneScroll;
     },
 
-    _openImageFileDialog({captureSelection = true}) {
+    _openImageFileDialog({captureSelection = true} = {}) {
         if (captureSelection) {
             // capture the current selection before it's lost by clicking the
             // file input button


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8637
- add a default object to `_openImageFileDialog` args so that destructuring with default params works when not passed a value