### PR TITLE
🐛 Fixed confirmation modals when leaving editor with unsaved changes

### DIFF
--- a/app/mixins/editor-base-controller.js
+++ b/app/mixins/editor-base-controller.js
@@ -595,6 +595,7 @@ export default Mixin.create({
             let leaveTransition = this.get('leaveEditorTransition');
 
             if (!transition && this.get('showLeaveEditorModal')) {
+                this.set('leaveEditorTransition', null);
                 this.set('showLeaveEditorModal', false);
                 return;
             }


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/9000
- reset the stored transition when clicking the "Stay" button in the modal so that subsequent transitions don't get stuck