### PR TITLE
🐛 Fix save button showing "Retry" when user slug field loses focus

### DIFF
--- a/app/controllers/team/user.js
+++ b/app/controllers/team/user.js
@@ -128,7 +128,7 @@ export default Controller.extend({
         if (!newSlug || slug === newSlug) {
             this.set('slugValue', slug);
 
-            return;
+            return true;
         }
 
         let serverSlug = yield this.get('slugGenerator').generateSlug('user', newSlug);
@@ -136,7 +136,7 @@ export default Controller.extend({
         // If after getting the sanitized and unique slug back from the API
         // we end up with a slug that matches the existing slug, abort the change
         if (serverSlug === slug) {
-            return;
+            return true;
         }
 
         // Because the server transforms the candidate slug by stripping
@@ -155,11 +155,12 @@ export default Controller.extend({
             if (slug === slugTokens.join('-') && serverSlug !== newSlug) {
                 this.set('slugValue', slug);
 
-                return;
+                return true;
             }
         }
 
         this.set('slugValue', serverSlug);
+        return true;
     }).group('saveHandlers'),
 
     save: task(function* () {


### PR DESCRIPTION
no issue
- the `updateSlug` task never returned a value if there was no change needed, this meant that giving the slug field focus then blurring it again caused the "Save" button to become red with "Retry" text
- always return true from `updateSlug` - this stops the button from showing "Retry" and will instead show "Saved" which is a little less confusing