### PR TITLE
⚡️ hemingway editor mode (disable backspace)

### DIFF
--- a/app/styles/components/notifications.css
+++ b/app/styles/components/notifications.css
@@ -25,7 +25,7 @@
     color: #fff;
     font-size: 1.2rem;
     line-height: 1.4em;
-    opacity: 0.8;
+    opacity: 0.88;
     transition: opacity 0.3s ease;
 }
 
@@ -39,6 +39,12 @@
     padding: 10px 15px;
     border-radius: 3px;
     transition: background 0.2s ease;
+}
+
+.gh-notification-title {
+    display: block;
+    margin-bottom: 5px;
+    font-weight: 600;
 }
 
 .gh-notification a {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7561,7 +7561,7 @@ simple-is@~0.2.0:
 
 "simplemde@https://github.com/kevinansfield/simplemde-markdown-editor.git#ghost":
   version "1.11.2"
-  resolved "https://github.com/kevinansfield/simplemde-markdown-editor.git#05ba8d8ff395b148258743a31ef7e07ae5579d3e"
+  resolved "https://github.com/kevinansfield/simplemde-markdown-editor.git#42971ea4d997f5bec519c1c68cf63bda6b278cb2"
   dependencies:
     codemirror "*"
     codemirror-spell-checker "*"


### PR DESCRIPTION
no issue
- adds Hemingway Mode toggle to the editor toolbar that disables backspace
- shortcut is <kbd>Ctrl+Alt+H</kbd>