### PR TITLE
🐛 fix display/message bugs in re-auth modal

### DIFF
--- a/app/components/modals/re-authenticate.js
+++ b/app/components/modals/re-authenticate.js
@@ -45,16 +45,17 @@ export default ModalComponent.extend(ValidationEngine, {
         this.set('authenticationError', null);
 
         return this.validate({property: 'signin'}).then(() => {
-            this._authenticate().then(() => {
+            return this._authenticate().then(() => {
                 this.get('notifications').closeAlerts();
                 this.send('closeModal');
+                return true;
             }).catch((error) => {
                 if (error && error.errors) {
                     error.errors.forEach((err) => {
                         if (isVersionMismatchError(err)) {
                             return this.get('notifications').showAPIError(error);
                         }
-                        err.message = htmlSafe(err.message);
+                        err.message = htmlSafe(err.context || err.message);
                     });
 
                     this.get('errors').add('password', 'Incorrect password');
@@ -64,6 +65,7 @@ export default ModalComponent.extend(ValidationEngine, {
             });
         }, () => {
             this.get('hasValidated').pushObject('password');
+            return false;
         });
     },
 
@@ -95,9 +97,9 @@ export default ModalComponent.extend(ValidationEngine, {
 
     reauthenticate: task(function* () {
         if (this.get('config.ghostOAuth')) {
-            yield this._oauthConfirm();
+            return yield this._oauthConfirm();
         } else {
-            yield this._passwordConfirm();
+            return yield this._passwordConfirm();
         }
     }).drop(),
 

--- a/app/styles/components/modals.css
+++ b/app/styles/components/modals.css
@@ -183,8 +183,10 @@
 @media (min-width: 901px) {
     .modal-body .login-form {
         display: flex;
+        align-items: center;
     }
     .modal-body .login-form .password-wrap {
         flex: 1;
+        margin-right: 10px;
     }
 }


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8656
- prevents button stretching from flexbox and adds margin between input and button
- use the `context` attribute returned from the server instead of the `message` so the error is now `Your password is incorrect.` instead of `You are not authorised to make this request.`
- return truthy/falsy values from the auth tasks so that the save-state button shows the correct state

![re-auth-fixes](https://user-images.githubusercontent.com/415/27835276-3229d094-60d2-11e7-8208-af83b08e82da.gif)
