### PR TITLE
🐛 fix autosave when title loses focus

### DIFF
--- a/app/mixins/editor-base-controller.js
+++ b/app/mixins/editor-base-controller.js
@@ -567,7 +567,7 @@ export default Mixin.create({
         },
 
         save(options) {
-            this.get('save').perform(options);
+            return this.get('save').perform(options);
         },
 
         setSaveType(newType) {
@@ -585,6 +585,9 @@ export default Mixin.create({
 
         autoSaveNew() {
             if (this.get('model.isNew')) {
+                // force "dirty" state so save task doesn't abort on blank title
+                this.set('hasDirtyAttributes', true);
+
                 this.send('save', {silent: true, backgroundSave: true});
             }
         },


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8636
- `save` action on editor base controller was not returning so the `_super` call in `editor.new` controller's `save` action returned `undefined` which broke the `.then` call
- force a dirty state in the `autoSaveNew` action so that the save still happens when the body gains focus whilst the title is blank