### PR TITLE
🚀 supercharge tags performance

### DIFF
--- a/app/components/gh-tag.js
+++ b/app/components/gh-tag.js
@@ -1,15 +1,5 @@
 import Component from 'ember-component';
-import injectService from 'ember-service/inject';
-import {invokeAction} from 'ember-invoke-action';
 
 export default Component.extend({
-    feature: injectService(),
-
-    willDestroyElement() {
-        this._super(...arguments);
-
-        if (this.get('tag.isDeleted') && this.get('onDelete')) {
-            invokeAction(this, 'onDelete');
-        }
-    }
+    tagName: ''
 });

--- a/app/components/power-select-vertical-collection-options.js
+++ b/app/components/power-select-vertical-collection-options.js
@@ -1,0 +1,6 @@
+import OptionsComponent from 'ember-power-select/components/power-select/options';
+import layout from '../templates/components/power-select-vertical-collection-options';
+
+export default OptionsComponent.extend({
+    layout
+});

--- a/app/controllers/posts.js
+++ b/app/controllers/posts.js
@@ -17,8 +17,6 @@ export default Controller.extend({
     _hasLoadedTags: false,
     _hasLoadedAuthors: false,
 
-    showDeletePostModal: false,
-
     availableTypes: [{
         name: 'All posts',
         value: null
@@ -101,10 +99,6 @@ export default Controller.extend({
     }),
 
     actions: {
-        toggleDeletePostModal() {
-            this.toggleProperty('showDeletePostModal');
-        },
-
         changeType(type) {
             this.set('type', get(type, 'value'));
         },

--- a/app/controllers/settings/tags.js
+++ b/app/controllers/settings/tags.js
@@ -1,5 +1,6 @@
 import Controller from 'ember-controller';
 import injectController from 'ember-controller/inject';
+import run from 'ember-runloop';
 import {alias, equal, sort} from 'ember-computed';
 
 export default Controller.extend({
@@ -12,7 +13,7 @@ export default Controller.extend({
     tagContentFocused: equal('keyboardFocus', 'tagContent'),
 
     // TODO: replace with ordering by page count once supported by the API
-    tags: sort('model', function (a, b) {
+    sortedTags: sort('model', function (a, b) {
         let idA = +a.get('id');
         let idB = +b.get('id');
 
@@ -24,6 +25,30 @@ export default Controller.extend({
 
         return 0;
     }),
+
+    scrollTagIntoView(tag) {
+        run.scheduleOnce('afterRender', this, function () {
+            let id = `#gh-tag-${tag.get('id')}`;
+            let element = document.querySelector(id);
+
+            if (element) {
+                let scroll = document.querySelector('.tag-list');
+                let {scrollTop} = scroll;
+                let scrollHeight = scroll.offsetHeight;
+                let element = document.querySelector(id);
+                let elementTop = element.offsetTop;
+                let elementHeight = element.offsetHeight;
+
+                if (elementTop < scrollTop) {
+                    element.scrollIntoView(true);
+                }
+
+                if (elementTop + elementHeight > scrollTop + scrollHeight) {
+                    element.scrollIntoView(false);
+                }
+            }
+        });
+    },
 
     actions: {
         leftMobile() {

--- a/app/routes/posts.js
+++ b/app/routes/posts.js
@@ -1,11 +1,10 @@
 import $ from 'jquery';
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 import InfinityRoute from 'ember-infinity/mixins/route';
-import ShortcutsRoute from 'ghost-admin/mixins/shortcuts-route';
 import {assign} from 'ember-platform';
 import {isBlank} from 'ember-utils';
 
-export default AuthenticatedRoute.extend(InfinityRoute, ShortcutsRoute, {
+export default AuthenticatedRoute.extend(InfinityRoute, {
     titleToken: 'Content',
 
     perPage: 30,
@@ -32,7 +31,6 @@ export default AuthenticatedRoute.extend(InfinityRoute, ShortcutsRoute, {
     },
 
     _type: null,
-    _selectedPostIndex: null,
 
     model(params) {
         return this.get('session.user').then((user) => {
@@ -121,50 +119,8 @@ export default AuthenticatedRoute.extend(InfinityRoute, ShortcutsRoute, {
         });
     },
 
-    stepThroughPosts(step) {
-        let currentPost = this.get('controller.selectedPost');
-        let posts = this.get('controller.model');
-        let length = posts.get('length');
-        let newPosition;
-
-        // when the currentPost is deleted we won't be able to use indexOf.
-        // we keep track of the index locally so we can select next after deletion
-        if (this._selectedPostIndex !== null && length) {
-            newPosition = this._selectedPostIndex + step;
-        } else {
-            newPosition = posts.indexOf(currentPost) + step;
-        }
-
-        // if we are on the first or last item
-        // just do nothing (desired behavior is to not
-        // loop around)
-        if (newPosition >= length) {
-            return;
-        } else if (newPosition < 0) {
-            return;
-        }
-
-        this._selectedPostIndex = newPosition;
-        this.set('controller.selectedPost', posts.objectAt(newPosition));
-    },
-
-    shortcuts: {
-        'up, k': 'moveUp',
-        'down, j': 'moveDown',
-        'enter': 'editPost',
-        'c': 'newPost',
-        'command+backspace, ctrl+backspace': 'deletePost'
-    },
-
-    resetController() {
-        this.set('controller.selectedPost', null);
-        this.set('controller.showDeletePostModal', false);
-    },
-
     actions: {
         willTransition() {
-            this._selectedPostIndex = null;
-
             if (this.get('controller')) {
                 this.resetController();
             }
@@ -175,35 +131,6 @@ export default AuthenticatedRoute.extend(InfinityRoute, ShortcutsRoute, {
             $('.content-list').scrollTop(0);
 
             this._super(...arguments);
-        },
-
-        newPost() {
-            this.transitionTo('editor.new');
-        },
-
-        moveUp() {
-            this.stepThroughPosts(-1);
-        },
-
-        moveDown() {
-            this.stepThroughPosts(1);
-        },
-
-        editPost() {
-            let selectedPost = this.get('controller.selectedPost');
-
-            if (selectedPost) {
-                this.transitionTo('editor.edit', selectedPost.get('id'));
-            }
-        },
-
-        deletePost() {
-            this.get('controller').send('toggleDeletePostModal');
-        },
-
-        onPostDeletion() {
-            // select next post (re-select the current index)
-            this.stepThroughPosts(0);
         }
     }
 });

--- a/app/routes/settings/tags/tag.js
+++ b/app/routes/settings/tags/tag.js
@@ -11,6 +11,11 @@ export default AuthenticatedRoute.extend({
         return {tag_slug: model.get('slug')};
     },
 
+    setupController(controller, model) {
+        this._super(...arguments);
+        this.controllerFor('settings.tags').scrollTagIntoView(model);
+    },
+
     // reset the model so that mobile screens react to an empty selectedTag
     deactivate() {
         this._super(...arguments);

--- a/app/styles/layouts/content.css
+++ b/app/styles/layouts/content.css
@@ -79,7 +79,8 @@
 }
 
 .gh-contentfilter-menu-dropdown {
-    min-width: 150px;
+    width: 180px;
+    max-height: 220px;
     margin-top: 10px;
     padding: 5px 0 7px 0;
     border: none !important;
@@ -91,6 +92,12 @@
 .gh-contentfilter-menu-dropdown .ember-power-select-search input {
     display: block !important;
     margin: 0 10px !important;
+}
+
+.gh-contentfilter-menu-dropdown .ember-power-select-option {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 

--- a/app/templates/components/gh-tag.hbs
+++ b/app/templates/components/gh-tag.hbs
@@ -1,4 +1,4 @@
-<div class="settings-tag">
+<div class="settings-tag" id="gh-tag-{{tag.id}}">
     {{#link-to 'settings.tags.tag' tag class="tag-edit-button"}}
         <span class="tag-title">{{tag.name}}</span>
         <span class="label label-default">/{{tag.slug}}</span>

--- a/app/templates/components/power-select-vertical-collection-options.hbs
+++ b/app/templates/components/power-select-vertical-collection-options.hbs
@@ -1,0 +1,16 @@
+{{#if select.loading}}
+    {{#if loadingMessage}}
+        <li class="ember-power-select-option ember-power-select-option--loading-message" role="option">{{loadingMessage}}</li>
+    {{/if}}
+{{/if}}
+
+{{#vertical-collection options minHeight=30 staticHeight=true bufferSize=5 as |opt index|}}
+    <li class="ember-power-select-option"
+        aria-selected="{{ember-power-select-is-selected opt select.selected}}"
+        aria-disabled={{ember-power-select-true-string-if-present opt.disabled}}
+        aria-current="{{eq opt select.highlighted}}"
+        data-option-index="{{groupIndex}}{{index}}"
+        role="option">
+        {{yield opt select}}
+    </li>
+{{/vertical-collection}}

--- a/app/templates/posts.hbs
+++ b/app/templates/posts.hbs
@@ -86,7 +86,6 @@
             {{#each model as |post|}}
                 {{gh-posts-list-item
                     post=post
-                    active=(eq post selectedPost)
                     onDoubleClick="openEditor"
                     data-test-post-id=post.id}}
             {{else}}
@@ -109,16 +108,6 @@
             scrollable=".gh-main"
             triggerOffset=1000}}
     </section>
-
-    {{#if showDeletePostModal}}
-        {{gh-fullscreen-modal "delete-post"
-            model=(hash
-                post=selectedPost
-                onSuccess=(route-action 'onPostDeletion')
-            )
-            close=(action "toggleDeletePostModal")
-            modifier="action wide"}}
-    {{/if}}
 
     {{outlet}}
 </section>

--- a/app/templates/posts.hbs
+++ b/app/templates/posts.hbs
@@ -53,6 +53,7 @@
                 dropdownClass="gh-contentfilter-menu-dropdown"
                 searchPlaceholder="Search tags"
                 matchTriggerWidth=false
+                optionsComponent="power-select-vertical-collection-options"
                 data-test-tag-select=true
                 as |tag|
             }}

--- a/app/templates/settings/tags.hbs
+++ b/app/templates/settings/tags.hbs
@@ -7,18 +7,19 @@
     </header>
 
     {{#gh-tags-management-container tags=tags selectedTag=selectedTag enteredMobile="enteredMobile" leftMobile="leftMobile" as |container|}}
-        {{#gh-infinite-scroll
-            fetch="loadNextPage"
-            isLoading=isLoading
-            classNames="tag-list"
-            as |checkScroll|
-        }}
+        <div class="tag-list">
             <section class="tag-list-content settings-tags {{if tagListFocused 'keyboard-focused'}}">
-                {{#each tags as |tag|}}
-                    {{gh-tag tag=tag onDelete=(action checkScroll)}}
-                {{/each}}
+                {{#vertical-collection sortedTags
+                    minHeight=67
+                    staticHeight=true
+                    bufferSize=5
+                    containerSelector=".tag-list"
+                    as |tag|
+                }}
+                    {{gh-tag tag=tag}}
+                {{/vertical-collection}}
             </section>
-        {{/gh-infinite-scroll}}
+        </div>
         <section class="settings-menu-container tag-settings {{if tagContentFocused 'keyboard-focused'}} {{if container.displaySettingsPane 'tag-settings-in'}}">
             {{outlet}}
         </section>

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "node": ">= 4"
   },
   "devDependencies": {
+    "@html-next/vertical-collection": "^1.0.0-beta.4",
     "autoprefixer": "6.7.7",
     "blueimp-md5": "2.7.0",
     "bower": "1.8.0",

--- a/tests/acceptance/settings/tags-test.js
+++ b/tests/acceptance/settings/tags-test.js
@@ -4,6 +4,7 @@ import $ from 'jquery';
 import destroyApp from '../../helpers/destroy-app';
 import run from 'ember-runloop';
 import startApp from '../../helpers/start-app';
+import wait from 'ember-test-helpers/wait';
 import {Response} from 'ember-cli-mirage';
 import {afterEach, beforeEach, describe, it} from 'mocha';
 import {authenticateSession, invalidateSession} from 'ghost-admin/tests/helpers/ember-simple-auth';
@@ -79,6 +80,9 @@ describe('Acceptance: Settings - Tags', function () {
 
             await visit('/settings/tags');
 
+            // second wait is needed for the vertical-collection to settle
+            await wait();
+
             // it redirects to first tag
             expect(currentURL(), 'currentURL').to.equal(`/settings/tags/${tag1.slug}`);
 
@@ -125,6 +129,8 @@ describe('Acceptance: Settings - Tags', function () {
                 keyup(38);
             });
 
+            await wait();
+
             // it navigates to previous tag
             expect(currentURL(), 'url after keyboard up arrow').to.equal(`/settings/tags/${tag1.slug}`);
 
@@ -137,6 +143,8 @@ describe('Acceptance: Settings - Tags', function () {
                 keydown(40);
                 keyup(40);
             });
+
+            await wait();
 
             // it navigates to previous tag
             expect(currentURL(), 'url after keyboard down arrow').to.equal(`/settings/tags/${tag2.slug}`);
@@ -203,6 +211,9 @@ describe('Acceptance: Settings - Tags', function () {
 
             await visit('/settings/tags/tag-1');
 
+            // second wait is needed for the vertical-collection to settle
+            await wait();
+
             expect(currentURL(), 'URL after direct load').to.equal('/settings/tags/tag-1');
 
             // it loads all other tags
@@ -218,38 +229,13 @@ describe('Acceptance: Settings - Tags', function () {
                 .to.equal('Tag 1');
         });
 
-        it('has infinite scroll pagination of tags list', async function () {
-            server.createList('tag', 32);
-
-            await visit('settings/tags/tag-0');
-
-            // it loads first page
-            expect(find('.settings-tags .settings-tag').length, 'tag list count on first load')
-                .to.equal(15);
-
-            await find('.tag-list').scrollTop(find('.tag-list-content').height());
-            await triggerEvent('.tag-list', 'scroll');
-
-            // it loads the second page
-            expect(find('.settings-tags .settings-tag').length, 'tag list count on second load')
-                .to.equal(30);
-
-            await find('.tag-list').scrollTop(find('.tag-list-content').height());
-
-            // NOTE: FF has issues with scrolling further in acceptance tests
-            // but works fine outside of tests
-            //
-            // await triggerEvent('.tag-list', 'scroll');
-            //
-            // // it loads the final page
-            // expect(find('.settings-tags .settings-tag').length, 'tag list count on third load')
-            //     .to.equal(32);
-        });
-
         it('shows the internal tag label', async function () {
             server.create('tag', {name: '#internal-tag', slug: 'hash-internal-tag', visibility: 'internal'});
 
             await visit('settings/tags/');
+
+            // second wait is needed for the vertical-collection to settle
+            await wait();
 
             expect(currentURL()).to.equal('/settings/tags/hash-internal-tag');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -86,6 +86,20 @@
   dependencies:
     "@glimmer/util" "^0.22.0"
 
+"@html-next/vertical-collection@^1.0.0-beta.4":
+  version "1.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@html-next/vertical-collection/-/vertical-collection-1.0.0-beta.4.tgz#f159020a1b1a6e48b5a271d61e2e0ab2d91927cc"
+  dependencies:
+    babel-plugin-filter-imports "^0.3.1"
+    babel-plugin-transform-es2015-block-scoping "^6.24.1"
+    babel6-plugin-strip-class-callcheck "^6.0.0"
+    broccoli-funnel "^1.2.0"
+    broccoli-merge-trees "^2.0.0"
+    broccoli-rollup "^1.2.0"
+    chalk "^1.1.3"
+    ember-cli-babel "^6.0.0-beta.10"
+    ember-cli-htmlbars "^1.1.1"
+
 JSONStream@^1.0.3:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.1.tgz#707f761e01dae9e16f1bcf93703b78c70966579a"
@@ -612,6 +626,18 @@ babel-plugin-debug-macros@^0.1.1, babel-plugin-debug-macros@^0.1.6:
   dependencies:
     semver "^5.3.0"
 
+babel-plugin-debug-macros@^0.1.11:
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.1.11.tgz#6c562bf561fccd406ce14ab04f42c218cf956605"
+  dependencies:
+    semver "^5.3.0"
+
+babel-plugin-ember-modules-api-polyfill@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-1.4.1.tgz#2b05e1b37e492449319a9cc2bdca460cda70b5b1"
+  dependencies:
+    ember-rfc176-data "^0.1.0"
+
 babel-plugin-eval@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz#a2faed25ce6be69ade4bfec263f70169195950da"
@@ -702,7 +728,7 @@ babel-plugin-transform-es2015-block-scoped-functions@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-block-scoping@^6.23.0:
+babel-plugin-transform-es2015-block-scoping@^6.23.0, babel-plugin-transform-es2015-block-scoping@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz#76c295dc3a4741b1665adfd3167215dcff32a576"
   dependencies:
@@ -930,6 +956,41 @@ babel-preset-env@^1.2.0:
     babel-plugin-transform-regenerator "^6.22.0"
     browserslist "^1.4.0"
     invariant "^2.2.2"
+
+babel-preset-env@^1.5.1:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.6.0.tgz#2de1c782a780a0a5d605d199c957596da43c44e4"
+  dependencies:
+    babel-plugin-check-es2015-constants "^6.22.0"
+    babel-plugin-syntax-trailing-function-commas "^6.22.0"
+    babel-plugin-transform-async-to-generator "^6.22.0"
+    babel-plugin-transform-es2015-arrow-functions "^6.22.0"
+    babel-plugin-transform-es2015-block-scoped-functions "^6.22.0"
+    babel-plugin-transform-es2015-block-scoping "^6.23.0"
+    babel-plugin-transform-es2015-classes "^6.23.0"
+    babel-plugin-transform-es2015-computed-properties "^6.22.0"
+    babel-plugin-transform-es2015-destructuring "^6.23.0"
+    babel-plugin-transform-es2015-duplicate-keys "^6.22.0"
+    babel-plugin-transform-es2015-for-of "^6.23.0"
+    babel-plugin-transform-es2015-function-name "^6.22.0"
+    babel-plugin-transform-es2015-literals "^6.22.0"
+    babel-plugin-transform-es2015-modules-amd "^6.22.0"
+    babel-plugin-transform-es2015-modules-commonjs "^6.23.0"
+    babel-plugin-transform-es2015-modules-systemjs "^6.23.0"
+    babel-plugin-transform-es2015-modules-umd "^6.23.0"
+    babel-plugin-transform-es2015-object-super "^6.22.0"
+    babel-plugin-transform-es2015-parameters "^6.23.0"
+    babel-plugin-transform-es2015-shorthand-properties "^6.22.0"
+    babel-plugin-transform-es2015-spread "^6.22.0"
+    babel-plugin-transform-es2015-sticky-regex "^6.22.0"
+    babel-plugin-transform-es2015-template-literals "^6.22.0"
+    babel-plugin-transform-es2015-typeof-symbol "^6.23.0"
+    babel-plugin-transform-es2015-unicode-regex "^6.22.0"
+    babel-plugin-transform-exponentiation-operator "^6.22.0"
+    babel-plugin-transform-regenerator "^6.22.0"
+    browserslist "^2.1.2"
+    invariant "^2.2.2"
+    semver "^5.3.0"
 
 babel-register@^6.24.1:
   version "6.24.1"
@@ -1297,6 +1358,18 @@ broccoli-debug@^0.6.1:
     sanitize-filename "^1.6.1"
     tree-sync "^1.2.2"
 
+broccoli-debug@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/broccoli-debug/-/broccoli-debug-0.6.2.tgz#4c6e89459fc3de7d5d4fc7b77e57f46019f44db1"
+  dependencies:
+    broccoli-plugin "^1.2.1"
+    fs-tree-diff "^0.5.2"
+    heimdalljs "^0.2.1"
+    heimdalljs-logger "^0.1.7"
+    minimatch "^3.0.3"
+    symlink-or-copy "^1.1.8"
+    tree-sync "^1.2.2"
+
 broccoli-file-creator@^1.0.0, broccoli-file-creator@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/broccoli-file-creator/-/broccoli-file-creator-1.1.1.tgz#1b35b67d215abdfadd8d49eeb69493c39e6c3450"
@@ -1541,7 +1614,7 @@ broccoli-postcss@3.3.0:
     object-assign "4.1.1"
     postcss "5.2.16"
 
-broccoli-rollup@^1.0.3:
+broccoli-rollup@^1.0.3, broccoli-rollup@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/broccoli-rollup/-/broccoli-rollup-1.3.0.tgz#43a0a7798555bab54217009eb470a4ff5a056df0"
   dependencies:
@@ -1763,6 +1836,13 @@ browserslist@^1.3.6, browserslist@^1.4.0, browserslist@^1.5.2, browserslist@^1.7
     caniuse-db "^1.0.30000639"
     electron-to-chromium "^1.2.7"
 
+browserslist@^2.1.2:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.1.5.tgz#e882550df3d1cd6d481c1a3e0038f2baf13a4711"
+  dependencies:
+    caniuse-lite "^1.0.30000684"
+    electron-to-chromium "^1.3.14"
+
 bser@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/bser/-/bser-1.0.2.tgz#381116970b2a6deea5646dd15dd7278444b56169"
@@ -1874,6 +1954,10 @@ caniuse-api@^1.5.2:
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
   version "1.0.30000666"
   resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000666.tgz#951ed9f3d3bfaa08a06dafbb5089ab07cce6ab90"
+
+caniuse-lite@^1.0.30000684:
+  version "1.0.30000697"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000697.tgz#125fb00604b63fbb188db96a667ce2922dcd6cdd"
 
 capture-exit@^1.1.0:
   version "1.2.0"
@@ -2677,6 +2761,10 @@ electron-to-chromium@^1.2.7:
   version "1.3.9"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.9.tgz#db1cba2a26aebcca2f7f5b8b034554468609157d"
 
+electron-to-chromium@^1.3.14:
+  version "1.3.15"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.15.tgz#08397934891cbcfaebbd18b82a95b5a481138369"
+
 element-resize-detector@1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/element-resize-detector/-/element-resize-detector-1.1.4.tgz#ec48a09b44ab0e35a352242e15406b3fa679d7f1"
@@ -2781,6 +2869,23 @@ ember-cli-babel@^5.0.0, ember-cli-babel@^5.1.3, ember-cli-babel@^5.1.5, ember-cl
     clone "^2.0.0"
     ember-cli-version-checker "^1.0.2"
     resolve "^1.1.2"
+
+ember-cli-babel@^6.0.0-beta.10:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.6.0.tgz#a8362bc44841bfdf89b389f3197f104d7ba526da"
+  dependencies:
+    amd-name-resolver "0.0.6"
+    babel-plugin-debug-macros "^0.1.11"
+    babel-plugin-ember-modules-api-polyfill "^1.4.1"
+    babel-plugin-transform-es2015-modules-amd "^6.24.0"
+    babel-polyfill "^6.16.0"
+    babel-preset-env "^1.5.1"
+    broccoli-babel-transpiler "^6.0.0"
+    broccoli-debug "^0.6.2"
+    broccoli-funnel "^1.0.0"
+    broccoli-source "^1.1.0"
+    clone "^2.0.0"
+    ember-cli-version-checker "^2.0.0"
 
 ember-cli-broccoli-sane-watcher@^2.0.4:
   version "2.0.4"
@@ -3082,6 +3187,13 @@ ember-cli-version-checker@^1.0.2, ember-cli-version-checker@^1.1.3, ember-cli-ve
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz#0bc2d134c830142da64bf9627a0eded10b61ae72"
   dependencies:
+    semver "^5.3.0"
+
+ember-cli-version-checker@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.0.0.tgz#e1f7d8e4cdcd752ac35f1611e4daa8836db4c4c7"
+  dependencies:
+    resolve "^1.3.3"
     semver "^5.3.0"
 
 ember-cli@2.13.1:
@@ -3493,6 +3605,10 @@ ember-responsive@2.0.2:
   dependencies:
     ember-cli-babel "^5.1.6"
     ember-getowner-polyfill "^1.1.1"
+
+ember-rfc176-data@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.1.0.tgz#e248824d9bc41f63053fd52da0452ddcf16a044a"
 
 ember-route-action-helper@2.0.3:
   version "2.0.3"
@@ -7185,7 +7301,7 @@ resolve@1.1.7, resolve@1.1.x, resolve@~1.1.0, resolve@~1.1.6:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.2, resolve@^1.1.3, resolve@^1.1.4, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.2.0, resolve@^1.3.0, resolve@^1.3.2:
+resolve@^1.1.2, resolve@^1.1.3, resolve@^1.1.4, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.2.0, resolve@^1.3.0, resolve@^1.3.2, resolve@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
   dependencies:


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8540
- use `{{vertical-collection}}` in the tags dropdown filter list, opening the dropdown is now virtually instant as it's not attempting to immediately render components for every tag in the list
- remove pagination/infinite scroll from tags screen
- load all tags when accessing the tags screen
  - will pause to show spinner if no tags have previously been loaded
  - if tags exist in the ember data store, show the list immediately and load/update list in the background
- use `{{vertical-collection}}` to render enough tags to fill the scrollable area with a small buffer and use occlusion and element re-use to swap tags in whilst scrolling (suuuuper fast no matter number of tags loaded)
- scroll tags into view when they are selected (keyboard nav now makes a lot more sense)
- tested with 875 tags and 2x/5x CPU throttling with no major slowdowns 🎉 

TODO:
- [x] implement {{vertical-collection}} for the tags dropdown to speed up rendering
- [ ] ~~see if there's a way to scroll to tags that are in the occluded area~~
  - edge-case, only relevant when accessing the individual tag route directly - everything works at the moment but the active tag isn't scrolled into view
  - may be possible by using tag index and scrolling to calculated height rather than using browser's `element.scrollIntoView()`)

NB: I'm leaving the scroll-to-tag TODO for now, it's a nice-to-have for an edge case and we can re-visit if needed later once the tags screen has been redesigned