### PR TITLE
Set background for body in nightmode

### DIFF
--- a/app/styles/app-dark.css
+++ b/app/styles/app-dark.css
@@ -68,6 +68,7 @@
 
 body {
     color: #e5eff5;
+    background: #263238;
 }
 
 pre {


### PR DESCRIPTION
- Refs: TryGhost/Ghost#9093

This pull request _just_ sets the background color of the entire page to the same color as the `.gh-main` area. I don't want to say it closs 9093, because it's just a band-aid fix.

My train of thought for this is there might be other areas that have similar issues, so setting the background color for the body will make these issues less annoying for end users as it should cover up any white areas.