### PR TITLE
[HOLD] 🐛 fix loss of editor focus on new post autosave

### DIFF
--- a/app/mixins/editor-base-controller.js
+++ b/app/mixins/editor-base-controller.js
@@ -42,6 +42,7 @@ export default Mixin.create({
     showLeaveEditorModal: false,
     showReAuthenticateModal: false,
     showDeletePostModal: false,
+    shouldFocusEditor: true,
 
     application: injectController(),
     notifications: injectService(),

--- a/app/mixins/editor-base-controller.js
+++ b/app/mixins/editor-base-controller.js
@@ -73,6 +73,7 @@ export default Mixin.create({
 
     // save 3 seconds after the last edit
     _autosave: task(function* () {
+        // force an instant save on first body edit for new posts
         if (this.get('_canAutosave') && this.get('model.isNew')) {
             return this.get('autosave').perform();
         }

--- a/app/mixins/editor-base-controller.js
+++ b/app/mixins/editor-base-controller.js
@@ -29,7 +29,7 @@ const DEFAULT_TITLE = '(Untitled)';
 const TITLE_DEBOUNCE = testing ? 10 : 700;
 
 // time in ms to save after last content edit
-const AUTOSAVE_TIMEOUT = 1000;
+const AUTOSAVE_TIMEOUT = 3000;
 // time in ms to force a save if the user is continuously typing
 const TIMEDSAVE_TIMEOUT = 10000;
 

--- a/app/mixins/editor-base-controller.js
+++ b/app/mixins/editor-base-controller.js
@@ -29,9 +29,9 @@ const DEFAULT_TITLE = '(Untitled)';
 const TITLE_DEBOUNCE = testing ? 10 : 700;
 
 // time in ms to save after last content edit
-const AUTOSAVE_TIMEOUT = 3000;
+const AUTOSAVE_TIMEOUT = 1000;
 // time in ms to force a save if the user is continuously typing
-const TIMEDSAVE_TIMEOUT = 60000;
+const TIMEDSAVE_TIMEOUT = 10000;
 
 PostModel.eachAttribute(function (name) {
     watchedProps.push(`model.${name}`);
@@ -73,6 +73,10 @@ export default Mixin.create({
 
     // save 3 seconds after the last edit
     _autosave: task(function* () {
+        if (this.get('_canAutosave') && this.get('model.isNew')) {
+            return this.get('autosave').perform();
+        }
+
         yield timeout(AUTOSAVE_TIMEOUT);
 
         if (this.get('_canAutosave')) {

--- a/app/mixins/editor-base-controller.js
+++ b/app/mixins/editor-base-controller.js
@@ -507,16 +507,14 @@ export default Mixin.create({
 
         model.set('titleScratch', newTitle);
 
-        // if model is not new and title is not DEFAULT_TITLE, or model is new and
-        // has a title, don't generate a slug
-        if ((!model.get('isNew') || model.get('title')) && newTitle !== DEFAULT_TITLE) {
-            return;
+        // generate a slug if a post is new and doesn't have a title yet or
+        // if the title is still '(Untitled)' and the slug is unaltered.
+        if ((this.get('model.isNew') && !newTitle) || model.get('title') === DEFAULT_TITLE) {
+            // debounce for 700 milliseconds
+            yield timeout(TITLE_DEBOUNCE);
+
+            yield this.get('generateSlug').perform();
         }
-
-        // debounce for 700 milliseconds
-        yield timeout(TITLE_DEBOUNCE);
-
-        yield this.get('generateSlug').perform();
     }).restartable(),
 
     generateSlug: task(function* () {

--- a/app/mixins/editor-base-controller.js
+++ b/app/mixins/editor-base-controller.js
@@ -31,7 +31,7 @@ const TITLE_DEBOUNCE = testing ? 10 : 700;
 // time in ms to save after last content edit
 const AUTOSAVE_TIMEOUT = 3000;
 // time in ms to force a save if the user is continuously typing
-const TIMEDSAVE_TIMEOUT = 10000;
+const TIMEDSAVE_TIMEOUT = 60000;
 
 PostModel.eachAttribute(function (name) {
     watchedProps.push(`model.${name}`);

--- a/app/routes/editor/edit.js
+++ b/app/routes/editor/edit.js
@@ -5,6 +5,12 @@ import base from 'ghost-admin/mixins/editor-base-route';
 export default AuthenticatedRoute.extend(base, {
     titleToken: 'Editor',
 
+    beforeModel(transition) {
+        this.set('_transitionedFromNew', transition.data.fromNew);
+
+        this._super(...arguments);
+    },
+
     model(params) {
         /* eslint-disable camelcase */
         let query = {
@@ -34,6 +40,11 @@ export default AuthenticatedRoute.extend(base, {
                 return this.replaceWith('posts.index');
             }
         });
+    },
+
+    setupController(controller) {
+        this._super(...arguments);
+        controller.set('shouldFocusEditor', this.get('_transitionedFromNew'));
     },
 
     actions: {

--- a/app/routes/editor/new.js
+++ b/app/routes/editor/new.js
@@ -17,5 +17,15 @@ export default AuthenticatedRoute.extend(base, {
             controller,
             model
         });
+    },
+
+    actions: {
+        willTransition(transition) {
+            // decorate the transition object so the editor.edit route
+            // knows this was the previous active route
+            transition.data.fromNew = true;
+
+            this._super(...arguments);
+        }
     }
 });

--- a/app/templates/components/gh-post-settings-menu.hbs
+++ b/app/templates/components/gh-post-settings-menu.hbs
@@ -17,6 +17,7 @@
             <form>
             <div class="form-group">
                 <label for="url">Post URL</label>
+                {{!-- new posts don't have a preview link --}}
                 {{#unless model.isNew}}
                     {{#if model.isPublished}}
                     <a class="post-view-link" target="_blank" href="{{model.absoluteUrl}}">

--- a/app/templates/components/gh-post-settings-menu.hbs
+++ b/app/templates/components/gh-post-settings-menu.hbs
@@ -17,15 +17,17 @@
             <form>
             <div class="form-group">
                 <label for="url">Post URL</label>
-                {{#if model.isPublished}}
-                <a class="post-view-link" target="_blank" href="{{model.absoluteUrl}}">
-                    View post {{inline-svg "external"}}
-                </a>
-                {{else}}
-                <a class="post-view-link" target="_blank" href="{{model.previewUrl}}">
-                    Preview {{inline-svg "external"}}
-                </a>
-                {{/if}}
+                {{#unless model.isNew}}
+                    {{#if model.isPublished}}
+                    <a class="post-view-link" target="_blank" href="{{model.absoluteUrl}}">
+                        View post {{inline-svg "external"}}
+                    </a>
+                    {{else}}
+                    <a class="post-view-link" target="_blank" href="{{model.previewUrl}}">
+                        Preview {{inline-svg "external"}}
+                    </a>
+                    {{/if}}
+                {{/unless}}
 
                 <div class="gh-input-icon gh-icon-link">
                     {{inline-svg "link"}}

--- a/app/templates/editor/edit.hbs
+++ b/app/templates/editor/edit.hbs
@@ -38,7 +38,7 @@
     {{#gh-markdown-editor
         tabindex="2"
         placeholder="Begin writing your story..."
-        autofocus=model.isNew
+        autofocus=shouldFocusEditor
         uploadedImageUrls=editor.uploadedImageUrls
         mobiledoc=(readonly model.scratch)
         isFullScreen=editor.isFullScreen


### PR DESCRIPTION
refs TryGhost/Ghost#8723
- #795 contained a regression where the body focus was lost during the new->edit transition because at that point `model.isNew` is false
- returns `shouldFocusEditor` code that was removed in #768 (it was assumed the body should _always_ have focus in that PR)
- instant-save if body is edited and the post is new - fixes issue where you could keep typing without any save when body had autofocus
- don't show preview link for new posts - fixes issue where it links directly to the admin endpoint so it would force a refresh

