### PR TITLE
🐛 Fix order of multiple upload results

### DIFF
--- a/app/components/gh-uploader.js
+++ b/app/components/gh-uploader.js
@@ -166,7 +166,7 @@ export default Component.extend({
         // NOTE: for...of loop results in a transpilation that errors in Edge,
         // once we drop IE11 support we should be able to use native for...of
         for (let i = 0; i < files.length; i++) {
-            uploads.push(this.get('_uploadFile').perform(files[i]));
+            uploads.push(this.get('_uploadFile').perform(files[i], i));
         }
 
         // populates this.errors and this.uploadUrls
@@ -179,7 +179,7 @@ export default Component.extend({
         this.onComplete(this.get('uploadUrls'));
     }).drop(),
 
-    _uploadFile: task(function* (file) {
+    _uploadFile: task(function* (file, index) {
         let ajax = this.get('ajax');
         let formData = this._getFormData(file);
         let url = `${ghostPaths().apiRoot}${this.get('uploadUrl')}`;
@@ -219,7 +219,7 @@ export default Component.extend({
                 url: uploadUrl
             };
 
-            this.get('uploadUrls').pushObject(result);
+            this.get('uploadUrls')[index] = result;
             this.onUploadSuccess(result);
 
             return true;

--- a/tests/integration/components/gh-uploader-test.js
+++ b/tests/integration/components/gh-uploader-test.js
@@ -138,6 +138,29 @@ describe('Integration: Component: gh-uploader', function() {
             expect(results[0].fileName).to.equal('file2.png');
         });
 
+        it('onComplete returns results in same order as selected', async function () {
+            // first request has a delay to simulate larger file
+            server.post('/ghost/api/v0.1/uploads/', function () {
+                // second request has no delay to simulate small file
+                stubSuccessfulUpload(server, 0);
+
+                return [200, {'Content-Type': 'application/json'}, '"/content/images/test.png"'];
+            }, 100);
+
+            this.set('uploadsFinished', sinon.spy());
+
+            this.render(hbs`{{#gh-uploader files=files onComplete=(action uploadsFinished)}}{{/gh-uploader}}`);
+            this.set('files', [
+                createFile(['test'], {name: 'file1.png'}), // large - finishes last
+                createFile(['test'], {name: 'file2.png'})  // small - finishes first
+            ]);
+            await wait();
+
+            let [results] = this.get('uploadsFinished').getCall(0).args;
+            expect(results.length).to.equal(2);
+            expect(results[0].fileName).to.equal('file1.png');
+        });
+
         it('doesn\'t allow new files to be set whilst uploading', async function () {
             let errorSpy = sinon.spy(console, 'error');
             stubSuccessfulUpload(server, 100);


### PR DESCRIPTION
no issue
- push upload results into an array at the same index as the passed in files array