### PR TITLE
🐛 Fixed visibility of spellcheck errors in Night Shift mode

### DIFF
--- a/app/styles/app-dark.css
+++ b/app/styles/app-dark.css
@@ -329,3 +329,7 @@ input,
     background: var(--lightgrey);
     color: var(--darkgrey);
 }
+
+.CodeMirror .cm-spell-error:not(.cm-url):not(.cm-comment):not(.cm-tag):not(.cm-word) {
+    background: rgba(255, 0, 0, .30);
+}


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/9056
- decrease transparency of background color applied to spellcheck errors in night shift

Before:
<img width="400" alt="screen shot 2017-09-27 at 17 16 54" src="https://user-images.githubusercontent.com/415/30925193-ed245298-a3a8-11e7-93ee-06dc51abdf4a.png">

After:
<img width="400" alt="screen shot 2017-09-27 at 17 18 49" src="https://user-images.githubusercontent.com/415/30925201-f32fa9e4-a3a8-11e7-9ec1-a0d6ee3c15d1.png">

