### PR TITLE
🐛 fix PSM throbber bugs

### DIFF
--- a/app/components/gh-post-settings-menu.js
+++ b/app/components/gh-post-settings-menu.js
@@ -6,6 +6,7 @@ import computed, {alias} from 'ember-computed';
 import formatMarkdown from 'ghost-admin/utils/format-markdown';
 import injectService from 'ember-service/inject';
 import moment from 'moment';
+import run from 'ember-runloop';
 import {guidFor} from 'ember-metal/utils';
 import {htmlSafe} from 'ember-string';
 import {invokeAction} from 'ember-invoke-action';
@@ -155,7 +156,13 @@ export default Component.extend(SettingsMenuMixin, {
     actions: {
         showSubview() {
             this._super(...arguments);
-            this.set('_showThrobbers', false);
+
+            // Chrome appears to have an animation bug that cancels the slide
+            // transition unless there's a delay between the animation starting
+            // and the throbbers being removed
+            run.later(this, function () {
+                this.set('_showThrobbers', false);
+            }, 50);
         },
 
         closeSubview() {

--- a/app/components/gh-tour-item.js
+++ b/app/components/gh-tour-item.js
@@ -121,9 +121,9 @@ const GhTourItemComponent = Component.extend({
     },
 
     willDestroyElement() {
-        this._super(...arguments);
         this.get('tour').off('optOut', this._handleOptOut);
-        this.get('tour').off('viewed', this._handleOptOut);
+        this.get('tour').off('viewed', this._handleViewed);
+        this._super(...arguments);
     },
 
     _removeIfViewed(id) {

--- a/app/services/tour.js
+++ b/app/services/tour.js
@@ -113,7 +113,7 @@ export default Service.extend(Evented, {
         let viewed = this.get('viewed');
 
         if (!viewed.includes(id)) {
-            this.get('viewed').push(id);
+            viewed.pushObject(id);
             this.trigger('viewed', id);
             return this.syncViewed();
         } else {

--- a/app/templates/components/gh-post-settings-menu.hbs
+++ b/app/templates/components/gh-post-settings-menu.hbs
@@ -1,4 +1,4 @@
-{{#gh-tabs-manager selected="showSubview" id="entry-controls" class="settings-menu-container"}}
+{{#gh-tabs-manager selected=(action "showSubview") id="entry-controls" class="settings-menu-container"}}
 <div id="entry-controls">
     <div class="{{if isViewingSubview 'settings-menu-pane-out-left' 'settings-menu-pane-in'}} settings-menu settings-menu-pane">
         <div class="settings-menu-header">
@@ -173,7 +173,7 @@
     {{gh-tour-item "static-post"
         target="label[for='static-page'] p"
         throbberAttachment="middle middle"
-        throbberOffset="0px 75px"
+        throbberOffset="0px 33px"
         popoverTriangleClass="bottom-right"
     }}
 


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8611
- fix positioning of "static page" throbber
- fix PSM throbbers re-appearing after PSM close/open (need to use `pushObject` instead of `push` so that it's KVO compliant and the `_activeThrobbers` CP is updated)
- fix order of `willDestroyElement` so that we don't attempt to use `get` after the component is destroyed
- fix issue in Chrome that was preventing the Meta Data link from sliding the PSM panels

TODO:
- [x] fix meta panel link