### PR TITLE
🐛 fix duplicate posts bug, more intelligent autosave when transitioning

### DIFF
--- a/app/templates/editor/edit.hbs
+++ b/app/templates/editor/edit.hbs
@@ -57,8 +57,8 @@
                 placeholder="Post Title"
                 tabindex="1"
                 autoExpand=".gh-markdown-editor-pane"
-                focusOut=(action "saveTitle")
-                update=(action (perform updateTitle))
+                update=(action "updateTitle")
+                focusOut=(action (perform saveTitle))
                 keyEvents=(hash
                     9=(action markdown.focus 'bottom')
                     13=(action markdown.focus 'top')

--- a/tests/unit/mixins/editor-base-controller-test.js
+++ b/tests/unit/mixins/editor-base-controller-test.js
@@ -72,7 +72,7 @@ describe('Unit: Mixin: editor-base-controller', function() {
         });
     });
 
-    describe('updateTitle', function () {
+    describe('saveTitle', function () {
         it('should invoke generateSlug if the post is new and a title has not been set', function (done) {
             let object;
 
@@ -89,8 +89,10 @@ describe('Unit: Mixin: editor-base-controller', function() {
             expect(object.get('model.isNew')).to.be.true;
             expect(object.get('model.titleScratch')).to.not.be.ok;
 
+            object.set('model.titleScratch', 'test');
+
             run(() => {
-                object.get('updateTitle').perform('test');
+                object.get('saveTitle').perform();
             });
 
             wait().then(() => {
@@ -100,12 +102,12 @@ describe('Unit: Mixin: editor-base-controller', function() {
             });
         });
 
-        it('should invoke generateSlug if the post is not new and a title is "(Untitled)"', function (done) {
+        it('should invoke generateSlug if the post is not new and it\'s title is "(Untitled)"', function (done) {
             let object;
 
             run(() => {
                 object = EmberObject.extend(EditorBaseControllerMixin, {
-                    model: EmberObject.create({isNew: false}),
+                    model: EmberObject.create({isNew: false, title: '(Untitled)'}),
                     generateSlug: task(function* () {
                         this.set('model.slug', 'test-slug');
                         yield RSVP.resolve();
@@ -116,12 +118,14 @@ describe('Unit: Mixin: editor-base-controller', function() {
             expect(object.get('model.isNew')).to.be.false;
             expect(object.get('model.titleScratch')).to.not.be.ok;
 
+            object.set('model.titleScratch', 'New Title');
+
             run(() => {
-                object.get('updateTitle').perform('(Untitled)');
+                object.get('saveTitle').perform();
             });
 
             wait().then(() => {
-                expect(object.get('model.titleScratch')).to.equal('(Untitled)');
+                expect(object.get('model.titleScratch')).to.equal('New Title');
                 expect(object.get('model.slug')).to.equal('test-slug');
                 done();
             });
@@ -148,8 +152,10 @@ describe('Unit: Mixin: editor-base-controller', function() {
             expect(object.get('model.title')).to.equal('a title');
             expect(object.get('model.titleScratch')).to.not.be.ok;
 
+            object.set('model.titleScratch', 'test');
+
             run(() => {
-                object.get('updateTitle').perform('test');
+                object.get('saveTitle').perform();
             });
 
             wait().then(() => {
@@ -176,8 +182,10 @@ describe('Unit: Mixin: editor-base-controller', function() {
             expect(object.get('model.isNew')).to.be.false;
             expect(object.get('model.title')).to.not.be.ok;
 
+            object.set('model.titleScratch', 'title');
+
             run(() => {
-                object.get('updateTitle').perform('title');
+                object.get('saveTitle').perform();
             });
 
             wait().then(() => {


### PR DESCRIPTION
no issue
- fixes bug where multiple posts were created starting with one char and growing until the new->edit transition completed, e.g. posts with content such as `a`, `ab`, `abcd` were created in quick succession
  - moves old `_savePromise` body into the `save` task
  - call the `save` task instead of the old `_savePromise` so that concurrency is handled properly
- fixes odd behaviour with the "Are you sure you want to leave?" modal appearing too often - it's now aware of on-going or scheduled saves and will wait for those to complete before transitioning
  - move all transition abort/save/retry handling into `toggleLeaveEditorModal` method
  - check for a running save, wait for it to finish then retry the transition
  - check for a scheduled autosave, cancel it if present and perform an immediate autosave then retry the transition
  - don't attempt new->edit transition on successful save of new post if we're already waiting for a different transition
  - once the new->edit transition has completed, if the post body content has changed schedule an autosave manually so that the user doesn't need to type something again to save what they assume is already saved
  - remove debounced slug generation/save on type of title field in favour of generation and save on focus out which plays a lot nicer with the new transition autosave behaviour