### PR TITLE
Fixed missing Unsplash icons when API doesn't return an unsplash setting

### DIFF
--- a/app/models/setting.js
+++ b/app/models/setting.js
@@ -25,5 +25,5 @@ export default Model.extend(ValidationEngine, {
     password: attr('string'),
     slack: attr('slack-settings'),
     amp: attr('boolean'),
-    unsplash: attr('unsplash-settings')
+    unsplash: attr('unsplash-settings', {defaultValue: {isActive: true}})
 });

--- a/app/transforms/unsplash-settings.js
+++ b/app/transforms/unsplash-settings.js
@@ -2,23 +2,27 @@
 import Transform from 'ember-data/transform';
 import UnsplashObject from 'ghost-admin/models/unsplash-integration';
 
+const DEFAULT_SETTINGS = {
+    isActive: true
+};
+
 export default Transform.extend({
     deserialize(serialized) {
         if (serialized) {
             let settingsObject;
             try {
-                settingsObject = JSON.parse(serialized) || {};
+                settingsObject = JSON.parse(serialized) || DEFAULT_SETTINGS;
             } catch (e) {
-                settingsObject = {};
+                settingsObject = DEFAULT_SETTINGS;
             }
 
             return UnsplashObject.create(settingsObject);
         }
 
-        return null;
+        return DEFAULT_SETTINGS;
     },
 
     serialize(deserialized) {
-        return deserialized ? JSON.stringify(deserialized) : {};
+        return deserialized ? JSON.stringify(deserialized) : JSON.stringify(DEFAULT_SETTINGS);
     }
 });

--- a/tests/acceptance/editor-test.js
+++ b/tests/acceptance/editor-test.js
@@ -763,5 +763,16 @@ describe('Acceptance: Editor', function() {
                 'facebook title not present after closing subview'
             ).to.equal(0);
         });
+
+        it('has unsplash icon when server doesn\'t return unsplash settings key', async function () {
+            server.createList('post', 1);
+
+            await visit('/editor/1');
+
+            expect(
+                find('.editor-toolbar .fa-camera'),
+                'unsplash toolbar button'
+            ).to.exist;
+        });
     });
 });

--- a/tests/unit/transforms/unsplash-settings-test.js
+++ b/tests/unit/transforms/unsplash-settings-test.js
@@ -1,0 +1,46 @@
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupTest} from 'ember-mocha';
+
+describe('Unit: Transform: unsplash-settings', function () {
+    setupTest('transform:unsplash-settings', {
+        // Specify the other units that are required for this test.
+        // needs: ['transform:foo']
+    });
+
+    it('deserializes to default value when null', function () {
+        let serialized = null;
+        let result = this.subject().deserialize(serialized);
+        expect(result.isActive).to.be.true;
+    });
+
+    it('deserializes to default value when blank string', function () {
+        let serialized = '';
+        let result = this.subject().deserialize(serialized);
+        expect(result.isActive).to.be.true;
+    });
+
+    it('deserializes to default value when invalid JSON', function () {
+        let serialized = 'not JSON';
+        let result = this.subject().deserialize(serialized);
+        expect(result.isActive).to.be.true;
+    });
+
+    it('deserializes valid JSON object', function () {
+        let serialized = '{"isActive":false}';
+        let result = this.subject().deserialize(serialized);
+        expect(result.isActive).to.be.false;
+    });
+
+    it('serializes to JSON string', function () {
+        let deserialized = {isActive: false};
+        let result = this.subject().serialize(deserialized);
+        expect(result).to.equal('{"isActive":false}');
+    });
+
+    it('serializes to default value when blank', function () {
+        let deserialized = '';
+        let result = this.subject().serialize(deserialized);
+        expect(result).to.equal('{"isActive":true}');
+    });
+});


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/9031
- add a default value `unsplash` value to the `setting` model so that Unsplash is activated when the server doesn't return an `unsplash` setting
- update the `unsplash-settings` transform to always deserialize or serialize to `{isActive: true}` when the value is blank or not parsable
- add acceptance regression test covering API not returning an `unplash` setting
- add unit tests for the `unsplash-settings` transform