### PR TITLE
Improve admin styles on mobile

### DIFF
--- a/app/styles/layouts/apps.css
+++ b/app/styles/layouts/apps.css
@@ -61,6 +61,13 @@
     transition: background 0.3s ease;
 }
 
+@media (max-width: 500px) {
+    .apps-card-app {
+        min-height: 75px;
+        height: auto;
+    }
+}
+
 .apps-grid-cell:first-child .apps-card-app {
     border-top: none;
 }
@@ -68,6 +75,12 @@
 .apps-card-left {
     display: flex;
     align-items: center;
+}
+
+@media (max-width: 500px) {
+    .apps-card-left {
+        flex-basis: 70%;
+    }
 }
 
 .apps-card-right {
@@ -118,6 +131,7 @@
 }
 @media (max-width: 500px) {
     .apps-card-meta {
+        flex-basis: 70%;
         padding-right: 20px;
     }
 }
@@ -133,6 +147,7 @@
 }
 @media (max-width: 500px) {
     .apps-card-app-title {
+        white-space: normal;
         font-size: 1.5rem;
     }
 }

--- a/app/styles/layouts/editor.css
+++ b/app/styles/layouts/editor.css
@@ -380,6 +380,13 @@
     padding: 10vw 4vw;
 }
 
+@media (max-width: 500px) {
+    .gh-markdown-editor-pane,
+    .gh-markdown-editor-preview {
+        padding: 15vw 4vw;
+    }
+}
+
 .gh-markdown-editor-side-by-side .gh-markdown-editor-pane,
 .gh-markdown-editor-side-by-side .gh-markdown-editor-preview {
     padding: 4vw;

--- a/app/styles/layouts/main.css
+++ b/app/styles/layouts/main.css
@@ -252,6 +252,12 @@ body > .ember-view:not(.default-liquid-destination) {
     color:  color(var(--midgrey) l(+5%));
 }
 
+@media (max-width: 500px) {
+    .gh-nav-foot-sitelink {
+        height: 56px;
+    }
+}
+
 .gh-nav-foot-sitelink svg {
     width: 13px;
     margin-left: 5px;
@@ -482,6 +488,21 @@ body > .ember-view:not(.default-liquid-destination) {
         font-size: 1.2rem;
     }
 
+    .gh-mobile-nav-bar a.active {
+        background: color(var(--blue) lightness(+10%));
+        color: #fff;
+    }
+
+    .gh-mobile-nav-bar a.active svg {
+        fill: #fff;
+    }
+
+    .gh-mobile-nav-bar a.active.gh-nav-main-users g,
+    .gh-mobile-nav-bar a.active.gh-nav-main-users path {
+        fill: transparent;
+        stroke: white;
+    }
+
     .gh-mobile-nav-bar svg,
     .gh-mobile-nav-bar svg g {
         width: 15px;
@@ -547,6 +568,15 @@ body > .ember-view:not(.default-liquid-destination) {
     letter-spacing: 0.4px;
     /* match button height to avoid jump on navigation between screens*/
     min-height: 35px;
+}
+
+@media (max-width: 500px) {
+    .gh-canvas-title {
+        display: block;
+    }
+    .gh-canvas-title svg {
+        margin: 0 5px;
+    }
 }
 
 .gh-canvas-title a {

--- a/app/styles/layouts/settings.css
+++ b/app/styles/layouts/settings.css
@@ -64,6 +64,12 @@
     max-width: 250px;
 }
 
+@media (max-width: 500px) {
+    .gh-setting-action-largeimg img {
+        max-width: 190px;
+    }
+}
+
 .gh-setting-action-smallimg img:hover,
 .gh-setting-action-largeimg img:hover {
     cursor: pointer;
@@ -294,8 +300,16 @@
     line-height: inherit;
 }
 
-@media (max-width: 400px) {
+@media (max-width: 500px) {
+    #importfile {
+        flex-direction: column;
+    }
+    #importfile input {
+        width: 150px;
+    }
+
     #startupload {
+        margin-left: 0;
         margin-top: 5px;
     }
 }
@@ -354,6 +368,15 @@
 .gh-themes-container {
     padding: 25px 0;
     border-top: var(--lightgrey) 1px solid;
+}
+
+@media (max-width: 500px) {
+    .gh-themes-container .apps-configured {
+        justify-content: flex-end;
+    }
+    .gh-themes-container .apps-card-meta {
+        flex-basis: auto;
+    }
 }
 
 .gh-themes-uploadbtn {

--- a/app/styles/layouts/users.css
+++ b/app/styles/layouts/users.css
@@ -9,6 +9,31 @@
     text-transform: none;
 }
 
+@media (max-width: 500px) {
+    .gh-invited-users .apps-card-meta {
+        max-width: 165px;
+    }
+
+    .gh-invited-users .apps-card-app-title {
+        width: 200px;
+    }
+
+    .gh-invited-users .apps-card-app-desc {
+        max-height: none;
+        display: block;
+    }
+
+    .gh-invited-users .apps-configured {
+        flex-direction: column;
+        align-items: flex-end;
+    }
+
+    .gh-invited-users .apps-configured a {
+        margin-bottom: 7px
+    }
+}
+
+
 .user-list-item-icon {
     flex-shrink: 0;
     display: flex;
@@ -128,10 +153,26 @@
     width: 60%;
 }
 
+@media (max-width: 500px) {
+    .invite-new-user .form-group:nth-of-type(1) {
+        float: none;
+        width: 100%;
+    }
+}
+
 .invite-new-user .form-group:nth-of-type(2) {
     float: left;
     margin-left: 10px;
     width: 35%;
+}
+
+@media (max-width: 500px) {
+    .invite-new-user .form-group:nth-of-type(2) {
+        float: none;
+        margin-top: 10px;
+        margin-left: 0;
+        width: 100%;
+    }
 }
 
 .invite-new-user .form-group input {


### PR DESCRIPTION
Trying to close https://github.com/TryGhost/Ghost/issues/8744, I went through several parts of the admin interface improving the mobile styles (focusing on iPhone 6 and up).

I've tried to follow the CSS style as close as possible but please review the changes 👍

Here are the screens (could have missed one). 

### Active styles for the bottom bar (and more padding for the editor)
<img width="250px" src="https://user-images.githubusercontent.com/1236790/32420247-0228328c-c27f-11e7-95f6-bb5b0311c19f.png">

### Equal height for the bottom menu and the sidebar
<img width="250px" src="https://user-images.githubusercontent.com/1236790/32420243-f0885a2a-c27e-11e7-9d94-dac8cc3c458c.png">

### Team members screen
<img width="250px" src="https://user-images.githubusercontent.com/1236790/32420218-a1076d9c-c27e-11e7-8f56-fe7a5f677fc8.png">

### Invite people
<img width="250px" src="https://user-images.githubusercontent.com/1236790/32420228-d127d0b6-c27e-11e7-89b9-1b1697dc58d2.png">

### Better cover image width
<img width="250px" src="https://user-images.githubusercontent.com/1236790/32420265-5656c076-c27f-11e7-8597-5c746c191b4b.png">

### Theme picker
<img width="250px" src="https://user-images.githubusercontent.com/1236790/32420276-6e54b3c2-c27f-11e7-914a-49ad34ede011.png">

### Import content
<img width="250px" src="https://user-images.githubusercontent.com/1236790/32420280-7a954278-c27f-11e7-973e-8aee24d5f18a.png">