### PR TITLE
🐛 Fixed unreadable Unsplash search text in Night Shift mode

### DIFF
--- a/app/styles/app-dark.css
+++ b/app/styles/app-dark.css
@@ -308,6 +308,10 @@ input,
     color: #fff;
 }
 
+.gh-unsplash-search:focus {
+    background-color: color(var(--lightgrey));
+}
+
 .gh-unsplash-zoom {
     background: rgba(0,0,0,0.8);
 }


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/9030
- don't change the search input's background color when the input has focus in Night Shift

Before:
![unsplash-search-before](https://user-images.githubusercontent.com/415/30686694-f9c6742e-9eb0-11e7-9a03-64f2bfc92ad4.gif)

After:
![unsplash-search-after](https://user-images.githubusercontent.com/415/30686702-ff679782-9eb0-11e7-8c9a-d223fb16216c.gif)
