### PR TITLE
🐛 Fixed blog icon not shown in nav

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -5,7 +5,10 @@
 
     <div class="gh-viewport {{if ui.autoNav 'gh-autonav'}} {{if ui.showSettingsMenu 'settings-menu-expanded'}} {{if ui.showMobileMenu 'mobile-menu-expanded'}}">
         {{#if showNavMenu}}
-            {{gh-nav-menu open=ui.autoNavOpen}}
+            {{gh-nav-menu
+                open=ui.autoNavOpen
+                icon=settings.settledIcon
+            }}
         {{/if}}
 
         {{#gh-main onMouseEnter=(action "closeAutoNav" target=ui)}}


### PR DESCRIPTION
closes TryGhost/Ghost#9293

Added https://github.com/TryGhost/Ghost-Admin/commit/14aa87ed39b93826d33ac23ac955aafcd4d5d69b#diff-f63965ba48df687541db46e0e1b2c2ecL10 back, which broke the rendering of the blog icon in the nav menu.