### PR TITLE
Upload/Download redirects UI

### DIFF
--- a/app/components/gh-uploader.js
+++ b/app/components/gh-uploader.js
@@ -69,7 +69,7 @@ export default Component.extend({
     onComplete() {},
     onFailed() {},
     onStart() {},
-    onUploadFail() {},
+    onUploadFailure() {},
     onUploadSuccess() {},
 
     // Optional closure actions
@@ -240,7 +240,7 @@ export default Component.extend({
 
             // TODO: check for or expose known error types?
             this.get('errors').pushObject(result);
-            this.onUploadFail(result);
+            this.onUploadFailure(result);
         }
     }),
 

--- a/app/controllers/settings/general.js
+++ b/app/controllers/settings/general.js
@@ -110,7 +110,7 @@ export default Controller.extend({
             if (fileInput.length > 0) {
                 // reset file input value before clicking so that the same image
                 // can be selected again
-                fileInput.value = '';
+                fileInput.val('');
 
                 // simulate click to open file dialog
                 // using jQuery because IE11 doesn't support MouseEvent

--- a/app/templates/settings/general.hbs
+++ b/app/templates/settings/general.hbs
@@ -63,11 +63,9 @@
             <div class="gh-setting-content">
                 <div class="gh-setting-title">Publication icon</div>
                 <div class="gh-setting-desc">A square, social icon used in the UI of your publication, at least 60x60px</div>
-                {{#if uploader.errors}}
-                    {{#each uploader.errors as |error|}}
-                        <div class="gh-setting-error" data-test-error="icon">{{error.message}}</div>
-                    {{/each}}
-                {{/if}}
+                {{#each uploader.errors as |error|}}
+                    <div class="gh-setting-error" data-test-error="icon">{{error.message}}</div>
+                {{/each}}
             </div>
             <div class="gh-setting-action gh-setting-action-smallimg">
                 {{#if uploader.isUploading}}
@@ -98,11 +96,9 @@
             <div class="gh-setting-content">
                 <div class="gh-setting-title">Publication logo</div>
                 <div class="gh-setting-desc">The primary logo for your brand displayed across your theme, should be transparent and at least 600px x 72px</div>
-                {{#if uploader.errors}}
-                    {{#each uploader.errors as |error|}}
-                        <div class="gh-setting-error" data-test-error="logo">{{error.message}}</div>
-                    {{/each}}
-                {{/if}}
+                {{#each uploader.errors as |error|}}
+                    <div class="gh-setting-error" data-test-error="logo">{{error.message}}</div>
+                {{/each}}
             </div>
             <div class="gh-setting-action gh-setting-action-smallimg">
                 {{#if uploader.isUploading}}
@@ -133,11 +129,9 @@
             <div class="gh-setting-content">
                 <div class="gh-setting-title">Publication cover</div>
                 <div class="gh-setting-desc">An optional large background image for your site</div>
-                {{#if uploader.errors}}
-                    {{#each uploader.errors as |error|}}
-                        <div class="gh-setting-error" data-test-error="coverImage">{{error.message}}</div>
-                    {{/each}}
-                {{/if}}
+                {{#each uploader.errors as |error|}}
+                    <div class="gh-setting-error" data-test-error="coverImage">{{error.message}}</div>
+                {{/each}}
             </div>
             <div class="gh-setting-action gh-setting-action-largeimg">
                 {{#if uploader.isUploading}}

--- a/app/templates/settings/labs.hbs
+++ b/app/templates/settings/labs.hbs
@@ -51,7 +51,7 @@
                 <div class="gh-setting-desc">Download all of your posts and settings in a single, glorious JSON file</div>
             </div>
             <div class="gh-setting-action">
-                <button type="button" class="gh-btn gh-btn-hover-blue" {{action "exportData"}}><span>Export</span></button>
+                <button type="button" class="gh-btn gh-btn-hover-blue" {{action "downloadFile" "db"}}><span>Export</span></button>
             </div>
         </div>
         <div class="gh-setting">
@@ -102,6 +102,52 @@
             <div class="gh-setting-action">
                 <div class="for-checkbox">{{gh-feature-flag "subscribers"}}</div>
             </div>
+        </div>
+        <div class="gh-setting">
+            {{#gh-uploader
+                files=redirectsUpload
+                extensions=jsonExtension
+                uploadUrl="/redirects/json/"
+                paramName="redirects"
+                onUploadSuccess=(perform redirectUploadResult true)
+                onUploadFailure=(perform redirectUploadResult false)
+                as |uploader|
+            }}
+            <div class="gh-setting-content">
+                <div class="gh-setting-title">Redirects</div>
+                <div class="gh-setting-desc">Configure redirects for old or moved content, more info in <a href="https://docs.ghost.org/v1/docs/redirects">the docs</a></div>
+                {{#each uploader.errors as |error|}}
+                    <div class="gh-setting-error" data-test-error="redirects">{{error.message}}</div>
+                {{/each}}
+            </div>
+            <div class="gh-setting-action" style="display: flex; flex-direction: column">
+                {{#if uploader.isUploading}}
+                    {{uploader.progressBar}}
+                {{else}}
+                    <button
+                        type="button"
+                        class="gh-btn gh-btn-icon {{if redirectSuccess "gh-btn-green"}} {{if redirectFailure "gh-btn-red"}}"
+                        onclick={{action "triggerFileDialog"}}
+                        data-test-button="upload-redirects"
+                    >
+                        <span>
+                            {{#if redirectSuccess}}
+                                {{inline-svg "check-circle"}} Uploaded
+                            {{else if redirectFailure}}
+                                {{inline-svg "retry"}} Upload Failed
+                            {{else}}
+                                Upload redirects JSON
+                            {{/if}}
+                        </span>
+                    </button>
+                    <span><a href="#" {{action "downloadFile" "redirects/json"}} data-test-link="download-redirects">Download current redirects</a></span>
+                {{/if}}
+
+                <div style="display:none">
+                    {{gh-file-input multiple=false action=(action (mut redirectsUpload)) accept=jsonMimeType data-test-file-input="redirects"}}
+                </div>
+            </div>
+            {{/gh-uploader}}
         </div>
 
     </section>

--- a/tests/integration/components/gh-uploader-test.js
+++ b/tests/integration/components/gh-uploader-test.js
@@ -375,13 +375,13 @@ describe('Integration: Component: gh-uploader', function() {
             expect(failures[0].message).to.equal('Error: No upload for you');
         });
 
-        it('triggers onUploadFail when each upload fails', async function () {
+        it('triggers onUploadFailure when each upload fails', async function () {
             this.set('uploadFail', sinon.spy());
 
             this.render(hbs`
                 {{#gh-uploader
                     files=files
-                    onUploadFail=(action uploadFail)}}
+                    onUploadFailure=(action uploadFail)}}
                 {{/gh-uploader}}
             `);
             this.set('files', [


### PR DESCRIPTION
refs TryGhost/Ghost#9028

- add upload/download UI to labs screen
  - displays success/failure state in the button for 5 secs after uploading
- minor refactor to remove redundant `{{#if}}` conditionals in general settings screen
- minor naming refactor of `onUploadFail` -> `onUploadFailure` for `{{gh-uploader}}`'s closure action

![redirects-ui](https://user-images.githubusercontent.com/415/30693550-ff40a110-9ec7-11e7-8791-bb6fc19914fb.gif)


## TODO

- [x] tests
- [x] show success/failure state in the upload button for a few seconds after upload
- [x] manual test with server-side PR