### PR TITLE
🎨 Fix legibility of contributor names in Night Shift

### DIFF
--- a/app/styles/app-dark.css
+++ b/app/styles/app-dark.css
@@ -297,6 +297,10 @@ input,
     background: #fff;
 }
 
+.gh-contributors a:before {
+    color: #738a94;
+}
+
 .user-cover-edit {
     color: #fff;
 }


### PR DESCRIPTION
This closes TryGhost/Ghost#8851.

- Changes font color in contributor's nametags to a more legible ```#738a94```

**Here is the result...** 

![screenshot from 2017-08-05 22-27-24](https://user-images.githubusercontent.com/5911308/29000047-55d738be-7a2d-11e7-810b-ccd76f1e2d20.png)
