### PR TITLE
Run Chrome in headless mode on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,23 +16,25 @@ branches:
 cache:
   yarn: true
   directories:
-    - node_modules
-    - broccoli-persistent-cache
+    - $HOME/.npm
+    - $HOME/.cache # includes bower's cache
 
 addons:
   firefox: "latest"
   chrome: "stable"
 
+before_install:
+  # install latest yarn
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH=$HOME/.yarn/bin:$PATH
+
 install:
-  - npm i -g yarn
   - yarn global add bower
   - yarn
   - bower install
 
 before_script:
-  - yarn add --force node-sass # temporary, workaround for https://github.com/yarnpkg/yarn/issues/1981
   - export DISPLAY=:99; sh -e /etc/init.d/xvfb start; sleep 3;
-  - export BROCCOLI_PERSISTENT_FILTER_CACHE_ROOT=/home/travis/build/TryGhost/Ghost-Admin/broccoli-persistent-cache
 
 script:
   - COVERAGE=true npm test

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "postcss-custom-properties": "6.1.0",
     "postcss-easy-import": "2.1.0",
     "simplemde": "https://github.com/kevinansfield/simplemde-markdown-editor.git#ghost",
+    "testem": "1.18.4",
     "top-gh-contribs": "2.0.4",
     "torii": "0.8.2",
     "walk-sync": "0.3.2"

--- a/testem.js
+++ b/testem.js
@@ -11,5 +11,16 @@ module.exports = {
     launch_in_dev: [
         'Chrome',
         'Firefox'
-    ]
+    ],
+    browser_args: {
+        chrome: {
+            mode: 'ci',
+            args: [
+                '--disable-gpu',
+                '--headless',
+                '--remote-debugging-port=9222',
+                '--window-size=1440,900'
+            ]
+        }
+    }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8890,7 +8890,7 @@ testem@1.15.0:
     tap-parser "^5.1.0"
     xmldom "^0.1.19"
 
-testem@^1.18.0:
+testem@1.18.4, testem@^1.18.0:
   version "1.18.4"
   resolved "https://registry.yarnpkg.com/testem/-/testem-1.18.4.tgz#e45fed922bec2f54a616c43f11922598ac97eb41"
   dependencies:


### PR DESCRIPTION
no issue
- align Travis config more closely to default ember-cli setup
- run Chrome in headless mode in CI (Travis + `ember test`, `ember test --server` is "dev" mode)
- install yarn via install script rather than npm
- remove broccoli cache from Travis cache (not sure it ever worked?)
- remove forced node-sass install (no longer needed)
- add `testem` as a top-level dep to force the latest version (ember-data is pinned at 1.15)