### PR TITLE
🐛 Fixed search losing focus when removing search term

### DIFF
--- a/app/components/gh-search-input-trigger.js
+++ b/app/components/gh-search-input-trigger.js
@@ -1,7 +1,5 @@
 import Component from '@ember/component';
-import {invokeAction} from 'ember-invoke-action';
 import {isBlank} from '@ember/utils';
-import {run} from '@ember/runloop';
 
 export default Component.extend({
     open() {
@@ -12,21 +10,32 @@ export default Component.extend({
         this.get('select.actions').close();
     },
 
+    _focusInput() {
+        this.$('input')[0].focus();
+    },
+
     actions: {
         captureMouseDown(e) {
             e.stopPropagation();
         },
 
         search(term) {
+            // open dropdown if not open and term is present
+            // close dropdown if open and term is blank
             if (isBlank(term) === this.get('select.isOpen')) {
-                run.scheduleOnce('afterRender', this, isBlank(term) ? this.close : this.open);
+                isBlank(term) ? this.close() : this.open();
+
+                // ensure focus isn't lost when dropdown is closed
+                if (isBlank(term)) {
+                    this._focusInput();
+                }
             }
 
-            invokeAction(this, 'select.actions.search', term);
+            this.get('select').actions.search(term);
         },
 
         focusInput() {
-            this.$('input')[0].focus();
+            this._focusInput();
         },
 
         resetInput() {


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/9075
- ensure we re-focus the input element after closing the dropdown so that it's not necessary to click on the search input again after using backspace
- removes unnecessary use of `run.scheduleOnce`
  - this was causing the error in TryGhost/Ghost#9075 because search was happening out of sync with the open/close of the dropdown in turn causing `ember-basic-dropdown` to try measuring non-existent elements
  - alternative fix would be to wrap each open/close, focus, and search call in separate `run.scheduleOnce('afterRender', ...)` calls
- remove use of `invokeAction`, it's not been necessary in Ember for a while now and we should be calling methods directly where possible for easier debugging