### PR TITLE
🐛 Fixed search behaviour to not use RegExp

### DIFF
--- a/app/components/gh-search-input.js
+++ b/app/components/gh-search-input.js
@@ -14,9 +14,9 @@ export function computedGroup(category) {
         }
 
         return this.get('content').filter((item) => {
-            let search = new RegExp(this.get('currentSearch'), 'ig');
+            let search = this.get('currentSearch').toString().toLowerCase();
 
-            return (item.category === category) && item.title.match(search);
+            return (item.category === category) && (item.title.toString().toLowerCase().indexOf(search) >= 0);
         });
     });
 }

--- a/app/helpers/highlighted-text.js
+++ b/app/helpers/highlighted-text.js
@@ -2,7 +2,10 @@ import {helper} from '@ember/component/helper';
 import {htmlSafe} from '@ember/string';
 
 export function highlightedText([text, termToHighlight]) {
-    return htmlSafe(text.replace(new RegExp(termToHighlight, 'ig'), '<span class="highlight">$&</span>'));
+    // replace any non-word character with an escaped character
+    let sanitisedTerm = termToHighlight.replace(new RegExp(/\W/ig), '\\$&');
+
+    return htmlSafe(text.replace(new RegExp(sanitisedTerm, 'ig'), '<span class="highlight">$&</span>'));
 }
 
 export default helper(highlightedText);


### PR DESCRIPTION
closes TryGhost/Ghost#8959

- Treated the search input as a literal string rather than `RegExp` to allow characters that need escaping in `RegExp` and disable `RegExp` characters like `|`.
- Replaced any non-word characters in `highlighted-text` fn with escaped characters, so they're working with `RegExp`.

![regex_search](https://user-images.githubusercontent.com/8037602/30951455-4b9a6ee4-a44d-11e7-874a-a1777bbe73ad.gif)
