### PR TITLE
Remove unwanted String.prototype extensions

### DIFF
--- a/app/utils/format-markdown.js
+++ b/app/utils/format-markdown.js
@@ -4,7 +4,41 @@ import markdownit from 'npm:markdown-it';
 import markdownitFootnote from 'npm:markdown-it-footnote';
 import markdownitLazyHeaders from 'npm:markdown-it-lazy-headers';
 import markdownitMark from 'npm:markdown-it-mark';
-import markdownitNamedHeaders from 'npm:markdown-it-named-headers';
+
+let slugify = function slugify(inputString, usedHeaders) {
+    let slug = inputString.replace(/[^\w]/g, '').toLowerCase();
+    if (usedHeaders[slug]) {
+        usedHeaders[slug]++;
+        slug += usedHeaders[slug];
+    }
+    return slug;
+};
+
+// originally from https://github.com/leff/markdown-it-named-headers
+// moved here to avoid pulling in http://stringjs.com dependency
+let markdownitNamedHeaders = function markdownitNamedHeaders(md) {
+    let originalHeadingOpen = md.renderer.rules.heading_open;
+
+    // eslint-disable-next-line camelcase
+    md.renderer.rules.heading_open = function (tokens, idx, options, env, self) {
+        let usedHeaders = {};
+
+        tokens[idx].attrs = tokens[idx].attrs || [];
+
+        let title = tokens[idx + 1].children.reduce(function (acc, t) {
+            return acc + t.content;
+        }, '');
+
+        let slug = slugify(title, usedHeaders);
+        tokens[idx].attrs.push(['id', slug]);
+
+        if (originalHeadingOpen) {
+            return originalHeadingOpen.apply(this, arguments);
+        } else {
+            return self.renderToken(...arguments);
+        }
+    };
+};
 
 // eslint-disable-next-line new-cap
 let md = markdownit({
@@ -15,17 +49,7 @@ let md = markdownit({
 .use(markdownitFootnote)
 .use(markdownitLazyHeaders)
 .use(markdownitMark)
-.use(markdownitNamedHeaders, {
-    // match legacy Showdown IDs otherwise default is github style dasherized
-    slugify(inputString, usedHeaders) {
-        let slug = inputString.replace(/[^\w]/g, '').toLowerCase();
-        if (usedHeaders[slug]) {
-            usedHeaders[slug]++;
-            slug += usedHeaders[slug];
-        }
-        return slug;
-    }
-});
+.use(markdownitNamedHeaders);
 
 export default function formatMarkdown(_markdown, replaceJS = true) {
     let markdown = _markdown || '';

--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "markdown-it-footnote": "3.0.1",
     "markdown-it-lazy-headers": "0.1.3",
     "markdown-it-mark": "2.0.0",
-    "markdown-it-named-headers": "0.0.4",
     "matchdep": "2.0.0",
     "password-generator": "2.1.0",
     "postcss-color-function": "4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6431,12 +6431,6 @@ markdown-it-mark@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/markdown-it-mark/-/markdown-it-mark-2.0.0.tgz#46a1aa947105aed8188978e0a016179e404f42c7"
 
-markdown-it-named-headers@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/markdown-it-named-headers/-/markdown-it-named-headers-0.0.4.tgz#82efc28324240a6b1e77b9aae501771d5f351c1f"
-  dependencies:
-    string "^3.0.1"
-
 markdown-it-terminal@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/markdown-it-terminal/-/markdown-it-terminal-0.1.0.tgz#545abd8dd01c3d62353bfcea71db580b51d22bd9"
@@ -8682,10 +8676,6 @@ string-width@^2.0.0:
 string.prototype.startswith@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/string.prototype.startswith/-/string.prototype.startswith-0.2.0.tgz#da68982e353a4e9ac4a43b450a2045d1c445ae7b"
-
-string@^3.0.1:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/string/-/string-3.3.3.tgz#5ea211cd92d228e184294990a6cc97b366a77cb0"
 
 string_decoder@0.10, string_decoder@~0.10.0, string_decoder@~0.10.x:
   version "0.10.31"


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8958
- `markdown-it-named-headers` pulled in [`string.js`](http://stringjs.com) despite it not being used which added a lot of String.prototype extensions and caused Ember deprecation notices
- moves the short `markdown-it-named-headers` functionality directly into our app code without using `String.js`