### PR TITLE
🐛 Fixed broken "retry" link when an Unsplash API request failed

### DIFF
--- a/app/services/unsplash.js
+++ b/app/services/unsplash.js
@@ -54,6 +54,10 @@ export default Service.extend({
         return reject();
     },
 
+    retryLastRequest() {
+        return this.get('_retryLastRequest').perform();
+    },
+
     changeColumnCount(newColumnCount) {
         if (newColumnCount !== this.get('columnCount')) {
             this.set('columnCount', newColumnCount);


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/9041
- add missing public `retryLastRequest()` method to Unsplash service