### PR TITLE
Improve built JS compatibility with CloudFlare's Auto Minify feature

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -134,6 +134,13 @@ module.exports = function (defaults) {
             enabled: true,
             extensions: ['js', 'css', 'png', 'jpg', 'jpeg', 'gif', 'map']
         },
+        minifyJS: {
+            options: {
+                output: {
+                    semicolons: true
+                }
+            }
+        },
         nodeAssets: {
             'blueimp-md5': {
                 import: ['js/md5.js']


### PR DESCRIPTION
refs TryGhost/Ghost#8815, TryGhost/Ghost#8840, TryGhost/Ghost#8842, TryGhost/Ghost#8849
- `ember-cli` 2.14 introduced some [new defaults for uglify-js](https://github.com/ember-cli/ember-cli/pull/7077) that resulted in CloudFlare's Auto Minify feature mangling the JS files and causing syntax errors
- revert the `semicolons: false` option to restore compatibility

**Note:** This does _not_ mean it's recommended to use CloudFlare's Auto Minify feature. It's still recommended that all CloudFlare's performance settings are [disabled for /ghost* URLs](https://docs.ghost.org/docs/troubleshooting#section-ghost-admin-not-loading)