### PR TITLE
🐛 Fixed "Someone else is editing" errors showing when no-one else is editing

### DIFF
--- a/app/components/gh-post-settings-menu.js
+++ b/app/components/gh-post-settings-menu.js
@@ -178,7 +178,7 @@ export default Component.extend(SettingsMenuMixin, {
                 return;
             }
 
-            this.get('model').save().catch((error) => {
+            this.get('savePost').perform().catch((error) => {
                 this.showError(error);
                 this.get('model').rollbackAttributes();
             });
@@ -193,7 +193,7 @@ export default Component.extend(SettingsMenuMixin, {
                 return;
             }
 
-            this.get('model').save(this.get('saveOptions')).catch((error) => {
+            this.get('savePost').perform().catch((error) => {
                 this.showError(error);
                 this.get('model').rollbackAttributes();
             });
@@ -221,7 +221,7 @@ export default Component.extend(SettingsMenuMixin, {
                 post.validate({property: 'publishedAtBlog'});
             } else {
                 post.set('publishedAtBlogDate', dateString);
-                return post.save();
+                return this.get('savePost').perform();
             }
         },
 
@@ -234,7 +234,7 @@ export default Component.extend(SettingsMenuMixin, {
                 post.validate({property: 'publishedAtBlog'});
             } else {
                 post.set('publishedAtBlogTime', time);
-                return post.save();
+                return this.get('savePost').perform();
             }
         },
 
@@ -249,7 +249,7 @@ export default Component.extend(SettingsMenuMixin, {
             model.set('customExcerpt', excerpt);
 
             return model.validate({property: 'customExcerpt'}).then(() => {
-                return model.save();
+                return this.get('savePost').perform();
             });
         },
 
@@ -264,7 +264,7 @@ export default Component.extend(SettingsMenuMixin, {
             model.set('codeinjectionHead', code);
 
             return model.validate({property: 'codeinjectionHead'}).then(() => {
-                return model.save();
+                return this.get('savePost').perform();
             });
         },
 
@@ -279,7 +279,7 @@ export default Component.extend(SettingsMenuMixin, {
             model.set('codeinjectionFoot', code);
 
             return model.validate({property: 'codeinjectionFoot'}).then(() => {
-                return model.save();
+                return this.get('savePost').perform();
             });
         },
 
@@ -302,7 +302,7 @@ export default Component.extend(SettingsMenuMixin, {
                     return;
                 }
 
-                return model.save();
+                return this.get('savePost').perform();
             });
         },
 
@@ -325,7 +325,7 @@ export default Component.extend(SettingsMenuMixin, {
                     return;
                 }
 
-                return model.save();
+                return this.get('savePost').perform();
             });
         },
 
@@ -348,7 +348,7 @@ export default Component.extend(SettingsMenuMixin, {
                     return;
                 }
 
-                return model.save();
+                return this.get('savePost').perform();
             });
         },
 
@@ -371,7 +371,7 @@ export default Component.extend(SettingsMenuMixin, {
                     return;
                 }
 
-                return model.save();
+                return this.get('savePost').perform();
             });
         },
 
@@ -394,7 +394,7 @@ export default Component.extend(SettingsMenuMixin, {
                     return;
                 }
 
-                return model.save();
+                return this.get('savePost').perform();
             });
         },
 
@@ -417,7 +417,7 @@ export default Component.extend(SettingsMenuMixin, {
                     return;
                 }
 
-                return model.save();
+                return this.get('savePost').perform();
             });
         },
 
