### PR TITLE
Fix double scrollbar in code injection editor of PSM

### DIFF
--- a/app/styles/components/settings-menu.css
+++ b/app/styles/components/settings-menu.css
@@ -209,6 +209,8 @@
 
 .settings-menu-content .CodeMirror-scroll {
     min-height: 170px;
+    overflow: hidden !important;
+    margin-right: 0;
 }
 
 /* Background


### PR DESCRIPTION
Fixes double scrollbar problem in code injection editor of PSM

refs #838, TryGhost/Ghost#8896

Before:
![double-scrollbar-exists](https://user-images.githubusercontent.com/2657006/30107602-36f5a6b2-933a-11e7-9b2b-9160a3e81cd5.png)

After:
![double-scrollbar-removed_](https://user-images.githubusercontent.com/2657006/30107646-5c76f3e6-933a-11e7-8d31-243d5781c13e.png)
