### PR TITLE
🎨 Added "Featured posts" filter and featured badge to stories list

### DIFF
--- a/app/components/gh-posts-list-item.js
+++ b/app/components/gh-posts-list-item.js
@@ -21,6 +21,7 @@ export default Component.extend({
 
     isFeatured: alias('post.featured'),
     isPage: alias('post.page'),
+    isDraft: equal('post.status', 'draft'),
     isPublished: equal('post.status', 'published'),
     isScheduled: equal('post.status', 'scheduled'),
 

--- a/app/controllers/posts.js
+++ b/app/controllers/posts.js
@@ -30,6 +30,9 @@ export default Controller.extend({
         name: 'Scheduled posts',
         value: 'scheduled'
     }, {
+        name: 'Featured posts',
+        value: 'featured'
+    }, {
         name: 'Pages',
         value: 'page'
     }],

--- a/app/routes/posts.js
+++ b/app/routes/posts.js
@@ -37,6 +37,10 @@ export default AuthenticatedRoute.extend(InfinityRoute, {
             let queryParams = this._typeParams(params.type);
             let filterParams = {tag: params.tag};
 
+            if (params.type === 'featured') {
+                filterParams.featured = true;
+            }
+
             if (user.get('isAuthor')) {
                 // authors can only view their own posts
                 filterParams.author = user.get('slug');

--- a/app/templates/components/gh-posts-list-item.hbs
+++ b/app/templates/components/gh-posts-list-item.hbs
@@ -2,16 +2,24 @@
 <p>{{subText}}</p>
 
 <section class="gh-content-entry-meta">
-    {{#if isPublished}}
-        {{#if post.page}}
-            <span class="gh-content-status-draft gh-badge gh-badge-black">Page</span>
-        {{else}}
-            <span class="gh-content-status-published">Published</span>
-        {{/if}}
-    {{else if isScheduled}}
+    {{#if isPage}}
+        <span class="gh-content-status-draft gh-badge gh-badge-black">Page</span>
+    {{/if}}
+
+    {{#if isScheduled}}
         <span class="gh-content-status-draft gh-badge">Scheduled</span>
-    {{else}}
+    {{/if}}
+
+    {{#if isDraft}}
         <span class="gh-content-status-draft gh-badge gh-badge-red">Draft</span>
+    {{/if}}
+
+    {{#if isFeatured}}
+        <span class="gh-content-status-featured gh-badge gh-badge-blue">Featured</span>
+    {{/if}}
+
+    {{#if (and isPublished (not post.page))}}
+        <span class="gh-content-status-published">Published</span>
     {{/if}}
 
     by <span class="gh-content-entry-author">{{authorName}}</span> &mdash;


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/9234
- add `featured` badge to stories/pages that have the featured flag
- add "Featured posts" to the post type filter dropdown
- simplified badge logic in `{{gh-posts-list-item}}`

![featured-filter](https://user-images.githubusercontent.com/415/32670874-11c0a028-c63d-11e7-99dd-ad4e14928d98.gif)