### PR TITLE
🐛 Fixed editor image uploads

### DIFF
--- a/app/components/gh-editor.js
+++ b/app/components/gh-editor.js
@@ -156,7 +156,10 @@ export default Component.extend({
         },
 
         uploadImages(fileList, resetInput) {
-            this.set('droppedFiles', fileList);
+            // convert FileList to an array so that resetting the input doesn't
+            // clear the file references before upload actions can be triggered
+            let files = Array.from(fileList);
+            this.set('droppedFiles', files);
             resetInput();
         },
 


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/9300
- as of https://github.com/TryGhost/Ghost-Admin/commit/74428efd8bf5a3d896dd1c5c549553893bc5aa05 we reset the file input earlier in the actions chain, this was clearing the file references before the editor was triggering the upload. By converting the `FileList` to an `Array` before resetting the input we keep hold of the file references and the upload works again.