### PR TITLE
🐛 Fixed "NaNUndefined" when inserting unordered list items

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8441,7 +8441,7 @@ simple-swizzle@^0.2.2:
 
 "simplemde@https://github.com/kevinansfield/simplemde-markdown-editor.git#ghost":
   version "1.11.2"
-  resolved "https://github.com/kevinansfield/simplemde-markdown-editor.git#4f13b1bc91c3d54cfa1d313197e855a8cf575c4a"
+  resolved "https://github.com/kevinansfield/simplemde-markdown-editor.git#3633c1038e767c3bdf0586aa9e05f3a66ab1f817"
   dependencies:
     codemirror "*"
     codemirror-spell-checker "*"


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/9302
- reverts the `simplemde` bump introduced in https://github.com/TryGhost/Ghost-Admin/pull/911/, the updated version of CodeMirror appears to contain a bug or incompatibility with SimpleMDE