### PR TITLE
Closes #8864

### DIFF
--- a/app/styles/layouts/editor.css
+++ b/app/styles/layouts/editor.css
@@ -158,6 +158,7 @@
 }
 
 .gh-og-preview-title {
+    color: #1d2129;
     max-height: 110px;
     overflow: hidden;
     margin-bottom: 5px;
@@ -169,6 +170,7 @@
 }
 
 .gh-og-preview-description {
+    color: #4b4f56;
     max-height: 80px;
     overflow: hidden;
     font-size: 12px;
@@ -201,7 +203,6 @@
 .gh-og-preview-footer-author {
     color: #3b5998;
 }
-
 
 /* Twitter Card Preview */
 .gh-twitter-preview {
@@ -259,8 +260,6 @@
     text-overflow: ellipsis;
     white-space: nowrap;
 }
-
-
 
 
 /* NEW editor


### PR DESCRIPTION
Assigns overrides to `og-preview-*` classes. Previously, the classes inherited their color from `body`. Now the preview appears correctly in both default and Night Shift modes.

Colors verified against Facebook's Sharing Debugger using the URL in @JohnONolan's bug report (TryGhost/Ghost#8864): https://developers.facebook.com/tools/debug/sharing/?q=https%3A%2F%2Fblog.ghost.org%2Fcustom-social-data%2F

I also threw in a couple blank line removals for organization. Opinionated but I did it for the sake of consistency.
