### PR TITLE
🐛  Fix datepicker bug for post dates in past

### DIFF
--- a/app/components/gh-date-time-picker.js
+++ b/app/components/gh-date-time-picker.js
@@ -20,6 +20,9 @@ export default Component.extend({
     _previousTime: '',
     _minDate: null,
     _maxDate: null,
+    // used to populate the initial date value in the date picker, before
+    // it gets updated and re-rendered to reflect those changes.
+    _initialDate: null,
 
     blogTimezone: reads('settings.activeTimezone'),
     hasError: or('dateError', 'timeError'),
@@ -55,13 +58,13 @@ export default Component.extend({
         let blogTimezone = this.get('blogTimezone');
 
         if (!isBlank(date)) {
-            this.set('_date', moment(date));
+            this.set('_initialDate', moment(date));
         } else {
-            this.set('_date', moment().tz(blogTimezone));
+            this.set('_initialDate', moment().tz(blogTimezone));
         }
 
         if (isBlank(time)) {
-            this.set('_time', this.get('_date').format('HH:mm'));
+            this.set('_time', this.get('_initialDate').format('HH:mm'));
         } else {
             this.set('_time', this.get('time'));
         }
@@ -83,6 +86,25 @@ export default Component.extend({
         } else {
             this.set('_maxDate', null);
         }
+    },
+
+    didUpdateAttrs() {
+        let date = this.get('date');
+        let time = this.get('time');
+        let blogTimezone = this.get('blogTimezone');
+
+        if (!isBlank(date)) {
+            this.set('_date', moment(date));
+        } else {
+            this.set('_date', moment().tz(blogTimezone));
+        }
+
+        if (isBlank(time)) {
+            this.set('_time', this.get('_date').format('HH:mm'));
+        } else {
+            this.set('_time', this.get('time'));
+        }
+        this.set('_previousTime', this.get('_time'));
     },
 
     actions: {

--- a/app/templates/components/gh-date-time-picker.hbs
+++ b/app/templates/components/gh-date-time-picker.hbs
@@ -7,7 +7,7 @@
     }}
         {{#dp.trigger tabindex="-1" data-test-date-time-picker-datepicker=true}}
             <div class="gh-date-time-picker-date {{if dateError "error"}}">
-                <input type="text" readonly value={{moment-format _date "MM/DD/YYYY"}} disabled={{disabled}} data-test-date-time-picker-date-input>
+                <input type="text" readonly value={{moment-format _initialDate "MM/DD/YYYY"}} disabled={{disabled}} data-test-date-time-picker-date-input>
                 {{inline-svg "calendar"}}
             </div>
         {{/dp.trigger}}


### PR DESCRIPTION
closes TryGhost/Ghost#8891

Having a very old post date, reverting it to a draft and then planning to publish/schedule it, resulted in the datepicker dropdown navigation to show a the wrong date. This was caused, because in the `gh-date-time-picker.js` component, we used only the `didReceiveAttrs()` hook to populate the needed `_date` property. Once, this property is passed to the `power-datepicker`'s navigation `dp.nav' it wouldn't get updated, when the value was changed.

In this PR, I added a property `_initalDate` to the `gh-date-time-picker` component, which will get populated in the `didReceiveAttrs()` hook with the same values as before my changes and used to render the date in the input field (which is read-only). I additionally added a `didUpdateAttrs()` hook, which then sets the `_date` property after any changes of the blog publish date and gets passed as the value for the `power-datepicker`. Any other changes on the publish date/time reflects this.

- adds `didUpdateAttrs()` to `gh-date-time-picker` component
- adds `_initialDate` property which is used in the read-only input fields and is populated in the `didReceiveAttrs()`

---

I don't know if this is the most correct/elegant way, but I tried many different approaches. It didn't seem to me like the issue was a wrongly set `published_at` time, but rather the value passed to the `power-datepicker` before being updated with the correct value. 

Ember `power-calender`, which is one of the components used in Ember `power-datepicker`, offers a [customisation of the navigation](http://www.ember-power-calendar.com/docs/the-nav) (the date/time that appears in the dropdown calender), but there seems to be no way of doing the same in `power-datepicker`. See [here](https://ember-datepicker.development.pagefrontapp.com/).

The end-result of this PR is this:

![datepicker_bug](https://user-images.githubusercontent.com/8037602/30313466-ab3066e8-97c7-11e7-9c40-37c45193f421.gif)
