### PR TITLE
Remove wishlist links

### DIFF
--- a/app/html/apps.html
+++ b/app/html/apps.html
@@ -67,7 +67,6 @@
                     <li role="presentation"><a class="dropdown-item help-menu-how-to" role="menuitem" tabindex="-1" href="http://support.ghost.org/how-to-use-ghost/" target="_blank"><i class="icon-book"></i> How to Use Ghost</a></li>
                     <li role="presentation"><a class="dropdown-item help-menu-markdown" role="menuitem" tabindex="-1" href="" data-ember-action="1036"><i class="icon-markdown"></i> Markdown Help</a></li>
                     <li class="divider"></li>
-                    <li role="presentation"><a class="dropdown-item help-menu-wishlist" role="menuitem" tabindex="-1" href="http://ideas.ghost.org/" target="_blank"><i class="icon-idea"></i> Wishlist</a></li>
                 </ul>
 </div>        </div>
     </footer>

--- a/app/html/themes.html
+++ b/app/html/themes.html
@@ -67,7 +67,6 @@
                     <li role="presentation"><a class="dropdown-item help-menu-how-to" role="menuitem" tabindex="-1" href="http://support.ghost.org/how-to-use-ghost/" target="_blank"><i class="icon-book"></i> How to Use Ghost</a></li>
                     <li role="presentation"><a class="dropdown-item help-menu-markdown" role="menuitem" tabindex="-1" href="" data-ember-action="1036"><i class="icon-markdown"></i> Markdown Help</a></li>
                     <li class="divider"></li>
-                    <li role="presentation"><a class="dropdown-item help-menu-wishlist" role="menuitem" tabindex="-1" href="http://ideas.ghost.org/" target="_blank"><i class="icon-idea"></i> Wishlist</a></li>
                 </ul>
 </div>        </div>
     </footer>

--- a/app/templates/components/gh-nav-menu.hbs
+++ b/app/templates/components/gh-nav-menu.hbs
@@ -15,9 +15,7 @@
             <li role="presentation">{{#link-to "team.user" session.user.slug classNames="dropdown-item user-menu-profile js-nav-item" role="menuitem" tabindex="-1"}}{{inline-svg "user-circle"}} Your Profile{{/link-to}}</li>
             <li role="presentation"><a class="dropdown-item help-menu-support" role="menuitem" tabindex="-1" href="https://help.ghost.org/" target="_blank">{{inline-svg "ambulance"}} Support Center</a></li>
             <li role="presentation"><a class="dropdown-item help-menu-tweet" role="menuitem" tabindex="-1" href="https://twitter.com/intent/tweet?text=%40TryGhost+Hi%21+Can+you+help+me+with+&related=TryGhost" target="_blank" onclick="window.open(this.href, 'twitter-share', 'width=550,height=235');return false;">{{inline-svg "twitter"}} Tweet @TryGhost!</a></li>
-            <li class="divider"></li>
             <li role="presentation"><a class="dropdown-item help-menu-how-to" role="menuitem" tabindex="-1" href="https://ghosthelp.zendesk.com/hc/en-us/categories/203268947-Ghost-Pro-" target="_blank">{{inline-svg "book-open"}} How to Use Ghost</a></li>
-            <li role="presentation"><a class="dropdown-item help-menu-wishlist" role="menuitem" tabindex="-1" href="http://ideas.ghost.org/" target="_blank">{{inline-svg "idea"}} Wishlist</a></li>
             <li class="divider"></li>
 
             {{#if showDropdownExtension}}

--- a/app/templates/publishbutton.html
+++ b/app/templates/publishbutton.html
@@ -67,7 +67,6 @@
         <li role="presentation"><a role="menuitem" tabindex="-1" href="https://twitter.com/intent/tweet?text=%40TryGhost+Hi%21+Can+you+help+me+with+&amp;related=TryGhost" target="_blank" onclick="window.open(this.href, 'twitter-share', 'width=550,height=235');return false;" class="dropdown-item help-menu-tweet"><i class="icon-twitter"></i> Tweet @TryGhost!</a></li>
         <li class="divider"></li>
         <li role="presentation"><a role="menuitem" tabindex="-1" href="http://support.ghost.org/how-to-use-ghost/" target="_blank" class="dropdown-item help-menu-how-to"><i class="icon-book"></i> How to Use Ghost</a></li>
-        <li role="presentation"><a role="menuitem" tabindex="-1" href="http://ideas.ghost.org/" target="_blank" class="dropdown-item help-menu-wishlist"><i class="icon-idea"></i> Wishlist</a></li>
         <li class="divider"></li>
         <li role="presentation"><a tabindex="-1" href="/ghost/signout/" id="ember1037" class="dropdown-item user-menu-signout ember-view"><i class="icon-signout"></i> Sign Out</a></li>
     </ul>


### PR DESCRIPTION
No issue

The uservoice wishlist has been pretty inactive and neglected for quite a long time now. Removing links to it from Ghost is the first step toward retiring it. We're still listening to user feedback in order to determine the Ghost roadmap, but simplifying the process around it.

Matches https://github.com/TryGhost/Ghost/pull/8981