### PR TITLE
Lighten upload theme description

### DIFF
--- a/app/styles/app-dark.css
+++ b/app/styles/app-dark.css
@@ -224,6 +224,10 @@ input,
     background: var(--lightgrey);
 }
 
+.gh-image-uploader .description {
+    color: var(--midgrey);
+}
+
 .gh-main > section.gh-editor-fullscreen {
     background: color(#212A2E l(+2%));
 }


### PR DESCRIPTION
Closes TryGhost/Ghost#8875
Not sure if midgrey or lightgrey should be used. IMHO lightgrey is too bright

Here's midgrey (which I used)
![image](https://user-images.githubusercontent.com/4383564/29196972-a91cb64c-7dfd-11e7-92a7-d4d9fcda4f89.png)