### PR TITLE
🐛 fix "failed" button flash on password reset

### DIFF
--- a/app/controllers/reset.js
+++ b/app/controllers/reset.js
@@ -49,6 +49,7 @@ export default Controller.extend(ValidationEngine, {
                 });
                 this.get('notifications').showAlert(resp.passwordreset[0].message, {type: 'warn', delayed: true, key: 'password.reset'});
                 this.get('session').authenticate('authenticator:oauth2', this.get('email'), credentials.newPassword);
+                return true;
             } catch (error) {
                 this.get('notifications').showAPIError(error, {key: 'password.reset'});
             }
@@ -69,7 +70,7 @@ export default Controller.extend(ValidationEngine, {
 
     actions: {
         submit() {
-            this.get('resetPassword').perform();
+            return this.get('resetPassword').perform();
         }
     }
 });


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8688
- `reset` task wasn't returning a truthy value on success so `gh-task-button` flashed the "retry" state before the transition happened