### PR TITLE
🐛 fix filter dropdown issues

### DIFF
--- a/app/controllers/posts.js
+++ b/app/controllers/posts.js
@@ -63,7 +63,9 @@ export default Controller.extend({
     }),
 
     availableTags: computed('_availableTags.[]', function () {
-        let tags = this.get('_availableTags');
+        let tags = this.get('_availableTags').filter((tag) => {
+            return tag.get('id') !== null;
+        });
         let options = tags.toArray();
 
         options.unshiftObject({name: 'All tags', slug: null});

--- a/app/styles/components/power-select.css
+++ b/app/styles/components/power-select.css
@@ -57,7 +57,7 @@
 }
 
 .ember-power-select-options:not([role="group"]) {
-    max-height: 70vh;
+    max-height: 50vh;
 }
 
 .ember-power-select-search input {

--- a/app/styles/layouts/content.css
+++ b/app/styles/layouts/content.css
@@ -80,7 +80,6 @@
 
 .gh-contentfilter-menu-dropdown {
     width: 180px;
-    max-height: 220px;
     margin-top: 10px;
     padding: 5px 0 7px 0;
     border: none !important;

--- a/app/templates/components/power-select-vertical-collection-options.hbs
+++ b/app/templates/components/power-select-vertical-collection-options.hbs
@@ -4,7 +4,7 @@
     {{/if}}
 {{/if}}
 
-{{#vertical-collection options minHeight=30 staticHeight=true bufferSize=5 as |opt index|}}
+{{#vertical-collection options minHeight=30 staticHeight=true bufferSize=10 as |opt index|}}
     <li class="ember-power-select-option"
         aria-selected="{{ember-power-select-is-selected opt select.selected}}"
         aria-disabled={{ember-power-select-true-string-if-present opt.disabled}}


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8729, closes https://github.com/TryGhost/Ghost/issues/8728
- remove the duplicated `max-height` rules for different parts of the power select dropdowns - they were interacting with each other and causing a large part of the lists to be unreachable
- filter the temporary tags that are created when using the PSM tags input so duplicates aren't visible in the tags dropdown filter