### PR TITLE
🐛 fix double-click on post to open editor

### DIFF
--- a/app/components/gh-posts-list-item.js
+++ b/app/components/gh-posts-list-item.js
@@ -10,6 +10,8 @@ import {isBlank} from 'ember-utils';
 const {Handlebars} = Ember;
 
 export default Component.extend({
+    ghostPaths: injectService(),
+
     tagName: 'li',
     classNames: ['gh-posts-list-item'],
     classNameBindings: ['active'],
@@ -22,7 +24,9 @@ export default Component.extend({
     isPublished: equal('post.status', 'published'),
     isScheduled: equal('post.status', 'scheduled'),
 
-    ghostPaths: injectService(),
+    // closure actions
+    onClick() {},
+    onDoubleClick() {},
 
     authorName: computed('post.author.name', 'post.author.email', function () {
         return this.get('post.author.name') || this.get('post.author.email');
@@ -57,11 +61,11 @@ export default Component.extend({
     },
 
     click() {
-        this.sendAction('onClick', this.get('post'));
+        this.onClick(this.get('post'));
     },
 
     doubleClick() {
-        this.sendAction('onDoubleClick', this.get('post'));
+        this.onDoubleClick(this.get('post'));
     },
 
     scrollIntoView() {

--- a/app/controllers/posts.js
+++ b/app/controllers/posts.js
@@ -113,6 +113,10 @@ export default Controller.extend({
 
         changeOrder(order) {
             this.set('order', get(order, 'value'));
+        },
+
+        openEditor(post) {
+            this.transitionToRoute('editor.edit', post.get('id'));
         }
     }
 });

--- a/app/templates/posts.hbs
+++ b/app/templates/posts.hbs
@@ -87,7 +87,7 @@
             {{#each model as |post|}}
                 {{gh-posts-list-item
                     post=post
-                    onDoubleClick="openEditor"
+                    onDoubleClick=(action "openEditor")
                     data-test-post-id=post.id}}
             {{else}}
                 <li class="no-posts-box">

--- a/tests/acceptance/content-test.js
+++ b/tests/acceptance/content-test.js
@@ -52,6 +52,7 @@ describe('Acceptance: Content', function() {
             // Displays all posts + pages
             expect(find(testSelector('post-id')).length, 'all posts count').to.equal(5);
 
+            // show draft posts
             await selectChoose(testSelector('type-select'), 'Draft posts');
 
             // API request is correct
@@ -62,6 +63,7 @@ describe('Acceptance: Content', function() {
             expect(find(testSelector('post-id')).length, 'drafts count').to.equal(1);
             expect(find(testSelector('post-id', draftPost.id)), 'draft post').to.exist;
 
+            // show published posts
             await selectChoose(testSelector('type-select'), 'Published posts');
 
             // API request is correct
@@ -73,6 +75,7 @@ describe('Acceptance: Content', function() {
             expect(find(testSelector('post-id', publishedPost.id)), 'admin published post').to.exist;
             expect(find(testSelector('post-id', authorPost.id)), 'author published post').to.exist;
 
+            // show scheduled posts
             await selectChoose(testSelector('type-select'), 'Scheduled posts');
 
             // API request is correct
@@ -83,6 +86,7 @@ describe('Acceptance: Content', function() {
             expect(find(testSelector('post-id')).length, 'scheduled count').to.equal(1);
             expect(find(testSelector('post-id', scheduledPost.id)), 'scheduled post').to.exist;
 
+            // show pages
             await selectChoose(testSelector('type-select'), 'Pages');
 
             // API request is correct
@@ -93,6 +97,7 @@ describe('Acceptance: Content', function() {
             expect(find(testSelector('post-id')).length, 'pages count').to.equal(1);
             expect(find(testSelector('post-id', publishedPage.id)), 'page post').to.exist;
 
+            // show all posts
             await selectChoose(testSelector('type-select'), 'All posts');
 
             // API request is correct
@@ -100,6 +105,7 @@ describe('Acceptance: Content', function() {
             expect(lastRequest.queryParams.status, '"all" request status param').to.equal('all');
             expect(lastRequest.queryParams.staticPages, '"all" request staticPages param').to.equal('all');
 
+            // show all posts by editor
             await selectChoose(testSelector('author-select'), editor.name);
 
             // API request is correct
@@ -108,12 +114,18 @@ describe('Acceptance: Content', function() {
             expect(lastRequest.queryParams.staticPages, '"all" request staticPages param').to.equal('all');
             expect(lastRequest.queryParams.filter, '"editor" request filter param')
                 .to.equal(`author:${editor.slug}`);
+
             // Displays editor post
             // TODO: implement "filter" param support and fix mirage post->author association
             // expect(find(testSelector('post-id')).length, 'editor post count').to.equal(1);
             // expect(find(testSelector('post-id', authorPost.id)), 'author post').to.exist;
 
             // TODO: test tags dropdown
+
+            // Double-click on a post opens editor
+            await triggerEvent(testSelector('post-id', authorPost.id), 'dblclick');
+
+            expect(currentURL(), 'url after double-click').to.equal(`/editor/${authorPost.id}`);
         });
     });
 


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8675
- move `gh-posts-list-item` to closure actions
- add missing `openEditor` action in posts controller