@@ -428,7 +428,7 @@ export default Component.extend(SettingsMenuMixin, {
                 return;
             }
 
-            this.get('model').save().catch((error) => {
+            this.get('savePost').perform().catch((error) => {
                 this.showError(error);
                 this.get('model').rollbackAttributes();
             });
@@ -441,7 +441,7 @@ export default Component.extend(SettingsMenuMixin, {
                 return;
             }
 
-            this.get('model').save().catch((error) => {
+            this.get('savePost').perform().catch((error) => {
                 this.showError(error);
                 this.get('model').rollbackAttributes();
             });
@@ -454,7 +454,7 @@ export default Component.extend(SettingsMenuMixin, {
                 return;
             }
 
-            this.get('model').save().catch((error) => {
+            this.get('savePost').perform().catch((error) => {
                 this.showError(error);
                 this.get('model').rollbackAttributes();
             });
@@ -467,7 +467,7 @@ export default Component.extend(SettingsMenuMixin, {
                 return;
             }
 
-            this.get('model').save().catch((error) => {
+            this.get('savePost').perform().catch((error) => {
                 this.showError(error);
                 this.get('model').rollbackAttributes();
             });
@@ -480,7 +480,7 @@ export default Component.extend(SettingsMenuMixin, {
                 return;
             }
 
-            this.get('model').save().catch((error) => {
+            this.get('savePost').perform().catch((error) => {
                 this.showError(error);
                 this.get('model').rollbackAttributes();
             });
@@ -493,7 +493,7 @@ export default Component.extend(SettingsMenuMixin, {
                 return;
             }
 
-            this.get('model').save().catch((error) => {
+            this.get('savePost').perform().catch((error) => {
                 this.showError(error);
                 this.get('model').rollbackAttributes();
             });
@@ -515,7 +515,7 @@ export default Component.extend(SettingsMenuMixin, {
                 return;
             }
 
-            model.save().catch((error) => {
+            this.get('savePost').perform().catch((error) => {
                 this.showError(error);
                 this.set('selectedAuthor', author);
                 model.rollbackAttributes();

--- a/app/mixins/editor-base-controller.js
+++ b/app/mixins/editor-base-controller.js
@@ -273,6 +273,21 @@ export default Mixin.create({
         return yield this.get('model').save();
     }).group('saveTasks'),
 
+    // used in the PSM so that saves are sequential and don't trigger collision
+    // detection errors
+    savePost: task(function* () {
+        try {
+            return yield this.get('model').save();
+        } catch (error) {
+            if (error) {
+                let status = this.get('model.status');
+                this.showErrorAlert(status, status, error);
+            }
+
+            throw error;
+        }
+    }).group('saveTasks'),
+
     /**
      * By default, a post will not change its publish state.
      * Only with a user-set value (via setSaveType action)

--- a/app/templates/components/gh-post-settings-menu.hbs
+++ b/app/templates/components/gh-post-settings-menu.hbs
@@ -142,6 +142,7 @@
                             id="static-page"
                             class="gh-input post-setting-static-page"
                             update=(action (mut model.page))
+                            data-test-checkbox="static-page"
                         }}
                         <span class="input-toggle-component"></span>
                         <p>Turn this post into a page</p>
@@ -153,6 +154,7 @@
                             id="featured"
                             class="gh-input post-setting-featured"
                             update=(action (mut model.featured))
+                            data-test-checkbox="featured"
                         }}
                         <span class="input-toggle-component"></span>
                         <p>Feature this post</p>

--- a/app/templates/editor/edit.hbs
+++ b/app/templates/editor/edit.hbs
@@ -154,5 +154,6 @@
         showSettingsMenu=ui.showSettingsMenu
         deletePost=(action "toggleDeletePostModal")
         updateSlug=updateSlug
+        savePost=savePost
     }}
 {{/liquid-wormhole}}


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8969

Collision detection errors were appearing incorrectly because the save routines in the post settings menu bypass the sequential saves in the main editor controller and so are prone to having stale data if a previous save is still in progress.

- added a new `savePost` task that is part of the `saveTasks` group so that all post saves are sequential
- pass the `savePost` task to the `{{gh-post-settings-menu}}` component
- use `savePost` task in `gh-post-settings-menu` instead of calling `save()` directly on the model instance

**Note:** See https://github.com/TryGhost/Ghost/issues/8969 for local reproduction steps.