### PR TITLE
🐛 Fixed error when navigating to tag from admin search box

### DIFF
--- a/app/components/gh-search-input.js
+++ b/app/components/gh-search-input.js
@@ -30,7 +30,7 @@ export default Component.extend({
     contentExpiresAt: false,
     currentSearch: '',
 
-    posts: computedGroup('Posts'),
+    posts: computedGroup('Stories'),
     pages: computedGroup('Pages'),
     users: computedGroup('Users'),
     tags: computedGroup('Tags'),
@@ -66,7 +66,7 @@ export default Component.extend({
         let groups = [];
 
         if (!isEmpty(this.get('posts'))) {
-            groups.pushObject({groupName: 'Posts', options: this.get('posts')});
+            groups.pushObject({groupName: 'Stories', options: this.get('posts')});
         }
 
         if (!isEmpty(this.get('pages'))) {
@@ -95,7 +95,7 @@ export default Component.extend({
                 return {
                     id: `post.${post.id}`,
                     title: post.title,
-                    category: post.page ? 'Pages' : 'Posts'
+                    category: post.page ? 'Pages' : 'Stories'
                 };
             }));
         }).catch((error) => {
@@ -172,7 +172,7 @@ export default Component.extend({
                 return;
             }
 
-            if (selected.category === 'Posts' || selected.category === 'Pages') {
+            if (selected.category === 'Stories' || selected.category === 'Pages') {
                 let id = selected.id.replace('post.', '');
                 this.get('router').transitionTo('editor.edit', id);
             }

--- a/app/models/setting.js
+++ b/app/models/setting.js
@@ -25,5 +25,7 @@ export default Model.extend(ValidationEngine, {
     password: attr('string'),
     slack: attr('slack-settings'),
     amp: attr('boolean'),
-    unsplash: attr('unsplash-settings', {defaultValue: {isActive: true}})
+    unsplash: attr('unsplash-settings', {defaultValue() {
+        return {isActive: true};
+    }})
 });

--- a/app/routes/settings/tags.js
+++ b/app/routes/settings/tags.js
@@ -7,14 +7,6 @@ import ShortcutsRoute from 'ghost-admin/mixins/shortcuts-route';
 export default AuthenticatedRoute.extend(CurrentUserSettings, ShortcutsRoute, {
     titleToken: 'Settings - Tags',
 
-    perPage: 30,
-    perPageParam: 'limit',
-    totalPagesParam: 'meta.pagination.pages',
-
-    queryParams: {
-        include: 'count.posts'
-    },
-
     shortcuts: {
         'up, k': 'moveUp',
         'down, j': 'moveDown',

--- a/app/serializers/tag.js
+++ b/app/serializers/tag.js
@@ -20,5 +20,20 @@ export default ApplicationSerializer.extend({
         delete data.count;
 
         hash[root] = [data];
+    },
+
+    // if we use `queryRecord` ensure we grab the first record to avoid
+    // DS.SERIALIZER.REST.QUERYRECORD-ARRAY-RESPONSE deprecations
+    normalizeResponse(store, primaryModelClass, payload, id, requestType) {
+        if (requestType === 'queryRecord') {
+            let singular = primaryModelClass.modelName;
+            let plural = pluralize(singular);
+
+            if (payload[plural]) {
+                payload[singular] = payload[plural][0];
+                delete payload[plural];
+            }
+        }
+        return this._super(...arguments);
     }
 });


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/9074
- remove unused pagination route attrs that were interfering with routing service - these were a pre-1.0 hangover from when the tags screen had infinite scroll
- fix `adapter returned an array for the primary data of a 'queryRecord' response` deprecation when loading a tag route directly
- change `Posts` to `Stories` in the search dropdown for consistency