### PR TITLE
🐛 Fixed incorrect Home/End key behaviour on Windows

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8512,7 +8512,7 @@ simple-swizzle@^0.2.2:
 
 "simplemde@https://github.com/kevinansfield/simplemde-markdown-editor.git#ghost":
   version "1.11.2"
-  resolved "https://github.com/kevinansfield/simplemde-markdown-editor.git#42971ea4d997f5bec519c1c68cf63bda6b278cb2"
+  resolved "https://github.com/kevinansfield/simplemde-markdown-editor.git#f2e981845cbcbb5b50d0df3c12b4d56f8412412a"
   dependencies:
     codemirror "*"
     codemirror-spell-checker "*"


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8775
- upgrades our SimpleMDE fork
  - [bumps CodeMirror version to 5.30.0](https://github.com/kevinansfield/simplemde-markdown-editor/commit/b3e9f8b579fd3175064e62794d1c2d9f12811360)
  - [fixes Home/End key behaviour on Windows](https://github.com/kevinansfield/simplemde-markdown-editor/commit/f2e981845cbcbb5b50d0df3c12b4d56f8412412a)