### PR TITLE
Improve users table mobile style

### DIFF
--- a/app/styles/layouts/apps.css
+++ b/app/styles/layouts/apps.css
@@ -132,7 +132,7 @@
 @media (max-width: 500px) {
     .apps-card-meta {
         flex-basis: 70%;
-        padding-right: 20px;
+        padding-right: 10px;
     }
 }
 

--- a/app/styles/layouts/users.css
+++ b/app/styles/layouts/users.css
@@ -85,6 +85,15 @@
     margin-left: 0.75em;
 }
 
+@media (max-width: 500px) {
+    .gh-active-users .apps-configured {
+        flex-wrap: nowrap;
+    }
+
+    .gh-active-users .gh-badge:first-child {
+        margin-left: 0;
+    }
+}
 
 /* Role Labels
 /* ---------------------------------------------------------- */


### PR DESCRIPTION
Another go at https://github.com/TryGhost/Ghost/issues/8744.

Without changing the markup it's going to be difficult to wrap the badges when we have more than one. It's a bit of a compromise, as it looks fine with a slightly larger screen (iPhone 6 plus) and I want to avoid changing the design.

I've tried to get more space where possible reducing a bit the internal padding.

### iPhone 6, one badge
<img src="https://user-images.githubusercontent.com/1236790/32683360-9870d798-c672-11e7-813b-fa7de69b522d.png" width="250">

### iPhone 6, two badges
<img src="https://user-images.githubusercontent.com/1236790/32683338-71e50072-c672-11e7-8d5f-ed80fc7f37e2.png" width="250">

### iPhone 6 plus, two badges
<img src="https://user-images.githubusercontent.com/1236790/32683341-7cbdd8ac-c672-11e7-9b08-75e67e53ecb4.png" width="250">


