### PR TITLE
Fix Ember deprecations and warnings

### DIFF
--- a/app/components/gh-post-settings-menu.js
+++ b/app/components/gh-post-settings-menu.js
@@ -6,6 +6,7 @@ import moment from 'moment';
 import {alias, or} from '@ember/object/computed';
 import {computed} from '@ember/object';
 import {guidFor} from '@ember/object/internals';
+import {htmlSafe} from '@ember/string';
 import {inject as injectService} from '@ember/service';
 import {run} from '@ember/runloop';
 import {task, timeout} from 'ember-concurrency';
@@ -38,13 +39,13 @@ export default Component.extend(SettingsMenuMixin, {
     twitterTitleScratch: alias('model.twitterTitleScratch'),
     slugValue: boundOneWay('model.slug'),
 
-    seoTitle: or('metaTitleScratch', 'model.titleScratch'),
-    twitterImage: or('model.twitterImage', 'model.featureImage'),
-    twitterTitle: or('twitterTitleScratch', 'seoTitle'),
-    twitterDescription: or('twitterDescriptionScratch', 'customExcerptScratch', 'seoDescription'),
+    facebookDescription: or('ogDescriptionScratch', 'customExcerptScratch', 'seoDescription'),
     facebookImage: or('model.ogImage', 'model.featureImage'),
     facebookTitle: or('ogTitleScratch', 'seoTitle'),
-    facebookDescription: or('ogDescriptionScratch', 'customExcerptScratch', 'seoDescription'),
+    seoTitle: or('metaTitleScratch', 'model.titleScratch'),
+    twitterDescription: or('twitterDescriptionScratch', 'customExcerptScratch', 'seoDescription'),
+    twitterImage: or('model.twitterImage', 'model.featureImage'),
+    twitterTitle: or('twitterTitleScratch', 'seoTitle'),
 
     _showSettingsMenu: false,
     _showThrobbers: false,
@@ -87,6 +88,16 @@ export default Component.extend(SettingsMenuMixin, {
 
         this._showSettingsMenu = this.get('showSettingsMenu');
     },
+
+    twitterImageStyle: computed('twitterImage', function () {
+        let image = this.get('twitterImage');
+        return htmlSafe(`background-image: url(${image})`);
+    }),
+
+    facebookImageStyle: computed('facebookImage', function () {
+        let image = this.get('facebookImage');
+        return htmlSafe(`background-image: url(${image})`);
+    }),
 
     showThrobbers: task(function* () {
         yield timeout(PSM_ANIMATION_LENGTH);

--- a/app/controllers/error.js
+++ b/app/controllers/error.js
@@ -5,15 +5,15 @@ export default Controller.extend({
 
     stack: false,
 
-    code: computed('content.status', function () {
-        return this.get('content.status') > 200 ? this.get('content.status') : 500;
+    code: computed('model.status', function () {
+        return this.get('model.status') > 200 ? this.get('model.status') : 500;
     }),
 
-    message: computed('content.statusText', function () {
+    message: computed('model.statusText', function () {
         if (this.get('code') === 404) {
             return 'Page not found';
         }
 
-        return this.get('content.statusText') !== 'error' ? this.get('content.statusText') : 'Internal Server Error';
+        return this.get('model.statusText') !== 'error' ? this.get('model.statusText') : 'Internal Server Error';
     })
 });

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -75,11 +75,9 @@ export default Model.extend(Comparable, ValidationEngine, {
 
     validationType: 'post',
 
-    author: belongsTo('user', {async: true}),
     authorId: attr('string'),
     createdAtUTC: attr('moment-utc'),
-    createdBy: attr(),
-    customExcerpt: attr(),
+    customExcerpt: attr('string'),
     featured: attr('boolean', {defaultValue: false}),
     featureImage: attr('string'),
     codeinjectionFoot: attr('string', {defaultValue: ''}),
@@ -99,18 +97,21 @@ export default Model.extend(Comparable, ValidationEngine, {
     page: attr('boolean', {defaultValue: false}),
     plaintext: attr('string'),
     publishedAtUTC: attr('moment-utc'),
-    publishedBy: belongsTo('user', {async: true}),
     slug: attr('string'),
     status: attr('string', {defaultValue: 'draft'}),
-    tags: hasMany('tag', {
-        embedded: 'always',
-        async: false
-    }),
     title: attr('string', {defaultValue: ''}),
     updatedAtUTC: attr('moment-utc'),
     updatedBy: attr(),
     url: attr('string'),
     uuid: attr('string'),
+
+    author: belongsTo('user', {async: true}),
+    createdBy: belongsTo('user', {async: true}),
+    publishedBy: belongsTo('user', {async: true}),
+    tags: hasMany('tag', {
+        embedded: 'always',
+        async: false
+    }),
 
     scratch: null,
     titleScratch: null,

--- a/app/serializers/post.js
+++ b/app/serializers/post.js
@@ -45,6 +45,13 @@ export default ApplicationSerializer.extend(EmbeddedRecordsMixin, {
 
         // We have a plural root in the API
         let root = pluralize(type.modelName);
+
+        // TODO: this is throwing a warning when saving a new post:
+        // The embedded relationship 'tags' is undefined for 'post' with id 'null'.
+        // Please include it in your original payload.
+        //
+        // This appears to be an issue in Ember Data - needs further investigation
+        // and possibly an issue raised
         let data = this.serialize(record, options);
 
         // Properties that exist on the model but we don't want sent in the payload

--- a/app/templates/components/gh-post-settings-menu.hbs
+++ b/app/templates/components/gh-post-settings-menu.hbs
@@ -282,7 +282,7 @@
                                     <label>Preview</label>
                                     <div class="gh-twitter-preview">
                                         {{#if twitterImage}}
-                                        <div class="gh-twitter-preview-image" style="background-image: url({{twitterImage}});"></div>
+                                        <div class="gh-twitter-preview-image" style={{twitterImageStyle}}></div>
                                         {{/if}}
                                         <div class="gh-twitter-preview-content">
                                             <div class="gh-twitter-preview-title">{{twitterTitle}}</div>
@@ -350,7 +350,7 @@
                                     <label>Preview</label>
                                     <div class="gh-og-preview">
                                         {{#if facebookImage}}
-                                        <div class="gh-og-preview-image" style="background-image: url({{facebookImage}});"></div>
+                                        <div class="gh-og-preview-image" style={{facebookImageStyle}}></div>
                                         {{/if}}
                                         <div class="gh-og-preview-content">
                                             <div class="gh-og-preview-title">{{truncate facebookTitle 88}}</div>

--- a/mirage/config/users.js
+++ b/mirage/config/users.js
@@ -1,9 +1,18 @@
+import {Response} from 'ember-cli-mirage';
 import {paginateModelArray} from '../utils';
 
 export default function mockUsers(server) {
     // /users/me = Always return the user with ID=1
     server.get('/users/me/', function ({users}) {
-        return users.find(1);
+        let user = users.find(1);
+
+        if (user) {
+            return user;
+        } else {
+            return new Response(404, {}, {errors: [
+                {message: 'Not found', errorType: 'NotFoundError'}
+            ]});
+        }
     });
 
     server.get('/users/', function ({users}, {queryParams}) {

--- a/tests/acceptance/authentication-test.js
+++ b/tests/acceptance/authentication-test.js
@@ -27,6 +27,9 @@ describe('Acceptance: Authentication', function () {
 
     describe('setup redirect', function () {
         beforeEach(function () {
+            // ensure the /users/me route doesn't error
+            server.create('user');
+
             server.get('authentication/setup', function () {
                 return {setup: [{status: false}]};
             });


### PR DESCRIPTION
no issue

- `controller.content` will no longer be an alias to `controller.model`
- re-org relationships and attrs in Post model, add missing transforms
- fix "unknown `error` field in payload" warning when `/users/me` returns 404 during tests
- fix unsafe style binding warnings caused by PSM twitter/facebook preview image styles