### PR TITLE
Fix field focus when adding navigation items

### DIFF
--- a/app/controllers/settings/design.js
+++ b/app/controllers/settings/design.js
@@ -64,6 +64,7 @@ export default Controller.extend({
         newNavItem.set('isNew', false);
         navItems.pushObject(newNavItem);
         this.set('newNavItem', NavigationItem.create({isNew: true}));
+        $('.gh-blognav-line:last input:first').focus();
     },
 
     _deleteTheme() {


### PR DESCRIPTION
Fixes TryGhost/Ghost#8764

After adding the item it sets the focus to the bottom gh-blognav-line element, the addNavItem gh-navitem component. 

I tried at first to see if I could edit the gh-navitem component. However, there are two gh-navitem components in the settings/design.hbs file. One is in the #each loop, which is surrounded by sortable-group component, the other is outside the each loop and is used to add items (addNavItem). Every time a new navItem is added the addNavItem gh-navitem component is pushed down to the bottom of the list. So that's why I decided to use jQuery outside the components to set the focus to that input box. 