### PR TITLE
🎨 fix download count position on setup/one

### DIFF
--- a/app/components/gh-download-count.js
+++ b/app/components/gh-download-count.js
@@ -10,6 +10,7 @@ export default Component.extend({
     ajax: injectService(),
     ghostPaths: injectService(),
 
+    tagName: '',
     count: '',
 
     _poll: task(function* () {


### PR DESCRIPTION
no issue
- default component tag of `<div>` forced the download count to appear on it's own line, setting `tagName: ''` returns the desired inline behaviour

Before:
![screen shot 2017-07-26 at 12 28 36](https://user-images.githubusercontent.com/415/28611879-5b135dee-71fe-11e7-9821-9393552fa4f8.png)

After:
![screen shot 2017-07-26 at 12 28 47](https://user-images.githubusercontent.com/415/28611884-60b41540-71fe-11e7-8184-fbb945796265.png)
