### PR TITLE
🎣  Added modal for unsaved changes in settings

### DIFF
--- a/app/components/modal-leave-settings.js
+++ b/app/components/modal-leave-settings.js
@@ -1,0 +1,12 @@
+import ModalComponent from 'ghost-admin/components/modal-base';
+import {invokeAction} from 'ember-invoke-action';
+
+export default ModalComponent.extend({
+    actions: {
+        confirm() {
+            invokeAction(this, 'confirm').finally(() => {
+                this.send('closeModal');
+            });
+        }
+    }
+});

--- a/app/routes/settings/general.js
+++ b/app/routes/settings/general.js
@@ -26,6 +26,8 @@ export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
     },
 
     setupController(controller, models) {
+        // reset the leave setting transition
+        controller.set('leaveSettingsTransition', null);
         controller.set('model', models.settings);
         controller.set('themes', this.get('store').peekAll('theme'));
         controller.set('availableTimezones', models.availableTimezones);
@@ -38,6 +40,19 @@ export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
 
         reloadSettings() {
             return this.get('settings').reload();
+        },
+
+        willTransition(transition) {
+            let controller = this.get('controller');
+            let model = controller.get('model');
+            let modelIsDirty = model.get('hasDirtyAttributes');
+
+            if (modelIsDirty) {
+                transition.abort();
+                controller.send('toggleLeaveSettingsModal', transition);
+                return;
+            }
         }
+
     }
 });

--- a/app/templates/components/modal-leave-settings.hbs
+++ b/app/templates/components/modal-leave-settings.hbs
@@ -1,0 +1,17 @@
+<header class="modal-header">
+    <h1>Are you sure you want to leave this page?</h1>
+</header>
+<a class="close" href="" title="Close" {{action "closeModal"}}>{{inline-svg "close"}}<span class="hidden">Close</span></a>
+
+<div class="modal-body">
+    <p>
+        Hey there! It looks like you didn't save the changes you made.
+    </p>
+
+    <p>Save before you go!</p>
+</div>
+
+<div class="modal-footer">
+    <button {{action "closeModal"}} class="gh-btn" data-test-stay-button><span>Stay</span></button>
+    <button {{action "confirm"}} class="gh-btn gh-btn-red" data-test-leave-button><span>Leave</span></button>
+</div>

--- a/app/templates/settings/general.hbs
+++ b/app/templates/settings/general.hbs
@@ -6,6 +6,13 @@
         </section>
     </header>
 
+    {{#if showLeaveSettingsModal}}
+        {{gh-fullscreen-modal "leave-settings"
+            confirm=(action "leaveSettings")
+            close=(action "toggleLeaveSettingsModal")
+            modifier="action wide"}}
+    {{/if}}
+
     <section class="view-container">
 
         <div class="gh-setting-header">Publication info</div>

--- a/tests/acceptance/settings/general-test.js
+++ b/tests/acceptance/settings/general-test.js
@@ -472,5 +472,48 @@ describe('Acceptance: Settings - General', function () {
             expect(find('[data-test-twitter-error]').text().trim(), 'inline validation response')
                 .to.equal('');
         });
+
+        it('warns when leaving without saving', async function () {
+            await visit('/settings/general');
+
+            expect(
+                find('[data-test-dated-permalinks-checkbox]').prop('checked'),
+                'date permalinks checkbox'
+            ).to.be.false;
+
+            await click('[data-test-toggle-pub-info]');
+            await fillIn('[data-test-title-input]', 'New Blog Title');
+
+            await click('[data-test-dated-permalinks-checkbox]');
+
+            expect(
+                find('[data-test-dated-permalinks-checkbox]').prop('checked'),
+                'dated permalink checkbox'
+            ).to.be.true;
+
+            await visit('/settings/team');
+
+            expect(find('.fullscreen-modal').length, 'modal exists').to.equal(1);
+
+            // Leave without saving
+            await(click('.fullscreen-modal [data-test-leave-button]'), 'leave without saving');
+
+            expect(currentURL(), 'currentURL').to.equal('/settings/team');
+
+            await visit('/settings/general');
+
+            expect(currentURL(), 'currentURL').to.equal('/settings/general');
+
+            // settings were not saved
+            expect(
+                find('[data-test-dated-permalinks-checkbox]').prop('checked'),
+                'date permalinks checkbox'
+            ).to.be.false;
+
+            expect(
+                find('[data-test-title-input]').text().trim(),
+                'Blog title'
+            ).to.equal('');
+        });
     });
 });


### PR DESCRIPTION
closes TryGhost/Ghost#8483

![leave-settings-model](https://user-images.githubusercontent.com/8037602/30907155-29d5007a-a3a4-11e7-98f4-f94b431eb78c.gif)

- Added a new modal component that gets rendered when leaving general/settings after changes have been done but not saved
- Added test

TODOs:
- [x] clarify behaviour for Twitter and Facebook, as they get saved independently from the save-button as soon as a valid input is given