### PR TITLE
🐛 Fixed failing Facebook URL validation for group urls

### DIFF
--- a/app/templates/team/user.hbs
+++ b/app/templates/team/user.hbs
@@ -172,35 +172,35 @@
                 {{#gh-form-group errors=user.errors hasValidated=user.hasValidated property="location"}}
                     <label for="user-location">Location</label>
                     {{gh-input user.location type="text" id="user-location" focusOut=(action "validate" "location" target=user) update=(action (mut user.location)) data-test-location-input=true}}
-                    {{gh-error-message errors=user.errors property="location"}}
+                    {{gh-error-message errors=user.errors property="location" data-test-location-error=true}}
                     <p>Where in the world do you live?</p>
                 {{/gh-form-group}}
 
                 {{#gh-form-group errors=user.errors hasValidated=user.hasValidated property="website"}}
                     <label for="user-website">Website</label>
                     {{gh-input user.website type="url" id="user-website" autocapitalize="off" autocorrect="off" autocomplete="off" focusOut=(action "validate" "website" target=user) update=(action (mut user.website)) data-test-website-input=true}}
-                    {{gh-error-message errors=user.errors property="website"}}
+                    {{gh-error-message errors=user.errors property="website" data-test-website-error=true}}
                     <p>Have a website or blog other than this one? Link it!</p>
                 {{/gh-form-group}}
 
                 {{#gh-form-group errors=user.errors hasValidated=user.hasValidated property="facebook"}}
                     <label for="user-facebook">Facebook Profile</label>
                     <input value={{user.facebook}} oninput={{action (mut _scratchFacebook) value="target.value"}} {{action "validateFacebookUrl" on="focusOut"}} type="url" class="gh-input" id="user-facebook" name="user[facebook]"  placeholder="https://www.facebook.com/username" autocorrect="off" data-test-facebook-input=true/>
-                    {{gh-error-message errors=user.errors property="facebook"}}
+                    {{gh-error-message errors=user.errors property="facebook" data-test-facebook-error=true}}
                     <p>URL of your personal Facebook Profile</p>
                 {{/gh-form-group}}
 
                 {{#gh-form-group errors=user.errors hasValidated=user.hasValidated property="twitter"}}
                     <label for="user-twitter">Twitter Profile</label>
                     <input value={{user.twitter}} oninput={{action (mut _scratchTwitter) value="target.value"}} {{action "validateTwitterUrl" on="focusOut"}} type="url" class="gh-input" id="user-twitter" name="user[twitter]"  placeholder="https://twitter.com/username" autocorrect="off" data-test-twitter-input=true/>
-                    {{gh-error-message errors=user.errors property="twitter"}}
+                    {{gh-error-message errors=user.errors property="twitter" data-test-twitter-error=true}}
                     <p>URL of your personal Twitter profile</p>
                 {{/gh-form-group}}
 
                 {{#gh-form-group errors=user.errors hasValidated=user.hasValidated property="bio" class="bio-container"}}
                     <label for="user-bio">Bio</label>
                     {{gh-textarea user.bio id="user-bio" focusOut=(action "validate" "bio" target=user) update=(action (mut user.bio)) data-test-bio-input=true}}
-                    {{gh-error-message errors=user.errors property="bio"}}
+                    {{gh-error-message errors=user.errors property="bio" data-test-bio-error=true}}
                     <p>
                         Write about you, in 200 characters or less.
                         {{gh-count-characters user.bio}}

--- a/tests/acceptance/settings/general-test.js
+++ b/tests/acceptance/settings/general-test.js
@@ -360,6 +360,11 @@ describe('Acceptance: Settings - General', function () {
                     find(`[data-test-${type}-error]`).text().trim(),
                     `${type} validation response for ${input}`
                 ).to.equal(expectedError);
+
+                expect(
+                    find(`[data-test-${type}-input]`).closest('.form-group').hasClass('error'),
+                    `${type} input should be in error state with '${input}'`
+                ).to.equal(!!expectedError);
             };
 
             let testFacebookValidation = async (...args) => testSocialInput('facebook', ...args);

--- a/tests/acceptance/settings/general-test.js
+++ b/tests/acceptance/settings/general-test.js
@@ -347,35 +347,23 @@ describe('Acceptance: Settings - General', function () {
         });
 
         it('handles social blog settings correctly', async function () {
-            let testFacebookValidation = async function(input, expectedValue, expectedError = '') {
-                await fillIn('[data-test-facebook-input]', input);
-                await triggerEvent('[data-test-facebook-input]', 'blur');
+            let testSocialInput = async function(type, input, expectedValue, expectedError = '') {
+                await fillIn(`[data-test-${type}-input]`, input);
+                await triggerEvent(`[data-test-${type}-input]`, 'blur');
 
                 expect(
-                    find('[data-test-facebook-input]').val(),
-                    `facebook value for ${input}`
+                    find(`[data-test-${type}-input]`).val(),
+                    `${type} value for ${input}`
                 ).to.equal(expectedValue);
 
                 expect(
-                    find('[data-test-facebook-error]').text().trim(),
-                    `facebook validation response for ${input}`
+                    find(`[data-test-${type}-error]`).text().trim(),
+                    `${type} validation response for ${input}`
                 ).to.equal(expectedError);
             };
 
-            let testTwitterValidation = async function(input, expectedValue, expectedError = '') {
-                await fillIn('[data-test-twitter-input]', input);
-                await triggerEvent('[data-test-twitter-input]', 'blur');
-
-                expect(
-                    find('[data-test-twitter-input]').val(),
-                    `twitter value for ${input}`
-                ).to.equal(expectedValue);
-
-                expect(
-                    find('[data-test-twitter-error]').text().trim(),
-                    `twitter validation response for ${input}`
-                ).to.equal(expectedError);
-            };
+            let testFacebookValidation = async (...args) => testSocialInput('facebook', ...args);
+            let testTwitterValidation = async (...args) => testSocialInput('twitter', ...args);
 
             await visit('/settings/general');
             await click('[data-test-toggle-social]');

--- a/tests/acceptance/settings/general-test.js
+++ b/tests/acceptance/settings/general-test.js
@@ -347,6 +347,36 @@ describe('Acceptance: Settings - General', function () {
         });
 
         it('handles social blog settings correctly', async function () {
+            let testFacebookValidation = async function(input, expectedValue, expectedError = '') {
+                await fillIn('[data-test-facebook-input]', input);
+                await triggerEvent('[data-test-facebook-input]', 'blur');
+
+                expect(
+                    find('[data-test-facebook-input]').val(),
+                    `facebook value for ${input}`
+                ).to.equal(expectedValue);
+
+                expect(
+                    find('[data-test-facebook-error]').text().trim(),
+                    `facebook validation response for ${input}`
+                ).to.equal(expectedError);
+            };
+
+            let testTwitterValidation = async function(input, expectedValue, expectedError = '') {
+                await fillIn('[data-test-twitter-input]', input);
+                await triggerEvent('[data-test-twitter-input]', 'blur');
+
+                expect(
+                    find('[data-test-twitter-input]').val(),
+                    `twitter value for ${input}`
+                ).to.equal(expectedValue);
+
+                expect(
+                    find('[data-test-twitter-error]').text().trim(),
+                    `twitter validation response for ${input}`
+                ).to.equal(expectedError);
+            };
+
             await visit('/settings/general');
             await click('[data-test-toggle-social]');
 
@@ -363,67 +393,43 @@ describe('Acceptance: Settings - General', function () {
             expect(find('[data-test-facebook-input]').val(), 'facebook value after blur with no change')
                 .to.equal('https://www.facebook.com/test');
 
-            await fillIn('[data-test-facebook-input]', 'facebook.com/username');
-            await triggerEvent('[data-test-facebook-input]', 'blur');
+            await testFacebookValidation(
+                'facebook.com/username',
+                'https://www.facebook.com/username');
 
-            expect(find('[data-test-facebook-input]').val()).to.be.equal('https://www.facebook.com/username');
-            expect(find('[data-test-facebook-error]').text().trim(), 'inline validation response')
-                .to.equal('');
+            await testFacebookValidation(
+                'testuser',
+                'https://www.facebook.com/testuser');
 
-            await fillIn('[data-test-facebook-input]', 'facebook.com/pages/some-facebook-page/857469375913?ref=ts');
-            await triggerEvent('[data-test-facebook-input]', 'blur');
+            await testFacebookValidation(
+                'ab99',
+                'https://www.facebook.com/ab99');
 
-            expect(find('[data-test-facebook-input]').val()).to.be.equal('https://www.facebook.com/pages/some-facebook-page/857469375913?ref=ts');
-            expect(find('[data-test-facebook-error]').text().trim(), 'inline validation response')
-                .to.equal('');
+            await testFacebookValidation(
+                'page/ab99',
+                'https://www.facebook.com/page/ab99');
 
-            await fillIn('[data-test-facebook-input]', '*(&*(%%))');
-            await triggerEvent('[data-test-facebook-input]', 'blur');
+            await testFacebookValidation(
+                'page/*(&*(%%))',
+                'https://www.facebook.com/page/*(&*(%%))');
 
-            expect(find('[data-test-facebook-error]').text().trim(), 'inline validation response')
-                .to.equal('The URL must be in a format like https://www.facebook.com/yourPage');
+            await testFacebookValidation(
+                'facebook.com/pages/some-facebook-page/857469375913?ref=ts',
+                'https://www.facebook.com/pages/some-facebook-page/857469375913?ref=ts');
 
-            await fillIn('[data-test-facebook-input]', 'http://github.com/username');
-            await triggerEvent('[data-test-facebook-input]', 'blur');
+            await testFacebookValidation(
+                'https://www.facebook.com/groups/savethecrowninn',
+                'https://www.facebook.com/groups/savethecrowninn');
 
-            expect(find('[data-test-facebook-input]').val()).to.be.equal('https://www.facebook.com/username');
-            expect(find('[data-test-facebook-error]').text().trim(), 'inline validation response')
-                .to.equal('');
+            await testFacebookValidation(
+                'http://github.com/username',
+                'http://github.com/username',
+                'The URL must be in a format like https://www.facebook.com/yourPage');
 
-            await fillIn('[data-test-facebook-input]', 'http://github.com/pages/username');
-            await triggerEvent('[data-test-facebook-input]', 'blur');
-
-            expect(find('[data-test-facebook-input]').val()).to.be.equal('https://www.facebook.com/pages/username');
-            expect(find('[data-test-facebook-error]').text().trim(), 'inline validation response')
-                .to.equal('');
-
-            await fillIn('[data-test-facebook-input]', 'testuser');
-            await triggerEvent('[data-test-facebook-input]', 'blur');
-
-            expect(find('[data-test-facebook-input]').val()).to.be.equal('https://www.facebook.com/testuser');
-            expect(find('[data-test-facebook-error]').text().trim(), 'inline validation response')
-                .to.equal('');
-
-            await fillIn('[data-test-facebook-input]', 'ab99');
-            await triggerEvent('[data-test-facebook-input]', 'blur');
-
-            expect(find('[data-test-facebook-input]').val()).to.be.equal('https://www.facebook.com/ab99');
-            expect(find('[data-test-facebook-error]').text().trim(), 'inline validation response')
-                .to.equal('');
-
-            await fillIn('[data-test-facebook-input]', 'page/ab99');
-            await triggerEvent('[data-test-facebook-input]', 'blur');
-
-            expect(find('[data-test-facebook-input]').val()).to.be.equal('https://www.facebook.com/page/ab99');
-            expect(find('[data-test-facebook-error]').text().trim(), 'inline validation response')
-                .to.equal('');
-
-            await fillIn('[data-test-facebook-input]', 'page/*(&*(%%))');
-            await triggerEvent('[data-test-facebook-input]', 'blur');
-
-            expect(find('[data-test-facebook-input]').val()).to.be.equal('https://www.facebook.com/page/*(&*(%%))');
-            expect(find('[data-test-facebook-error]').text().trim(), 'inline validation response')
-                .to.equal('');
+            await testFacebookValidation(
+                'http://github.com/pages/username',
+                'http://github.com/pages/username',
+                'The URL must be in a format like https://www.facebook.com/yourPage');
 
             // validates a twitter url correctly
 
@@ -439,38 +445,27 @@ describe('Acceptance: Settings - General', function () {
             expect(find('[data-test-twitter-input]').val(), 'twitter value after blur with no change')
                 .to.equal('https://twitter.com/test');
 
-            await fillIn('[data-test-twitter-input]', 'twitter.com/username');
-            await triggerEvent('[data-test-twitter-input]', 'blur');
+            await testTwitterValidation(
+                'twitter.com/username',
+                'https://twitter.com/username');
 
-            expect(find('[data-test-twitter-input]').val()).to.be.equal('https://twitter.com/username');
-            expect(find('[data-test-twitter-error]').text().trim(), 'inline validation response')
-                .to.equal('');
+            await testTwitterValidation(
+                'testuser',
+                'https://twitter.com/testuser');
 
-            await fillIn('[data-test-twitter-input]', '*(&*(%%))');
-            await triggerEvent('[data-test-twitter-input]', 'blur');
+            await testTwitterValidation(
+                'http://github.com/username',
+                'https://twitter.com/username');
 
-            expect(find('[data-test-twitter-error]').text().trim(), 'inline validation response')
-                .to.equal('The URL must be in a format like https://twitter.com/yourUsername');
+            await testTwitterValidation(
+                '*(&*(%%))',
+                '*(&*(%%))',
+                'The URL must be in a format like https://twitter.com/yourUsername');
 
-            await fillIn('[data-test-twitter-input]', 'http://github.com/username');
-            await triggerEvent('[data-test-twitter-input]', 'blur');
-
-            expect(find('[data-test-twitter-input]').val()).to.be.equal('https://twitter.com/username');
-            expect(find('[data-test-twitter-error]').text().trim(), 'inline validation response')
-                .to.equal('');
-
-            await fillIn('[data-test-twitter-input]', 'thisusernamehasmorethan15characters');
-            await triggerEvent('[data-test-twitter-input]', 'blur');
-
-            expect(find('[data-test-twitter-error]').text().trim(), 'inline validation response')
-                .to.equal('Your Username is not a valid Twitter Username');
-
-            await fillIn('[data-test-twitter-input]', 'testuser');
-            await triggerEvent('[data-test-twitter-input]', 'blur');
-
-            expect(find('[data-test-twitter-input]').val()).to.be.equal('https://twitter.com/testuser');
-            expect(find('[data-test-twitter-error]').text().trim(), 'inline validation response')
-                .to.equal('');
+            await testTwitterValidation(
+                'thisusernamehasmorethan15characters',
+                'thisusernamehasmorethan15characters',
+                'Your Username is not a valid Twitter Username');
         });
 
         it('warns when leaving without saving', async function () {

--- a/tests/acceptance/team-test.js
+++ b/tests/acceptance/team-test.js
@@ -547,6 +547,29 @@ describe('Acceptance: Team', function () {
 
                 expect(find('[data-test-website-input]').closest('.form-group').hasClass('error'), 'website input should be in error state').to.be.true;
 
+                let testSocialInput = async function(type, input, expectedValue, expectedError = '') {
+                    await fillIn(`[data-test-${type}-input]`, input);
+                    await triggerEvent(`[data-test-${type}-input]`, 'blur');
+
+                    expect(
+                        find(`[data-test-${type}-input]`).val(),
+                        `${type} value for ${input}`
+                    ).to.equal(expectedValue);
+
+                    expect(
+                        find(`[data-test-${type}-error]`).text().trim(),
+                        `${type} validation response for ${input}`
+                    ).to.equal(expectedError);
+
+                    expect(
+                        find(`[data-test-${type}-input]`).closest('.form-group').hasClass('error'),
+                        `${type} input should be in error state with '${input}'`
+                    ).to.equal(!!expectedError);
+                };
+
+                let testFacebookValidation = async (...args) => testSocialInput('facebook', ...args);
+                let testTwitterValidation = async (...args) => testSocialInput('twitter', ...args);
+
                 // Testing Facebook input
 
                 // displays initial value
@@ -561,53 +584,43 @@ describe('Acceptance: Team', function () {
                 expect(find('[data-test-facebook-input]').val(), 'facebook value after blur with no change')
                     .to.equal('https://www.facebook.com/test');
 
-                await fillIn('[data-test-facebook-input]', '');
-                await fillIn('[data-test-facebook-input]', ')(*&%^%)');
-                await triggerEvent('[data-test-facebook-input]', 'blur');
+                await testFacebookValidation(
+                    'facebook.com/username',
+                    'https://www.facebook.com/username');
 
-                expect(find('[data-test-facebook-input]').closest('.form-group').hasClass('error'), 'facebook input should be in error state').to.be.true;
+                await testFacebookValidation(
+                    'testuser',
+                    'https://www.facebook.com/testuser');
 
-                await fillIn('[data-test-facebook-input]', '');
-                await fillIn('[data-test-facebook-input]', 'pages/)(*&%^%)');
-                await triggerEvent('[data-test-facebook-input]', 'blur');
+                await testFacebookValidation(
+                    'ab99',
+                    'https://www.facebook.com/ab99');
 
-                expect(find('[data-test-facebook-input]').val()).to.be.equal('https://www.facebook.com/pages/)(*&%^%)');
-                expect(find('[data-test-facebook-input]').closest('.form-group').hasClass('error'), 'facebook input should be in error state').to.be.false;
+                await testFacebookValidation(
+                    'page/ab99',
+                    'https://www.facebook.com/page/ab99');
 
-                await fillIn('[data-test-facebook-input]', '');
-                await fillIn('[data-test-facebook-input]', 'testing');
-                await triggerEvent('[data-test-facebook-input]', 'blur');
+                await testFacebookValidation(
+                    'page/*(&*(%%))',
+                    'https://www.facebook.com/page/*(&*(%%))');
 
-                expect(find('[data-test-facebook-input]').val()).to.be.equal('https://www.facebook.com/testing');
-                expect(find('[data-test-facebook-input]').closest('.form-group').hasClass('error'), 'facebook input should be in error state').to.be.false;
+                await testFacebookValidation(
+                    'facebook.com/pages/some-facebook-page/857469375913?ref=ts',
+                    'https://www.facebook.com/pages/some-facebook-page/857469375913?ref=ts');
 
-                await fillIn('[data-test-facebook-input]', '');
-                await fillIn('[data-test-facebook-input]', 'somewebsite.com/pages/some-facebook-page/857469375913?ref=ts');
-                await triggerEvent('[data-test-facebook-input]', 'blur');
+                await testFacebookValidation(
+                    'https://www.facebook.com/groups/savethecrowninn',
+                    'https://www.facebook.com/groups/savethecrowninn');
 
-                expect(find('[data-test-facebook-input]').val()).to.be.equal('https://www.facebook.com/pages/some-facebook-page/857469375913?ref=ts');
-                expect(find('[data-test-facebook-input]').closest('.form-group').hasClass('error'), 'facebook input should be in error state').to.be.false;
+                await testFacebookValidation(
+                    'http://github.com/username',
+                    'http://github.com/username',
+                    'The URL must be in a format like https://www.facebook.com/yourPage');
 
-                await fillIn('[data-test-facebook-input]', '');
-                await fillIn('[data-test-facebook-input]', 'test');
-                await triggerEvent('[data-test-facebook-input]', 'blur');
-
-                expect(find('[data-test-facebook-input]').val()).to.be.equal('https://www.facebook.com/test');
-                expect(find('[data-test-facebook-input]').closest('.form-group').hasClass('error'), 'facebook input should be in error state').to.be.false;
-
-                await fillIn('[data-test-facebook-input]', '');
-                await fillIn('[data-test-facebook-input]', 'http://twitter.com/testuser');
-                await triggerEvent('[data-test-facebook-input]', 'blur');
-
-                expect(find('[data-test-facebook-input]').val()).to.be.equal('https://www.facebook.com/testuser');
-                expect(find('[data-test-facebook-input]').closest('.form-group').hasClass('error'), 'facebook input should be in error state').to.be.false;
-
-                await fillIn('[data-test-facebook-input]', '');
-                await fillIn('[data-test-facebook-input]', 'facebook.com/testing');
-                await triggerEvent('[data-test-facebook-input]', 'blur');
-
-                expect(find('[data-test-facebook-input]').val()).to.be.equal('https://www.facebook.com/testing');
-                expect(find('[data-test-facebook-input]').closest('.form-group').hasClass('error'), 'facebook input should be in error state').to.be.false;
+                await testFacebookValidation(
+                    'http://github.com/pages/username',
+                    'http://github.com/pages/username',
+                    'The URL must be in a format like https://www.facebook.com/yourPage');
 
                 // Testing Twitter input
 
@@ -623,32 +636,29 @@ describe('Acceptance: Team', function () {
                 expect(find('[data-test-twitter-input]').val(), 'twitter value after blur with no change')
                     .to.equal('https://twitter.com/test');
 
-                await fillIn('[data-test-twitter-input]', '');
-                await fillIn('[data-test-twitter-input]', ')(*&%^%)');
-                await triggerEvent('[data-test-twitter-input]', 'blur');
+                await testTwitterValidation(
+                    'twitter.com/username',
+                    'https://twitter.com/username');
 
-                expect(find('[data-test-twitter-input]').closest('.form-group').hasClass('error'), 'twitter input should be in error state').to.be.true;
+                await testTwitterValidation(
+                    'testuser',
+                    'https://twitter.com/testuser');
 
-                await fillIn('[data-test-twitter-input]', '');
-                await fillIn('[data-test-twitter-input]', 'name');
-                await triggerEvent('[data-test-twitter-input]', 'blur');
+                await testTwitterValidation(
+                    'http://github.com/username',
+                    'https://twitter.com/username');
 
-                expect(find('[data-test-twitter-input]').val()).to.be.equal('https://twitter.com/name');
-                expect(find('[data-test-twitter-input]').closest('.form-group').hasClass('error'), 'twitter input should be in error state').to.be.false;
+                await testTwitterValidation(
+                    '*(&*(%%))',
+                    '*(&*(%%))',
+                    'The URL must be in a format like https://twitter.com/yourUsername');
 
-                await fillIn('[data-test-twitter-input]', '');
-                await fillIn('[data-test-twitter-input]', 'http://github.com/user');
-                await triggerEvent('[data-test-twitter-input]', 'blur');
+                await testTwitterValidation(
+                    'thisusernamehasmorethan15characters',
+                    'thisusernamehasmorethan15characters',
+                    'Your Username is not a valid Twitter Username');
 
-                expect(find('[data-test-twitter-input]').val()).to.be.equal('https://twitter.com/user');
-                expect(find('[data-test-twitter-input]').closest('.form-group').hasClass('error'), 'twitter input should be in error state').to.be.false;
-
-                await fillIn('[data-test-twitter-input]', '');
-                await fillIn('[data-test-twitter-input]', 'twitter.com/user');
-                await triggerEvent('[data-test-twitter-input]', 'blur');
-
-                expect(find('[data-test-twitter-input]').val()).to.be.equal('https://twitter.com/user');
-                expect(find('[data-test-twitter-input]').closest('.form-group').hasClass('error'), 'twitter input should be in error state').to.be.false;
+                // Testing bio input
 
                 await fillIn('[data-test-website-input]', '');
                 await fillIn('[data-test-bio-input]', new Array(210).join('a'));


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/9160
- simplified FB validation to allow any valid FB url (autocomplete of raw usernames and facebook-like URLs is still in place)
- fixed a bug with sticky Twitter validation message, if you entered an invalid URL then changed it to an invalid username you still saw the invalid URL message (surfaced through new test helpers for validating facebook/twitter fields)