### PR TITLE
🎨 fix editor header not covering scrolled content

### DIFF
--- a/app/styles/app-dark.css
+++ b/app/styles/app-dark.css
@@ -250,6 +250,10 @@ input,
     background: rgba(0,0,0,0.2);
 }
 
+.gh-editor-header-small {
+    background: #263238;
+}
+
 .gh-editor .CodeMirror-cursor {
     border-color: #fff;
 }

--- a/app/styles/layouts/editor.css
+++ b/app/styles/layouts/editor.css
@@ -170,6 +170,7 @@
     height: 43px;
     padding: 0;
     padding-left: 15px;
+    background-color: #fff;
     border-bottom: var(--lightgrey) 1px solid;
     z-index: 100;
 }


### PR DESCRIPTION
no issue
- background color of the editor header at smaller screen sizes had been removed resulting in the editor content showing through when scrolling, this adds the explicit bg color back for both normal and dark mode