### PR TITLE
Remove smartquotes

### DIFF
--- a/app/styles/layouts/editor.css
+++ b/app/styles/layouts/editor.css
@@ -476,7 +476,7 @@
 .gh-editor .CodeMirror pre {
     padding: 0;
     color: color(var(--darkgrey) l(+5%));
-    font-family: “Consolas”, monaco, monospace;
+    font-family: "Consolas", monaco, monospace;
     font-size: 1.6rem;
 }
 


### PR DESCRIPTION
There's only one instance of smartquotes, removed in the edited editor.css file

ref: TryGhost/Ghost#8867

I haven't been able to reproduce the issue in my version of Edge, but that doesn't really mean anything, since my version of Edge can't seem to run the Ghost admin interface without crashing. I'm going to attribute that to user error (because I've made a lot of core changes to Windows) but I will post updates when I get access to another Windows computer

Whether or not this is causing an issue in Edge, it's probably a good idea to not use smartquotes since it's only used in _one_ place (for consistency and whatnot) 😆 