### PR TITLE
🐛 Fix double-scrollbar in code injection editor

### DIFF
--- a/app/styles/layouts/settings.css
+++ b/app/styles/layouts/settings.css
@@ -276,6 +276,12 @@
     border-radius: inherit;
 }
 
+/* Fixes issue 8896 */
+.settings-code-editor .CodeMirror-scroll {
+   overflow: hidden !important;
+   margin-right: 0;
+}
+
 .settings-code-editor .cm-s-xq-light span.cm-meta {
     color: #000;
 }

--- a/app/styles/layouts/settings.css
+++ b/app/styles/layouts/settings.css
@@ -276,7 +276,6 @@
     border-radius: inherit;
 }
 
-/* Fixes issue 8896 */
 .settings-code-editor .CodeMirror-scroll {
    overflow: hidden !important;
    margin-right: 0;


### PR DESCRIPTION
Override default `overflow: scroll` value that was causing the double scrollbar to appear.
Override an unnecessary (_at least for the __.settings-code-editor__ element scope_) `margin-right: -30px` on __.CodeMirror-scroll__ container that was causing the text inside to overflow.

Result:
![image](https://user-images.githubusercontent.com/29862596/29754576-52bd8a2c-8b88-11e7-8e0b-9a8b235df626.png)

This will fix the issue TryGhost/Ghost#8896
