### PR TITLE
clear password fields when leaving team/user page

### DIFF
--- a/app/routes/team/user.js
+++ b/app/routes/team/user.js
@@ -46,6 +46,11 @@ export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
     },
 
     actions: {
+        willTransition() {
+            this.controller.set('user.password', '');
+            this.controller.set('user.newPassword', '');
+            this.controller.set('user.ne2Password', '');
+        },
         didTransition() {
             this.modelFor('team.user').get('errors').clear();
         },


### PR DESCRIPTION
closes [TryGhost/Ghost#9174](https://github.com/TryGhost/Ghost/issues/9174)

- Added ```willTransition``` action which clears the password input fields when transitioning to a new route
