### PR TITLE
🐛 Fixed unreadable HTML property colours in Night Shift mode

### DIFF
--- a/app/styles/app-dark.css
+++ b/app/styles/app-dark.css
@@ -333,3 +333,7 @@ input,
 .CodeMirror .cm-spell-error:not(.cm-url):not(.cm-comment):not(.cm-tag):not(.cm-word) {
     background: rgba(255, 0, 0, .30);
 }
+
+.CodeMirror .CodeMirror-code .cm-string {
+    color: color(#183691 l(+25%));
+}


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/9080
- increase lightness of the default CodeMirror html property colour

Before:
<img width="439" alt="screen shot 2017-10-02 at 18 16 38" src="https://user-images.githubusercontent.com/415/31090094-5a5f8726-a79e-11e7-91fd-7fe34b645a79.png">

After:
<img width="439" alt="screen shot 2017-10-02 at 18 16 19" src="https://user-images.githubusercontent.com/415/31090098-619f9576-a79e-11e7-9d9a-cde9ff8c8ae1.png">