### PR TITLE
🐛 Fixed "scheduled at" datepicker not showing correct month when opening

### DIFF
--- a/app/templates/components/gh-date-time-picker.hbs
+++ b/app/templates/components/gh-date-time-picker.hbs
@@ -1,6 +1,7 @@
 <div class="gh-date-time-picker">
     {{#power-datepicker
         selected=_date
+        center=_date
         onSelect=(action "setDate" value="date")
         renderInPlace=true
         disabled=disabled as |dp|


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8891

- set the `center` option as well as the `selected` option for `{{power-datepicker}}` inside `{{gh-date-time-picker}}` to force the month view to jump to the correct date when the selection changes