### PR TITLE
Fix normalization of attrs in Mirage config and tests

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -72,6 +72,10 @@ export function testConfig() {
         };
     });
 
+    this.head('http://www.gravatar.com/avatar/:md5', function () {
+        return '';
+    }, 200);
+
     this.get('http://www.gravatar.com/avatar/:md5', function () {
         return '';
     }, 200);

--- a/mirage/config/authentication.js
+++ b/mirage/config/authentication.js
@@ -53,8 +53,8 @@ export default function mockAuthentication(server) {
 
     /* Setup ---------------------------------------------------------------- */
 
-    server.post('/authentication/setup', function ({roles, users}, request) {
-        let [attrs] = JSON.parse(request.requestBody).setup;
+    server.post('/authentication/setup', function ({roles, users}) {
+        let attrs = this.normalizedRequestAttrs();
         let role = roles.findBy({name: 'Owner'});
 
         // create owner role unless already exists

--- a/mirage/config/invites.js
+++ b/mirage/config/invites.js
@@ -28,10 +28,10 @@ export default function mockInvites(server) {
         /* eslint-disable camelcase */
         attrs.token = `${invites.all().models.length}-token`;
         attrs.expires = moment.utc().add(1, 'day').valueOf();
-        attrs.created_at = moment.utc().format();
-        attrs.created_by = 1;
-        attrs.updated_at = moment.utc().format();
-        attrs.updated_by = 1;
+        attrs.createdAt = moment.utc().format();
+        attrs.createdBy = 1;
+        attrs.updatedAt = moment.utc().format();
+        attrs.updatedBy = 1;
         attrs.status = 'sent';
         /* eslint-enable camelcase */
 

--- a/mirage/config/posts.js
+++ b/mirage/config/posts.js
@@ -56,8 +56,8 @@ export default function mockPosts(server) {
     });
 
     // Handle embedded author in post
-    server.put('/posts/:id/', ({posts}, request) => {
-        let {posts: [post]} = JSON.parse(request.requestBody);
+    server.put('/posts/:id/', function ({posts}, request) {
+        let post = this.normalizedRequestAttrs();
         let {author} = post;
         delete post.author;
 

--- a/mirage/config/subscribers.js
+++ b/mirage/config/subscribers.js
@@ -5,8 +5,8 @@ import {paginatedResponse} from '../utils';
 export default function mockSubscribers(server) {
     server.get('/subscribers/', paginatedResponse('subscribers'));
 
-    server.post('/subscribers/', function ({subscribers}, request) {
-        let [attrs] = JSON.parse(request.requestBody).subscribers;
+    server.post('/subscribers/', function ({subscribers}) {
+        let attrs = this.normalizedRequestAttrs();
         let subscriber = subscribers.findBy({email: attrs.email});
 
         if (subscriber) {
@@ -18,8 +18,8 @@ export default function mockSubscribers(server) {
                 }]
             });
         } else {
-            attrs.created_at = new Date();
-            attrs.created_by = 0;
+            attrs.createdAt = new Date();
+            attrs.createdBy = 0;
 
             return subscribers.create(attrs);
         }

--- a/mirage/config/tags.js
+++ b/mirage/config/tags.js
@@ -3,8 +3,8 @@ import {isBlank} from '@ember/utils';
 import {paginatedResponse} from '../utils';
 
 export default function mockTags(server) {
-    server.post('/tags/', function ({tags}, {requestBody}) {
-        let [attrs] = JSON.parse(requestBody).tags;
+    server.post('/tags/', function ({tags}) {
+        let attrs = this.normalizedRequestAttrs();
 
         if (isBlank(attrs.slug) && !isBlank(attrs.name)) {
             attrs.slug = dasherize(attrs.name);

--- a/tests/acceptance/editor-test.js
+++ b/tests/acceptance/editor-test.js
@@ -567,7 +567,7 @@ describe('Acceptance: Editor', function() {
             ).to.match(/cannot be longer than 300/);
 
             expect(
-                server.db.posts[0].custom_excerpt,
+                server.db.posts.find(post.id).customExcerpt,
                 'saved excerpt after validation error'
             ).to.be.blank;
 
@@ -576,7 +576,7 @@ describe('Acceptance: Editor', function() {
             await triggerEvent('[data-test-field="custom-excerpt"]', 'blur');
 
             expect(
-                server.db.posts[0].custom_excerpt,
+                server.db.posts.find(post.id).customExcerpt,
                 'saved excerpt'
             ).to.equal('Testing excerpt');
 
@@ -596,7 +596,7 @@ describe('Acceptance: Editor', function() {
             ).to.match(/cannot be longer than 65535/);
 
             expect(
-                server.db.posts[0].codeinjection_head,
+                server.db.posts.find(post.id).codeinjectionHead,
                 'saved header injection after validation error'
             ).to.be.blank;
 
@@ -605,7 +605,7 @@ describe('Acceptance: Editor', function() {
             await triggerEvent(headerCM.getInputField(), 'blur');
 
             expect(
-                server.db.posts[0].codeinjection_head,
+                server.db.posts.find(post.id).codeinjectionHead,
                 'saved header injection'
             ).to.equal('<script src="http://example.com/inject-head.js"></script>');
 
@@ -620,7 +620,7 @@ describe('Acceptance: Editor', function() {
             ).to.match(/cannot be longer than 65535/);
 
             expect(
-                server.db.posts[0].codeinjection_foot,
+                server.db.posts.find(post.id).codeinjectionFoot,
                 'saved footer injection after validation error'
             ).to.be.blank;
 
@@ -629,7 +629,7 @@ describe('Acceptance: Editor', function() {
             await triggerEvent(footerCM.getInputField(), 'blur');
 
             expect(
-                server.db.posts[0].codeinjection_foot,
+                server.db.posts.find(post.id).codeinjectionFoot,
                 'saved footer injection'
             ).to.equal('<script src="http://example.com/inject-foot.js"></script>');
 
@@ -656,7 +656,7 @@ describe('Acceptance: Editor', function() {
             ).to.match(/cannot be longer than 300/);
 
             expect(
-                server.db.posts[0].twitter_title,
+                server.db.posts.find(post.id).twitterTitle,
                 'saved twitter title after validation error'
             ).to.be.blank;
 
@@ -666,7 +666,7 @@ describe('Acceptance: Editor', function() {
             await triggerEvent('[data-test-field="twitter-title"]', 'blur');
 
             expect(
-                server.db.posts[0].twitter_title,
+                server.db.posts.find(post.id).twitterTitle,
                 'saved twitter title'
             ).to.equal('Test Twitter Title');
 
@@ -680,7 +680,7 @@ describe('Acceptance: Editor', function() {
             ).to.match(/cannot be longer than 500/);
 
             expect(
-                server.db.posts[0].twitter_description,
+                server.db.posts.find(post.id).twitterDescription,
                 'saved twitter description after validation error'
             ).to.be.blank;
 
@@ -690,7 +690,7 @@ describe('Acceptance: Editor', function() {
             await triggerEvent('[data-test-field="twitter-description"]', 'blur');
 
             expect(
-                server.db.posts[0].twitter_description,
+                server.db.posts.find(post.id).twitterDescription,
                 'saved twitter description'
             ).to.equal('Test Twitter Description');
 
@@ -717,7 +717,7 @@ describe('Acceptance: Editor', function() {
             ).to.match(/cannot be longer than 300/);
 
             expect(
-                server.db.posts[0].og_title,
+                server.db.posts.find(post.id).ogTitle,
                 'saved facebook title after validation error'
             ).to.be.blank;
 
@@ -727,7 +727,7 @@ describe('Acceptance: Editor', function() {
             await triggerEvent('[data-test-field="og-title"]', 'blur');
 
             expect(
-                server.db.posts[0].og_title,
+                server.db.posts.find(post.id).ogTitle,
                 'saved facebook title'
             ).to.equal('Test Facebook Title');
 
@@ -741,7 +741,7 @@ describe('Acceptance: Editor', function() {
             ).to.match(/cannot be longer than 500/);
 
             expect(
-                server.db.posts[0].og_description,
+                server.db.posts.find(post.id).ogDescription,
                 'saved facebook description after validation error'
             ).to.be.blank;
 
@@ -751,7 +751,7 @@ describe('Acceptance: Editor', function() {
             await triggerEvent('[data-test-field="og-description"]', 'blur');
 
             expect(
-                server.db.posts[0].og_description,
+                server.db.posts.find(post.id).ogDescription,
                 'saved facebook description'
             ).to.equal('Test Facebook Description');
 

--- a/tests/acceptance/setup-test.js
+++ b/tests/acceptance/setup-test.js
@@ -238,8 +238,8 @@ describe('Acceptance: Setup', function () {
             invalidateSession(application);
             server.loadFixtures('roles');
 
-            server.post('/invites', function ({invites}, request) {
-                let [params] = JSON.parse(request.requestBody).invites;
+            server.post('/invites/', function ({invites}) {
+                let attrs = this.normalizedRequestAttrs();
 
                 postCount++;
 
@@ -256,17 +256,15 @@ describe('Acceptance: Setup', function () {
                 }
 
                 // TODO: duplicated from mirage/config/invites - extract method?
-                /* eslint-disable camelcase */
-                params.token = `${invites.all().models.length}-token`;
-                params.expires = moment.utc().add(1, 'day').valueOf();
-                params.created_at = moment.utc().format();
-                params.created_by = 1;
-                params.updated_at = moment.utc().format();
-                params.updated_by = 1;
-                params.status = 'sent';
-                /* eslint-enable camelcase */
+                attrs.token = `${invites.all().models.length}-token`;
+                attrs.expires = moment.utc().add(1, 'day').valueOf();
+                attrs.createdAt = moment.utc().format();
+                attrs.createdBy = 1;
+                attrs.updatedAt = moment.utc().format();
+                attrs.updatedBy = 1;
+                attrs.status = 'sent';
 
-                return invites.create(params);
+                return invites.create(attrs);
             });
 
             // complete step 2 so we can access step 3


### PR DESCRIPTION
no issue

We weren't being consistent in our use of Mirage's `normalizedRequestAttrs()` method which meant that in certain cases Mirage's internal database had duplicated attrs, the original set being `camelCase` and the new/updated set being `underscore_case` which was not only confusing but can lead to errors or unexpected behaviour in tests.

- updated Mirage config to always normalize where necessary
- updated tests to always use `camelCase` attrs
- added `HEAD` route handler for gravatar to avoid unknown route noise in tests