### PR TITLE
🐛 Fixed incorrect autosave of published posts when leaving editor

### DIFF
--- a/app/mixins/editor-base-controller.js
+++ b/app/mixins/editor-base-controller.js
@@ -71,27 +71,29 @@ export default Mixin.create({
 
     // save 3 seconds after the last edit
     _autosave: task(function* () {
+        if (!this.get('_canAutosave')) {
+            return;
+        }
+
         // force an instant save on first body edit for new posts
-        if (this.get('_canAutosave') && this.get('model.isNew')) {
+        if (this.get('model.isNew')) {
             return this.get('autosave').perform();
         }
 
         yield timeout(AUTOSAVE_TIMEOUT);
-
-        if (this.get('_canAutosave')) {
-            this.get('autosave').perform();
-        }
+        this.get('autosave').perform();
     }).restartable(),
 
     // save at 60 seconds even if the user doesn't stop typing
     _timedSave: task(function* () {
+        if (!this.get('_canAutosave')) {
+            return;
+        }
+
         // eslint-disable-next-line no-constant-condition
         while (!testing && true) {
             yield timeout(TIMEDSAVE_TIMEOUT);
-
-            if (this.get('_canAutosave')) {
-                this.get('autosave').perform();
-            }
+            this.get('autosave').perform();
         }
     }).drop(),
 

--- a/app/mixins/editor-base-route.js
+++ b/app/mixins/editor-base-route.js
@@ -39,20 +39,18 @@ export default Mixin.create(styleBody, ShortcutsRoute, {
             let controllerIsDirty = controller.get('hasDirtyAttributes');
             let model = controller.get('model');
             let state = model.getProperties('isDeleted', 'isSaving', 'hasDirtyAttributes', 'isNew');
-            let deletedWithoutChanges,
-                fromNewToEdit;
 
             if (this.get('upgradeStatus.isRequired')) {
                 return this._super(...arguments);
             }
 
-            fromNewToEdit = this.get('routeName') === 'editor.new'
+            let fromNewToEdit = this.get('routeName') === 'editor.new'
                 && transition.targetName === 'editor.edit'
                 && transition.intent.contexts
                 && transition.intent.contexts[0]
                 && transition.intent.contexts[0].id === model.get('id');
 
-            deletedWithoutChanges = state.isDeleted
+            let deletedWithoutChanges = state.isDeleted
                 && (state.isSaving || !state.hasDirtyAttributes);
 
             if (!fromNewToEdit && !deletedWithoutChanges && controllerIsDirty) {


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/9072
- the checks when leaving the editor were detecting that the autosave tasks were running and so forcing an immediate autosave even though the autosave tasks wouldn't do anything
- exit early from autosave tasks if autosave isn't allowed