### PR TITLE
💄 Fix scrollbar on editor title input in Chrome on Windows

### DIFF
--- a/app/styles/layouts/editor.css
+++ b/app/styles/layouts/editor.css
@@ -342,6 +342,7 @@
     line-height: 1.15em;
     font-weight: bold;
     letter-spacing: 0.8px;
+    overflow: hidden;
 }
 
 .gh-editor-wordcount {


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8866
- add `overflow: hidden` to disable scrollbars on editor title input