### PR TITLE
🎨 fix non-square icon sizes

### DIFF
--- a/app/styles/components/power-select.css
+++ b/app/styles/components/power-select.css
@@ -7,7 +7,7 @@
 
 .ember-power-select-trigger svg {
     height: 4px;
-    width: 4px;
+    width: 6.11px;
     margin-left: 2px;
     vertical-align: middle;
 }

--- a/app/styles/patterns/forms.css
+++ b/app/styles/patterns/forms.css
@@ -290,7 +290,7 @@ textarea {
 
 .gh-select svg {
     height: 8px;
-    width: 8px;
+    width: 14px;
     position: absolute;
     top: 50%;
     right: 1.2rem;


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8665
- updates width/height for non-square icons to match the desired dimensions (width+height have to be specified for IE11)

Changes introduced in #724 failed to take into account a few of our icons are not square (notably the `arrow-*-small.svg` icons) resulting in some icons appearing too small.