### PR TITLE
🐛  Fix team page regression bug

### DIFF
--- a/app/templates/team/index.hbs
+++ b/app/templates/team/index.hbs
@@ -79,13 +79,13 @@
             {{#if session.user.isAuthor}}
                 {{#with session.user as |user|}}
                     {{#gh-user-active user=user as |component|}}
-                        {{gh-user-list-item user=user}}
+                        {{gh-user-list-item user=user component=component}}
                     {{/gh-user-active}}
                 {{/with}}
             {{else}}
                 {{#each sortedActiveUsers key="id" as |user|}}
                     {{#gh-user-active user=user as |component|}}
-                        {{gh-user-list-item user=user}}
+                        {{gh-user-list-item user=user component=component}}
                     {{/gh-user-active}}
                 {{/each}}
             {{/if}}


### PR DESCRIPTION
closes TryGhost/Ghost#8996

Fixes a bug, where properties in a nested component where not available and resulted in not rendering the users' profile images and 'last seen' dates on the team page.