### PR TITLE
✨  Increased tag description length to 500

### DIFF
--- a/app/templates/components/gh-tag-settings-form.hbs
+++ b/app/templates/components/gh-tag-settings-form.hbs
@@ -33,7 +33,7 @@
                 <label for="tag-description">Description</label>
                 {{gh-textarea scratchDescription id="tag-description" name="description" focusOut=(action 'setProperty' 'description' scratchDescription) update=(action (mut scratchDescription))}}
                 {{gh-error-message errors=tag.errors property="description"}}
-                <p>Maximum: <b>200</b> characters. You’ve used {{gh-count-down-characters scratchDescription 200}}</p>
+                <p>Maximum: <b>500</b> characters. You’ve used {{gh-count-down-characters scratchDescription 500}}</p>
             {{/gh-form-group}}
 
             <ul class="nav-list nav-list-block">

--- a/app/validators/tag-settings.js
+++ b/app/validators/tag-settings.js
@@ -30,8 +30,8 @@ export default BaseValidator.create({
     description(model) {
         let description = model.get('description');
 
-        if (!validator.isLength(description, 0, 200)) {
-            model.get('errors').add('description', 'Description cannot be longer than 200 characters.');
+        if (!validator.isLength(description, 0, 500)) {
+            model.get('errors').add('description', 'Description cannot be longer than 500 characters.');
             this.invalidate();
         }
     },

--- a/tests/integration/components/gh-tag-settings-form-test.js
+++ b/tests/integration/components/gh-tag-settings-form-test.js
@@ -273,7 +273,7 @@ describe('Integration: Component: gh-tag-settings-form', function () {
         expect(this.$('.seo-preview-description').text(), 'falls back to tag description without metaDescription').to.equal('Description.');
 
         run(() => {
-            this.set('tag.description', (new Array(200).join('x')));
+            this.set('tag.description', (new Array(500).join('x')));
         });
         let expectedLength = 156 + '…'.length;
         expect(this.$('.seo-preview-description').text().length, 'cuts description to max 156 chars').to.equal(expectedLength);

--- a/tests/unit/validators/tag-settings-test.js
+++ b/tests/unit/validators/tag-settings-test.js
@@ -194,11 +194,11 @@ describe('Unit: Validator: tag-settings', function () {
 
     it('validates description length', function () {
         // shortest invalid description
-        let tag = Tag.create({description: (new Array(202).join('x'))});
+        let tag = Tag.create({description: (new Array(502).join('x'))});
         let passed = false;
         let errors;
 
-        expect(tag.get('description').length, 'description length').to.equal(201);
+        expect(tag.get('description').length, 'description length').to.equal(501);
 
         run(() => {
             tag.validate({property: 'description'}).then(() => {
@@ -208,7 +208,7 @@ describe('Unit: Validator: tag-settings', function () {
 
         errors = tag.get('errors').errorsFor('description')[0];
         expect(errors.attribute, 'errors.description.attribute').to.equal('description');
-        expect(errors.message, 'errors.description.message').to.equal('Description cannot be longer than 200 characters.');
+        expect(errors.message, 'errors.description.message').to.equal('Description cannot be longer than 500 characters.');
 
         // TODO: tag.errors appears to be a singleton and previous errors are
         // not cleared despite creating a new tag object


### PR DESCRIPTION
no issue

- Increased the possible length of the tag description field from 200 to 500