### PR TITLE
Remove unused top notification count functionality

### DIFF
--- a/app/components/gh-alerts.js
+++ b/app/components/gh-alerts.js
@@ -1,6 +1,5 @@
 import Component from '@ember/component';
 import {alias} from '@ember/object/computed';
-import {observer} from '@ember/object';
 import {inject as service} from '@ember/service';
 
 export default Component.extend({
@@ -9,9 +8,5 @@ export default Component.extend({
 
     notifications: service(),
 
-    messages: alias('notifications.alerts'),
-
-    messageCountObserver: observer('messages.[]', function () {
-        this.sendAction('notify', this.get('messages').length);
-    })
+    messages: alias('notifications.alerts')
 });

--- a/app/components/gh-markdown-editor.js
+++ b/app/components/gh-markdown-editor.js
@@ -44,6 +44,7 @@ export default Component.extend(ShortcutsMixin, {
     mobiledoc: null,
     options: null,
     placeholder: '',
+    showMarkdownHelp: false,
     uploadedImageUrls: null,
 
     // Closure actions
@@ -52,7 +53,6 @@ export default Component.extend(ShortcutsMixin, {
     onImageFilesSelected() {},
     onPreviewToggle() {},
     onSplitScreenToggle() {},
-    showMarkdownHelp() {},
 
     // Internal attributes
     markdown: null,
@@ -132,7 +132,7 @@ export default Component.extend(ShortcutsMixin, {
                 {
                     name: 'guide',
                     action: () => {
-                        this.showMarkdownHelp();
+                        this.send('toggleMarkdownHelp');
                     },
                     className: 'fa fa-question-circle',
                     title: 'Markdown Guide'
@@ -603,6 +603,10 @@ export default Component.extend(ShortcutsMixin, {
 
         toggleHemingway() {
             this._toggleHemingway();
+        },
+
+        toggleMarkdownHelp() {
+            this.toggleProperty('showMarkdownHelp');
         },
 
         // put the toolbar/statusbar elements back so that SimpleMDE doesn't throw

--- a/app/components/gh-nav-menu.js
+++ b/app/components/gh-nav-menu.js
@@ -78,11 +78,5 @@ export default Component.extend({
         iconUrl += `?t=${(new Date()).valueOf()}`;
 
         this.set('iconStyle', htmlSafe(`background-image: url(${iconUrl})`));
-    },
-
-    actions: {
-        showMarkdownHelp() {
-            this.sendAction('showMarkdownHelp');
-        }
     }
 });

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -17,13 +17,5 @@ export default Controller.extend({
 
         return (this.get('currentPath') !== 'error404' || this.get('session.isAuthenticated'))
                 && !this.get('currentPath').match(/(signin|signup|setup|reset)/);
-    }),
-
-    topNotificationCount: 0,
-
-    actions: {
-        topNotificationChange(count) {
-            this.set('topNotificationCount', count);
-        }
-    }
+    })
 });

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -20,7 +20,6 @@ export default Controller.extend({
     }),
 
     topNotificationCount: 0,
-    showMarkdownHelpModal: false,
 
     actions: {
         topNotificationChange(count) {

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -205,10 +205,6 @@ export default Route.extend(ApplicationRouteMixin, ShortcutsRoute, {
             }
         },
 
-        toggleMarkdownHelpModal() {
-            this.get('controller').toggleProperty('showMarkdownHelpModal');
-        },
-
         // noop default for unhandled save (used from shortcuts)
         save: K,
 

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,14 +1,14 @@
 {{#gh-app showSettingsMenu=ui.showSettingsMenu}}
     {{#gh-skip-link anchor=".gh-main"}}Skip to main content{{/gh-skip-link}}
 
-    {{gh-alerts notify="topNotificationChange"}}
+    {{gh-alerts}}
 
     <div class="gh-viewport {{if ui.autoNav 'gh-autonav'}} {{if ui.showSettingsMenu 'settings-menu-expanded'}} {{if ui.showMobileMenu 'mobile-menu-expanded'}}">
         {{#if showNavMenu}}
             {{gh-nav-menu open=ui.autoNavOpen}}
         {{/if}}
 
-        {{#gh-main onMouseEnter=(action "closeAutoNav" target=ui) data-notification-count=topNotificationCount}}
+        {{#gh-main onMouseEnter=(action "closeAutoNav" target=ui)}}
             {{outlet}}
         {{/gh-main}}
 

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -5,10 +5,7 @@
 
     <div class="gh-viewport {{if ui.autoNav 'gh-autonav'}} {{if ui.showSettingsMenu 'settings-menu-expanded'}} {{if ui.showMobileMenu 'mobile-menu-expanded'}}">
         {{#if showNavMenu}}
-            {{gh-nav-menu
-                open=ui.autoNavOpen
-                icon=settings.settledIcon
-                showMarkdownHelp="toggleMarkdownHelpModal"}}
+            {{gh-nav-menu open=ui.autoNavOpen}}
         {{/if}}
 
         {{#gh-main onMouseEnter=(action "closeAutoNav" target=ui) data-notification-count=topNotificationCount}}
@@ -23,11 +20,5 @@
         {{gh-mobile-nav-bar}}
     </div>{{!gh-viewport}}
 {{/gh-app}}
-
-{{#if showMarkdownHelpModal}}
-    {{gh-fullscreen-modal "markdown-help"
-                          close=(route-action "toggleMarkdownHelpModal")
-                          modifier="wide"}}
-{{/if}}
 
 {{ember-load-remover}}

--- a/app/templates/components/gh-markdown-editor.hbs
+++ b/app/templates/components/gh-markdown-editor.hbs
@@ -23,3 +23,9 @@
         insert=(action "insertUnsplashPhoto")
         close=(action "toggleUnsplash")}}
 {{/if}}
+
+{{#if showMarkdownHelp}}
+    {{gh-fullscreen-modal "markdown-help"
+        close=(action "toggleMarkdownHelp")
+        modifier="wide"}}
+{{/if}}

--- a/app/templates/editor/edit.hbs
+++ b/app/templates/editor/edit.hbs
@@ -47,7 +47,6 @@
         onPreviewToggle=(action editor.togglePreview)
         onSplitScreenToggle=(action editor.toggleSplitScreen)
         onImageFilesSelected=(action editor.uploadImages)
-        showMarkdownHelp=(route-action "toggleMarkdownHelpModal")
         imageMimeTypes=editor.imageMimeTypes
         as |markdown|
     }}


### PR DESCRIPTION
no issue

- in a very old iteration of the admin design we needed a data attribute containing the number of notifications in order to add extra spacing in the styles. This hasn't been necessary for a long time and there are easier ways to do it now than using observers.