### PR TITLE
🐛 Fix missing Unsplash icons in uploaders when using config override

### DIFF
--- a/app/components/gh-image-uploader.js
+++ b/app/components/gh-image-uploader.js
@@ -20,6 +20,7 @@ export const IMAGE_EXTENSIONS = ['gif', 'jpg', 'jpeg', 'png', 'svg'];
 
 export default Component.extend({
     ajax: injectService(),
+    config: injectService(),
     notifications: injectService(),
     settings: injectService(),
 


### PR DESCRIPTION
no issue
- the `config` injection in `gh-image-uploader` was missing so the Unsplash button was only being displayed for the length of the session after visiting the Unsplash app screen (creates in-memory settings record based on config) or more permanently by saving the Unsplash settings (in which case the image uploader component reads the settings from the DB rather than config)