### PR TITLE
🐛 empty posts shouldn't be publishable

### DIFF
--- a/app/components/gh-editor-post-status.js
+++ b/app/components/gh-editor-post-status.js
@@ -7,6 +7,7 @@ const SAVE_TIMEOUT_MS = 3000;
 
 export default Component.extend({
     post: null,
+    isNew: reads('post.isNew'),
     isScheduled: reads('post.isScheduled'),
     isSaving: false,
 

--- a/app/templates/components/gh-editor-post-status.hbs
+++ b/app/templates/components/gh-editor-post-status.hbs
@@ -4,6 +4,8 @@
     Published
 {{else if isScheduled}}
     Scheduled
+{{else if isNew}}
+    New
 {{else}}
     Draft
 {{/if}}

--- a/app/templates/editor/edit.hbs
+++ b/app/templates/editor/edit.hbs
@@ -17,11 +17,13 @@
             </time>
         {{/if}}
         <section class="view-actions">
-            {{gh-publishmenu
-                post=model
-                saveTask=save
-                setSaveType=(action "setSaveType")
-                onOpen=(action "cancelAutosave")}}
+            {{#unless model.isNew}}
+                {{gh-publishmenu
+                    post=model
+                    saveTask=save
+                    setSaveType=(action "setSaveType")
+                    onOpen=(action "cancelAutosave")}}
+            {{/unless}}
 
             <button type="button" class="post-settings" title="Settings" {{action "openSettingsMenu"}} data-test-psm-trigger>
                 {{inline-svg "settings"}}


### PR DESCRIPTION
closes TryGhost/Ghost#8501
- don't show publish menu for new posts - the publishmenu options don't make much sense for a post that hasn't been saved yet
- show post status as "new" when a post is unsaved rather than "draft"