### PR TITLE
🗜  Increase soft limits

### DIFF
--- a/app/validators/tag-settings.js
+++ b/app/validators/tag-settings.js
@@ -12,8 +12,8 @@ export default BaseValidator.create({
         } else if (name.match(/^,/)) {
             model.get('errors').add('name', 'Tag names can\'t start with commas.');
             this.invalidate();
-        } else if (!validator.isLength(name, 0, 150)) {
-            model.get('errors').add('name', 'Tag names cannot be longer than 150 characters.');
+        } else if (!validator.isLength(name, 0, 191)) {
+            model.get('errors').add('name', 'Tag names cannot be longer than 191 characters.');
             this.invalidate();
         }
     },
@@ -21,8 +21,8 @@ export default BaseValidator.create({
     slug(model) {
         let slug = model.get('slug');
 
-        if (!validator.isLength(slug, 0, 150)) {
-            model.get('errors').add('slug', 'URL cannot be longer than 150 characters.');
+        if (!validator.isLength(slug, 0, 191)) {
+            model.get('errors').add('slug', 'URL cannot be longer than 191 characters.');
             this.invalidate();
         }
     },

--- a/app/validators/user.js
+++ b/app/validators/user.js
@@ -15,7 +15,7 @@ export default PasswordValidator.create({
             if (validator.empty(name)) {
                 model.get('errors').add('name', 'Please enter a name.');
                 this.invalidate();
-            } else if (!validator.isLength(name, 0, 150)) {
+            } else if (!validator.isLength(name, 0, 191)) {
                 model.get('errors').add('name', 'Name is too long');
                 this.invalidate();
             }

--- a/tests/acceptance/team-test.js
+++ b/tests/acceptance/team-test.js
@@ -476,7 +476,7 @@ describe('Acceptance: Team', function () {
                 expect(find('.user-details-bottom .first-form-group').hasClass('error'), 'username input is in error state with blank input').to.be.true;
 
                 // test too long user name
-                await fillIn('[data-test-name-input]', new Array(160).join('a'));
+                await fillIn('[data-test-name-input]', new Array(195).join('a'));
                 await triggerEvent('[data-test-name-input]', 'blur');
 
                 expect(find('.user-details-bottom .first-form-group').hasClass('error'), 'username input is in error state with too long input').to.be.true;

--- a/tests/unit/validators/tag-settings-test.js
+++ b/tests/unit/validators/tag-settings-test.js
@@ -53,10 +53,10 @@ describe('Unit: Validator: tag-settings', function () {
 
     it('passes with valid name', function () {
         // longest valid name
-        let tag = Tag.create({name: (new Array(151).join('x'))});
+        let tag = Tag.create({name: (new Array(192).join('x'))});
         let passed = false;
 
-        expect(tag.get('name').length, 'name length').to.equal(150);
+        expect(tag.get('name').length, 'name length').to.equal(191);
 
         run(() => {
             tag.validate({property: 'name'}).then(() => {
@@ -116,11 +116,11 @@ describe('Unit: Validator: tag-settings', function () {
 
     it('validates name length', function () {
         // shortest invalid name
-        let tag = Tag.create({name: (new Array(152).join('x'))});
+        let tag = Tag.create({name: (new Array(193).join('x'))});
         let passed = false;
         let nameErrors;
 
-        expect(tag.get('name').length, 'name length').to.equal(151);
+        expect(tag.get('name').length, 'name length').to.equal(192);
 
         run(() => {
             tag.validate({property: 'name'}).then(() => {
@@ -130,7 +130,7 @@ describe('Unit: Validator: tag-settings', function () {
 
         nameErrors = tag.get('errors').errorsFor('name')[0];
         expect(nameErrors.attribute, 'errors.name.attribute').to.equal('name');
-        expect(nameErrors.message, 'errors.name.message').to.equal('Tag names cannot be longer than 150 characters.');
+        expect(nameErrors.message, 'errors.name.message').to.equal('Tag names cannot be longer than 191 characters.');
 
         expect(passed, 'passed').to.be.false;
         expect(tag.get('hasValidated'), 'hasValidated').to.include('name');
@@ -138,10 +138,10 @@ describe('Unit: Validator: tag-settings', function () {
 
     it('passes with valid slug', function () {
         // longest valid slug
-        let tag = Tag.create({slug: (new Array(151).join('x'))});
+        let tag = Tag.create({slug: (new Array(192).join('x'))});
         let passed = false;
 
-        expect(tag.get('slug').length, 'slug length').to.equal(150);
+        expect(tag.get('slug').length, 'slug length').to.equal(191);
 
         run(() => {
             tag.validate({property: 'slug'}).then(() => {
@@ -155,11 +155,11 @@ describe('Unit: Validator: tag-settings', function () {
 
     it('validates slug length', function () {
         // shortest invalid slug
-        let tag = Tag.create({slug: (new Array(152).join('x'))});
+        let tag = Tag.create({slug: (new Array(193).join('x'))});
         let passed = false;
         let slugErrors;
 
-        expect(tag.get('slug').length, 'slug length').to.equal(151);
+        expect(tag.get('slug').length, 'slug length').to.equal(192);
 
         run(() => {
             tag.validate({property: 'slug'}).then(() => {
@@ -169,7 +169,7 @@ describe('Unit: Validator: tag-settings', function () {
 
         slugErrors = tag.get('errors').errorsFor('slug')[0];
         expect(slugErrors.attribute, 'errors.slug.attribute').to.equal('slug');
-        expect(slugErrors.message, 'errors.slug.message').to.equal('URL cannot be longer than 150 characters.');
+        expect(slugErrors.message, 'errors.slug.message').to.equal('URL cannot be longer than 191 characters.');
 
         expect(passed, 'passed').to.be.false;
         expect(tag.get('hasValidated'), 'hasValidated').to.include('slug');
@@ -177,10 +177,10 @@ describe('Unit: Validator: tag-settings', function () {
 
     it('passes with a valid description', function () {
         // longest valid description
-        let tag = Tag.create({description: (new Array(201).join('x'))});
+        let tag = Tag.create({description: (new Array(501).join('x'))});
         let passed = false;
 
-        expect(tag.get('description').length, 'description length').to.equal(200);
+        expect(tag.get('description').length, 'description length').to.equal(500);
 
         run(() => {
             tag.validate({property: 'description'}).then(() => {


### PR DESCRIPTION
refs TryGhost/Ghost#8143

Increases existing input validation lenght (soft limits) of the following fields:
   - `tags.name`: 191 chars
   - `tags.slug`: 191 chars
   - `users.name`: 191 chars