### PR TITLE
Fixes admin panel toggling issue on iOS devices

### DIFF
--- a/app/styles/layouts/main.css
+++ b/app/styles/layouts/main.css
@@ -314,6 +314,8 @@ body > .ember-view:not(.default-liquid-destination) {
         transform: translate3d(0,0,0);
     }
     .mobile-menu-expanded .content-cover {
+        width: 20vw;
+        cursor: pointer;
         transform: translate3d(80vw, 0, 0);
     }
 


### PR DESCRIPTION
Fixes admin panel toggling issue on iOS devices

Closes #8962
- Adding cursor css property to content-cover div to activate click
events on it (Known iOS quick fix)
- Adding width to content-cover to prevent overflowing