### PR TITLE
🐛 Fix #tags added via PSM having "public" visibility

### DIFF
--- a/app/models/tag.js
+++ b/app/models/tag.js
@@ -53,5 +53,5 @@ export default Model.extend(ValidationEngine, {
         if (this.get('isNew') && !this.get('isSaving')) {
             this.setVisibility();
         }
-    })
+    }).on('init')
 });


### PR DESCRIPTION
refs TryGhost/Ghost#8943
- Tag model has an observer watching the `isNew` and `name` properties so that it can set the `visibility: "internal"` property for new tags based on their name starting with a `#`
- PSM creates tags using `store.createRecord('tag', {name: tagName})` which means that the tag is instantiated with the `isNew` and `name` properties already set (unlike the tags screen where an empty tag is first created before the name is set via UI) - because the properties are there at instantiation the observer never fires because it's only watching for changes
- adds the `.on('init')` modifier to the `setVisibilityOnNew` observer so that it's run for the watched properties during instantiation as well as on change