### PR TITLE
Addresses TryGhost/Ghost #8876

### DIFF
--- a/app/controllers/subscribers.js
+++ b/app/controllers/subscribers.js
@@ -47,7 +47,7 @@ export default Controller.extend(PaginationMixin, {
         let direction = this.get('direction');
 
         return [{
-            label: 'Email address',
+            label: 'Email Address',
             valuePath: 'email',
             sorted: order === 'email',
             ascending: direction === 'asc',

--- a/app/styles/patterns/tables.css
+++ b/app/styles/patterns/tables.css
@@ -69,6 +69,7 @@ table td,
 }
 
 .ember-light-table .lt-column .lt-sort-icon {
+    display: inline-block;
     float: none;
     margin-left: 0.3rem;
 }
@@ -87,8 +88,7 @@ table td,
     background-size: 10px, auto, contain;
     background-repeat: no-repeat;
     height: 9px;
-    position: absolute;
-    left: -3px;
-    bottom: 3px;
     width: 15px;
+    top: 1px;
+    position: relative;
 }


### PR DESCRIPTION
Closes TryGhost/Ghost#8876

Changed arrow styles to enable correct positioning. The sort arrow displayed below the `th` label; this CSS change fixes it.

Capitalization change: opinionated, but changing capitalization of “Address” to match “Subscription Date”.

Before:

![before](https://user-images.githubusercontent.com/652530/29200241-932c6354-7e21-11e7-8873-888d62d90106.png)

After:

![after](https://user-images.githubusercontent.com/652530/29200244-98898d54-7e21-11e7-8068-eb9dd57846a2.png)

