### PR TITLE
🐛 Fix Unsplash when using Night Shift

### DIFF
--- a/app/styles/app-dark.css
+++ b/app/styles/app-dark.css
@@ -34,6 +34,7 @@
 @import "components/publishmenu.css";
 @import "components/popovers.css";
 @import "components/tour.css";
+@import "components/unsplash.css";
 
 
 /* Layouts: Groups of Components
@@ -127,7 +128,8 @@ input,
     stroke: var(--darkgrey);
 }
 
-.gh-main {
+.gh-main,
+.gh-unsplash-window {
     background: #263238;
 }
 
@@ -281,7 +283,8 @@ input,
     border-color: #fff;
 }
 
-.gh-logo {
+.gh-logo,
+.gh-unsplash-logo {
     filter: invert(100%) brightness(150%);
 }
 
@@ -299,4 +302,8 @@ input,
 
 .user-cover-edit {
     color: #fff;
+}
+
+.gh-unsplash-zoom {
+    background: rgba(0,0,0,0.8);
 }


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8905
- import unsplash css file in `app-dark.css`
- add background and logo styles to match night shift styles