### PR TITLE
✨Increase password length for changes and signups

### DIFF
--- a/app/validators/new-user.js
+++ b/app/validators/new-user.js
@@ -27,8 +27,8 @@ export default BaseValidator.extend({
     password(model) {
         let password = model.get('password');
 
-        if (!validator.isLength(password, 8)) {
-            model.get('errors').add('password', 'Password must be at least 8 characters long');
+        if (!validator.isLength(password, 10)) {
+            model.get('errors').add('password', 'Password must be at least 10 characters long');
             this.invalidate();
         }
     }

--- a/app/validators/reset.js
+++ b/app/validators/reset.js
@@ -10,8 +10,8 @@ export default BaseValidator.create({
         if (validator.empty(p1)) {
             model.get('errors').add('newPassword', 'Please enter a password.');
             this.invalidate();
-        } else if (!validator.isLength(p1, 8)) {
-            model.get('errors').add('newPassword', 'The password is not long enough.');
+        } else if (!validator.isLength(p1, 10)) {
+            model.get('errors').add('newPassword', 'Password must be at least 10 characters long.');
             this.invalidate();
         } else if (!validator.equals(p1, p2)) {
             model.get('errors').add('ne2Password', 'The two new passwords don\'t match.');

--- a/app/validators/user.js
+++ b/app/validators/user.js
@@ -96,8 +96,8 @@ export default BaseValidator.create({
                 this.invalidate();
             }
 
-            if (!validator.isLength(newPassword, 8)) {
-                model.get('errors').add('newPassword', 'Your password must be at least 8 characters long.');
+            if (!validator.isLength(newPassword, 10)) {
+                model.get('errors').add('newPassword', 'Your password must be at least 10 characters long.');
                 this.invalidate();
             }
         }

--- a/tests/acceptance/setup-test.js
+++ b/tests/acceptance/setup-test.js
@@ -113,7 +113,7 @@ describe('Acceptance: Setup', function () {
             // enter valid details and submit
             await fillIn('[data-test-email-input]', 'test@example.com');
             await fillIn('[data-test-name-input]', 'Test User');
-            await fillIn('[data-test-password-input]', 'password');
+            await fillIn('[data-test-password-input]', 'password99');
             await fillIn('[data-test-blog-title-input]', 'Blog Title');
             await click('.gh-btn-green');
 
@@ -180,7 +180,7 @@ describe('Acceptance: Setup', function () {
 
             await fillIn('[data-test-email-input]', 'test@example.com');
             await fillIn('[data-test-name-input]', 'Test User');
-            await fillIn('[data-test-password-input]', 'password');
+            await fillIn('[data-test-password-input]', 'password99');
             await fillIn('[data-test-blog-title-input]', 'Blog Title');
 
             // first post - simulated validation error
@@ -218,7 +218,7 @@ describe('Acceptance: Setup', function () {
             await visit('/setup/two');
             await fillIn('[data-test-email-input]', 'test@example.com');
             await fillIn('[data-test-name-input]', 'Test User');
-            await fillIn('[data-test-password-input]', 'password');
+            await fillIn('[data-test-password-input]', 'password99');
             await fillIn('[data-test-blog-title-input]', 'Blog Title');
             await click('.gh-btn-green');
 
@@ -271,7 +271,7 @@ describe('Acceptance: Setup', function () {
             await visit('/setup/two');
             await fillIn('[data-test-email-input]', 'test@example.com');
             await fillIn('[data-test-name-input]', 'Test User');
-            await fillIn('[data-test-password-input]', 'password');
+            await fillIn('[data-test-password-input]', 'password99');
             await fillIn('[data-test-blog-title-input]', 'Blog Title');
             await click('.gh-btn-green');
 

--- a/tests/acceptance/signup-test.js
+++ b/tests/acceptance/signup-test.js
@@ -100,7 +100,7 @@ describe('Acceptance: Signup', function() {
         expect(
             find('input[name="password"]').closest('.form-group').find('.response').text().trim(),
             'password field error text'
-        ).to.match(/must be at least 8 characters/);
+        ).to.match(/must be at least 10 characters/);
 
         // entering valid text in Password field clears error
         await fillIn('input[name="password"]', 'ValidPassword');

--- a/tests/acceptance/team-test.js
+++ b/tests/acceptance/team-test.js
@@ -657,6 +657,23 @@ describe('Acceptance: Team', function () {
                     'new password error when blank'
                 ).to.match(/can't be blank/);
 
+                // validates too short password (< 10 characters)
+                await fillIn('#user-password-new', 'password');
+                await fillIn('#user-new-password-verification', 'password');
+
+                // enter key triggers action
+                await keyEvent('#user-password-new', 'keyup', 13);
+
+                expect(
+                    find('#user-password-new').closest('.form-group').hasClass('error'),
+                    'new password has error class when password too short'
+                ).to.be.true;
+
+                expect(
+                    find('#user-password-new').siblings('.response').text(),
+                    'confirm password error when it it\'s too short'
+                ).to.match(/at least 10 characters long/);
+
                 // typing in inputs clears validation
                 await fillIn('#user-password-new', 'password99');
                 await triggerEvent('#user-password-new', 'input');

--- a/tests/acceptance/team-test.js
+++ b/tests/acceptance/team-test.js
@@ -658,7 +658,7 @@ describe('Acceptance: Team', function () {
                 ).to.match(/can't be blank/);
 
                 // typing in inputs clears validation
-                await fillIn('#user-password-new', 'password');
+                await fillIn('#user-password-new', 'password99');
                 await triggerEvent('#user-password-new', 'input');
 
                 expect(
@@ -680,7 +680,7 @@ describe('Acceptance: Team', function () {
                 ).to.match(/do not match/);
 
                 // submits with correct details
-                await fillIn('#user-new-password-verification', 'password');
+                await fillIn('#user-new-password-verification', 'password99');
                 await click('.button-change-password');
 
                 // hits the endpoint
@@ -692,8 +692,8 @@ describe('Acceptance: Team', function () {
 
                 // eslint-disable-next-line camelcase
                 expect(params.password[0].user_id).to.equal(user.id.toString());
-                expect(params.password[0].newPassword).to.equal('password');
-                expect(params.password[0].ne2Password).to.equal('password');
+                expect(params.password[0].newPassword).to.equal('password99');
+                expect(params.password[0].ne2Password).to.equal('password99');
 
                 // clears the fields
                 expect(


### PR DESCRIPTION
refs TryGhost/Ghost#9150
needs TryGhost/Ghost#9152

- Increase the password length in validators for signups, pw resets, and password changes for users to 10 instead of 8
- Update tests

Todos:
- [x] update/add more tests to make sure, existing signins etc. will still work