### PR TITLE
Guard against blank strings in `json-string` fields

### DIFF
--- a/app/transforms/json-string.js
+++ b/app/transforms/json-string.js
@@ -1,10 +1,11 @@
 import Transform from 'ember-data/transform';
 
 export default Transform.extend({
-    deserialize(serialised) {
-        return JSON.parse(serialised);
+    deserialize(serialized) {
+        let _serialized = serialized === '' ? null : serialized;
+        return JSON.parse(_serialized);
     },
-    serialize(deserialised) {
-        return deserialised ? JSON.stringify(deserialised) : null;
+    serialize(deserialized) {
+        return deserialized ? JSON.stringify(deserialized) : null;
     }
 });

--- a/tests/unit/transforms/json-string-test.js
+++ b/tests/unit/transforms/json-string-test.js
@@ -4,10 +4,6 @@ import {setupTest} from 'ember-mocha';
 
 describe('Unit: Transform: json-string', function() {
     setupTest('transform:json-string', {});
-    it('exists', function() {
-        let transform = this.subject();
-        expect(transform).to.be.ok;
-    });
 
     it('serialises an Object to a JSON String', function() {
         let transform = this.subject();
@@ -19,5 +15,10 @@ describe('Unit: Transform: json-string', function() {
         let transform = this.subject();
         let obj = {one: 'one', two: 'two'};
         expect(transform.deserialize(JSON.stringify(obj))).to.deep.equal(obj);
+    });
+
+    it('handles deserializing a blank string', function () {
+        let transform = this.subject();
+        expect(transform.deserialize('')).to.equal(null);
     });
 });


### PR DESCRIPTION
no issue

We've seen an issue where after an import a user record had `tour: ""` which meant they were unable to log in due to JSON parsing of the empty string failing.

- add a guard so that an empty string is transformed to `null` before parsing
- changed `serialised` to `serialized` to match spelling in all other serializers