### PR TITLE
🐛 Fixed "Post URL matches" text displaying when no slug match is found

### DIFF
--- a/app/templates/components/gh-psm-template-select.hbs
+++ b/app/templates/components/gh-psm-template-select.hbs
@@ -14,6 +14,8 @@
                 {{inline-svg "arrow-down-small"}}
             </span>
         </span>
-        <p>Post URL matches {{matchedSlugTemplate.filename}}</p>
+        {{#if matchedSlugTemplate}}
+            <p>Post URL matches {{matchedSlugTemplate.filename}}</p>
+        {{/if}}
     </div>
 {{/if}}


### PR DESCRIPTION
no issue
- adding missing conditional so we only display `Post URL matches post-slug-name.hbs` when a match is found