### PR TITLE
🙅  Disable image upload save btn when uploading

### DIFF
--- a/app/components/modals/upload-image.js
+++ b/app/components/modals/upload-image.js
@@ -10,6 +10,7 @@ export default ModalComponent.extend({
 
     url: '',
     newUrl: '',
+    _isUploading: false,
 
     config: injectService(),
     notifications: injectService(),
@@ -97,6 +98,10 @@ export default ModalComponent.extend({
 
         confirm() {
             this.get('uploadImage').perform();
+        },
+
+        isUploading() {
+            this.toggleProperty('_isUploading');
         }
     }
 });

--- a/app/templates/components/modals/upload-image.hbs
+++ b/app/templates/components/modals/upload-image.hbs
@@ -12,6 +12,8 @@
             image=newUrl
             saveButton=false
             update=(action 'fileUploaded')
+            uploadStarted=(action 'isUploading')
+            uploadFinished=(action 'isUploading')
             accept=model.accept
             extensions=model.extensions
             uploadUrl=model.uploadUrl
@@ -21,5 +23,9 @@
 
 <div class="modal-footer">
     <button {{action "closeModal"}} class="gh-btn"><span>Cancel</span></button>
-    {{gh-task-button task=uploadImage class="gh-btn gh-btn-blue right gh-btn-icon" data-test-modal-accept-button=true}}
+    {{#if _isUploading}}
+        <button class="gh-btn gh-btn-blue right gh-btn-icon disabled"><span>Save</span></button>
+    {{else}}
+        {{gh-task-button task=uploadImage class="gh-btn gh-btn-blue right gh-btn-icon" data-test-modal-accept-button=true}}
+    {{/if}}
 </div>


### PR DESCRIPTION
closes TryGhost/Ghost#8724

Adds a `isUploading` action that disables the `save` button for `upload-image` component until the upload process is finished.

![upload_image](https://user-images.githubusercontent.com/8037602/28769444-9af45534-75ec-11e7-84c0-3500f5dc8766.gif)
