### PR TITLE
🐛 prevent session sync issues with multiple tabs/refreshes

### DIFF
--- a/mirage/config/authentication.js
+++ b/mirage/config/authentication.js
@@ -15,16 +15,16 @@ export default function mockAuthentication(server) {
             }
 
             return {
-                access_token: '5JhTdKI7PpoZv4ROsFoERc6wCHALKFH5jxozwOOAErmUzWrFNARuH1q01TYTKeZkPW7FmV5MJ2fU00pg9sm4jtH3Z1LjCf8D6nNqLYCfFb2YEKyuvG7zHj4jZqSYVodN2YTCkcHv6k8oJ54QXzNTLIDMlCevkOebm5OjxGiJpafMxncm043q9u1QhdU9eee3zouGRMVVp8zkKVoo5zlGMi3zvS2XDpx7xsfk8hKHpUgd7EDDQxmMueifWv7hv6n',
-                expires_in: 3600,
-                refresh_token: 'XP13eDjwV5mxOcrq1jkIY9idhdvN3R1Br5vxYpYIub2P5Hdc8pdWMOGmwFyoUshiEB62JWHTl8H1kACJR18Z8aMXbnk5orG28br2kmVgtVZKqOSoiiWrQoeKTqrRV0t7ua8uY5HdDUaKpnYKyOdpagsSPn3WEj8op4vHctGL3svOWOjZhq6F2XeVPMR7YsbiwBE8fjT3VhTB3KRlBtWZd1rE0Qo2EtSplWyjGKv1liAEiL0ndQoLeeSOCH4rTP7'
+                access_token: 'MirageAccessToken',
+                expires_in: 172800,
+                refresh_token: 'MirageRefreshToken'
             };
         } else {
             // Password sign-in
             return {
-                access_token: '5JhTdKI7PpoZv4ROsFoERc6wCHALKFH5jxozwOOAErmUzWrFNARuH1q01TYTKeZkPW7FmV5MJ2fU00pg9sm4jtH3Z1LjCf8D6nNqLYCfFb2YEKyuvG7zHj4jZqSYVodN2YTCkcHv6k8oJ54QXzNTLIDMlCevkOebm5OjxGiJpafMxncm043q9u1QhdU9eee3zouGRMVVp8zkKVoo5zlGMi3zvS2XDpx7xsfk8hKHpUgd7EDDQxmMueifWv7hv6n',
-                expires_in: 3600,
-                refresh_token: 'XP13eDjwV5mxOcrq1jkIY9idhdvN3R1Br5vxYpYIub2P5Hdc8pdWMOGmwFyoUshiEB62JWHTl8H1kACJR18Z8aMXbnk5orG28br2kmVgtVZKqOSoiiWrQoeKTqrRV0t7ua8uY5HdDUaKpnYKyOdpagsSPn3WEj8op4vHctGL3svOWOjZhq6F2XeVPMR7YsbiwBE8fjT3VhTB3KRlBtWZd1rE0Qo2EtSplWyjGKv1liAEiL0ndQoLeeSOCH4rTP7',
+                access_token: 'MirageAccessToken',
+                expires_in: 172800,
+                refresh_token: 'MirageRefreshToken',
                 token_type: 'Bearer'
             };
         }

--- a/tests/acceptance/settings/tags-test.js
+++ b/tests/acceptance/settings/tags-test.js
@@ -10,6 +10,7 @@ import {afterEach, beforeEach, describe, it} from 'mocha';
 import {authenticateSession, invalidateSession} from 'ghost-admin/tests/helpers/ember-simple-auth';
 import {errorOverride, errorReset} from 'ghost-admin/tests/helpers/adapter-error';
 import {expect} from 'chai';
+import {timeout} from 'ember-concurrency';
 
 // Grabbed from keymaster's testing code because Ember's `keyEvent` helper
 // is for some reason not triggering the events in a way that keymaster detects:
@@ -182,6 +183,11 @@ describe('Acceptance: Settings - Tags', function () {
             // save new tag
             await fillIn('.tag-settings-pane input[name="name"]', 'New Tag');
             await triggerEvent('.tag-settings-pane input[name="name"]', 'blur');
+
+            // extra timeout needed for FF on Linux - sometimes it doesn't update
+            // quick enough, especially on Travis, and an extra wait() call
+            // doesn't help
+            await timeout(100);
 
             // it redirects to the new tag's URL
             expect(currentURL(), 'URL after tag creation').to.equal('/settings/tags/new-tag');

--- a/tests/acceptance/signin-test.js
+++ b/tests/acceptance/signin-test.js
@@ -58,9 +58,9 @@ describe('Acceptance: Signin', function() {
 
                 if (password === 'testpass') {
                     return {
-                        access_token: '5JhTdKI7PpoZv4ROsFoERc6wCHALKFH5jxozwOOAErmUzWrFNARuH1q01TYTKeZkPW7FmV5MJ2fU00pg9sm4jtH3Z1LjCf8D6nNqLYCfFb2YEKyuvG7zHj4jZqSYVodN2YTCkcHv6k8oJ54QXzNTLIDMlCevkOebm5OjxGiJpafMxncm043q9u1QhdU9eee3zouGRMVVp8zkKVoo5zlGMi3zvS2XDpx7xsfk8hKHpUgd7EDDQxmMueifWv7hv6n',
+                        access_token: 'MirageAccessToken',
                         expires_in: 3600,
-                        refresh_token: 'XP13eDjwV5mxOcrq1jkIY9idhdvN3R1Br5vxYpYIub2P5Hdc8pdWMOGmwFyoUshiEB62JWHTl8H1kACJR18Z8aMXbnk5orG28br2kmVgtVZKqOSoiiWrQoeKTqrRV0t7ua8uY5HdDUaKpnYKyOdpagsSPn3WEj8op4vHctGL3svOWOjZhq6F2XeVPMR7YsbiwBE8fjT3VhTB3KRlBtWZd1rE0Qo2EtSplWyjGKv1liAEiL0ndQoLeeSOCH4rTP7',
+                        refresh_token: 'MirageRefreshToken',
                         token_type: 'Bearer'
                     };
                 } else {


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/8616
- only refresh tokens on boot if we last refreshed more than 24hrs ago - this should prevent rapidly changing access/refresh tokens when opening new admin tabs or refreshing whilst other tabs are open
- fix token refresh test which was testing it's own behaviour instead of the applications 🙈

This may not be the full solution to the session issues but it closes one potential culprit and should at least reduce token churn which can only help track down the real cause.