### PR TITLE
Focus editor content area by default (attempt 2 😁) 

### DIFF
--- a/app/components/gh-post-settings-menu.js
+++ b/app/components/gh-post-settings-menu.js
@@ -40,7 +40,9 @@ export default Component.extend(SettingsMenuMixin, {
         this._super(...arguments);
 
         this.get('store').query('user', {limit: 'all'}).then((users) => {
-            this.set('authors', users.sortBy('name'));
+            if (!this.get('isDestroyed')) {
+                this.set('authors', users.sortBy('name'));
+            }
         });
 
         this.get('model.author').then((author) => {

--- a/app/components/gh-textarea.js
+++ b/app/components/gh-textarea.js
@@ -48,8 +48,10 @@ export default OneWayTextarea.extend(TextInputMixin, {
 
         // collapse the element first so that we can shrink as well as expand
         // then set the height to match the text height
-        el.style.height = 0;
-        el.style.height = `${el.scrollHeight}px`;
+        if (el) {
+            el.style.height = 0;
+            el.style.height = `${el.scrollHeight}px`;
+        }
     },
 
     _setupAutoExpand() {

--- a/app/controllers/editor/new.js
+++ b/app/controllers/editor/new.js
@@ -1,23 +1,6 @@
 import Controller from 'ember-controller';
 import EditorControllerMixin from 'ghost-admin/mixins/editor-base-controller';
 
-function K() {
-    return this;
-}
-
 export default Controller.extend(EditorControllerMixin, {
-    // Overriding autoSave on the base controller, as the new controller shouldn't be autosaving
-    autoSave: K,
-    actions: {
-        /**
-          * Redirect to editor after the first save
-          */
-        save(options) {
-            return this._super(options).then((model) => {
-                if (model.get('id')) {
-                    this.replaceRoute('editor.edit', model);
-                }
-            });
-        }
-    }
+
 });

--- a/app/mixins/editor-base-route.js
+++ b/app/mixins/editor-base-route.js
@@ -50,9 +50,10 @@ export default Mixin.create(styleBody, ShortcutsRoute, {
             // so we abort the transition and retry after the save has completed.
             if (state.isSaving) {
                 transition.abort();
-                controller.get('generateSlug.last').then(() => {
+                controller.get('saveTasks.last').then(() => {
                     transition.retry();
                 });
+                return;
             }
 
             fromNewToEdit = this.get('routeName') === 'editor.new'

--- a/app/routes/editor/edit.js
+++ b/app/routes/editor/edit.js
@@ -5,12 +5,6 @@ import base from 'ghost-admin/mixins/editor-base-route';
 export default AuthenticatedRoute.extend(base, {
     titleToken: 'Editor',
 
-    beforeModel(transition) {
-        this.set('_transitionedFromNew', transition.data.fromNew);
-
-        this._super(...arguments);
-    },
-
     model(params) {
         /* eslint-disable camelcase */
         let query = {
@@ -40,11 +34,6 @@ export default AuthenticatedRoute.extend(base, {
                 return this.replaceWith('posts.index');
             }
         });
-    },
-
-    setupController(controller) {
-        this._super(...arguments);
-        controller.set('shouldFocusEditor', this.get('_transitionedFromNew'));
     },
 
     actions: {

--- a/app/routes/editor/new.js
+++ b/app/routes/editor/new.js
@@ -17,15 +17,5 @@ export default AuthenticatedRoute.extend(base, {
             controller,
             model
         });
-    },
-
-    actions: {
-        willTransition(transition) {
-            // decorate the transition object so the editor.edit route
-            // knows this was the previous active route
-            transition.data.fromNew = true;
-
-            this._super(...arguments);
-        }
     }
 });

--- a/app/templates/editor/edit.hbs
+++ b/app/templates/editor/edit.hbs
@@ -35,8 +35,8 @@
     --}}
     {{#gh-markdown-editor
         tabindex="2"
-        placeholder="Click here to start..."
-        autofocus=shouldFocusEditor
+        placeholder="Now begin writing your story..."
+        autofocus=true
         uploadedImageUrls=editor.uploadedImageUrls
         mobiledoc=(readonly model.scratch)
         isFullScreen=editor.isFullScreen
@@ -54,7 +54,6 @@
                 class="gh-editor-title"
                 placeholder="Your Post Title"
                 tabindex="1"
-                shouldFocus=shouldFocusTitle
                 autoExpand=".gh-markdown-editor-pane"
                 focusOut=(action "saveTitle")
                 update=(action (perform updateTitle))


### PR DESCRIPTION
closes TryGhost/Ghost#8525
- always give focus to the editor content area by default when loading the editor
- allow content autosave to work for new posts (it was previously turned off for new posts)
- move transition-on-save behaviour from editor/new controller into the controller mixin's save routine
- cancel background autosave when "are you sure you want to leave?" modal is shown as it can cause the "leave" option to fail because it attempts to delete the post record that can be in flight (plus if we're saving anyway it doesn't make much sense to ask the user  🙈) - this is quite an edge-case as it will only happen if the user makes a content change to a draft post then tries to leave the screen within 3 seconds
- change the editor placeholder text