### PR TITLE
🎨 Link tags story count to filtered stories list

### DIFF
--- a/app/templates/components/gh-tag.hbs
+++ b/app/templates/components/gh-tag.hbs
@@ -8,6 +8,10 @@
         {{/if}}
 
         <p class="tag-description">{{tag.description}}</p>
-        <span class="tags-count">{{tag.count.posts}}</span>
+        <span class="tags-count">
+            {{#link-to "posts" (query-params type=null author=null tag=tag.slug order=null)}}
+                {{tag.count.posts}}
+            {{/link-to}}
+        </span>
     {{/link-to}}
 </div>


### PR DESCRIPTION
no issue
- adds a link to the existing stories count in the tags list that when clicked will transition to the stories screen showing all stories with that tag

![tags-link](https://user-images.githubusercontent.com/415/30650489-eabb1d86-9e1a-11e7-87b8-562894f89682.gif)
