### PR TITLE
🐛 fix enter key not working in text inputs/areas

### DIFF
--- a/app/mixins/text-input.js
+++ b/app/mixins/text-input.js
@@ -39,7 +39,7 @@ export default Mixin.create({
         }
 
         // prevent default TAB behaviour if we have a keyEvent for it
-        if (event.keyCode === 9 && this.get('keyEvents.9')) {
+        if (event.keyCode === 9 && typeof this.get('keyEvents.9') === 'function') {
             event.preventDefault();
         }
 
@@ -48,7 +48,7 @@ export default Mixin.create({
 
     keyPress(event) {
         // prevent default ENTER behaviour if we have a keyEvent for it
-        if (event.keyCode === 13 && this.get('keyEvents.13')) {
+        if (event.keyCode === 13 && typeof this.get('keyEvents.13') === 'function') {
             event.preventDefault();
         }
 


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8588, closes https://github.com/TryGhost/Ghost/issues/8639
- check that we have an action assigned to keyEvent codes before attempting to prevent the default behaviour
- no tests because browsers don't trigger form submissions in response to JS key events as a security measure