### PR TITLE
🐛 don't show mobile nav bar when not logged in

### DIFF
--- a/app/styles/layouts/main.css
+++ b/app/styles/layouts/main.css
@@ -489,6 +489,21 @@ body > .ember-view:not(.default-liquid-destination) {
         width: 15px;
         fill: var(--darkgrey);
     }
+
+    /* non-authed pages shouldn't have the mobile bar */
+    .ghost-setup .gh-viewport,
+    .ghost-reset .gh-viewport,
+    .ghost-signup .gh-viewport,
+    .ghost-login .gh-viewport {
+        padding-bottom: 0;
+    }
+
+    .ghost-setup .gh-mobile-nav-bar,
+    .ghost-reset .gh-mobile-nav-bar,
+    .ghost-signup .gh-mobile-nav-bar,
+    .ghost-login .gh-mobile-nav-bar {
+        display: none;
+    }
 }
 
 


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8625
- add CSS rules for the non-authed pages to remove the mobile nav bar