### PR TITLE
Update `ember-cli-mocha` to v0.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "ember-cli-htmlbars-inline-precompile": "1.0.2",
     "ember-cli-inject-live-reload": "1.7.0",
     "ember-cli-mirage": "0.2.8",
-    "ember-cli-mocha": "0.14.4",
+    "ember-cli-mocha": "^0.15.0",
     "ember-cli-moment-shim": "3.5.0",
     "ember-cli-node-assets": "0.2.2",
     "ember-cli-postcss": "3.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@ember/test-helpers@^0.7.16":
+  version "0.7.16"
+  resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-0.7.16.tgz#73a4acf4c7d1b92ce866f4c9e40c9723da4cf1e8"
+  dependencies:
+    broccoli-funnel "^2.0.1"
+    ember-cli-babel "^6.10.0"
+    ember-cli-htmlbars-inline-precompile "^1.0.0"
+
 "@glimmer/di@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@glimmer/di/-/di-0.2.0.tgz#73bfd4a6ee4148a80bf092e8a5d29bcac9d4ce7e"
@@ -2219,6 +2227,12 @@ commander@^2.5.0, commander@^2.6.0, commander@~2.13.0:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
 
+common-tags@^1.5.1:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.7.2.tgz#24d9768c63d253a56ecff93845b44b4df1d52771"
+  dependencies:
+    babel-runtime "^6.26.0"
+
 commoner@~0.10.3:
   version "0.10.8"
   resolved "https://registry.yarnpkg.com/commoner/-/commoner-0.10.8.tgz#34fc3672cd24393e8bb47e70caa0293811f4f2c5"
@@ -3034,7 +3048,7 @@ ember-cli-get-dependency-depth@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-get-dependency-depth/-/ember-cli-get-dependency-depth-1.0.0.tgz#e0afecf82a2d52f00f28ab468295281aec368d11"
 
-ember-cli-htmlbars-inline-precompile@1.0.2:
+ember-cli-htmlbars-inline-precompile@1.0.2, ember-cli-htmlbars-inline-precompile@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars-inline-precompile/-/ember-cli-htmlbars-inline-precompile-1.0.2.tgz#5b544f664d5d9911f08cd979c5f70d8cb0ca2add"
   dependencies:
@@ -3123,17 +3137,11 @@ ember-cli-mirage@0.2.8:
     pretender "^1.4.2"
     route-recognizer "^0.2.3"
 
-ember-cli-mocha@0.14.4:
-  version "0.14.4"
-  resolved "https://registry.yarnpkg.com/ember-cli-mocha/-/ember-cli-mocha-0.14.4.tgz#5f63907f952ec6d6609d551ce321dc83823ba63f"
+ember-cli-mocha@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-mocha/-/ember-cli-mocha-0.15.0.tgz#483b25a2c631b2b1913344686f497a81ced669b6"
   dependencies:
-    broccoli-funnel "^1.0.1"
-    broccoli-merge-trees "^2.0.0"
-    ember-cli-babel "^6.0.0"
-    ember-cli-test-loader "^2.0.0"
-    ember-mocha "^0.12.0"
-    mocha "^2.5.3"
-    resolve "^1.1.7"
+    ember-mocha "^0.13.0"
 
 ember-cli-moment-shim@3.5.0, ember-cli-moment-shim@^3.1.0:
   version "3.5.0"
@@ -3250,7 +3258,7 @@ ember-cli-test-info@^1.0.0:
   dependencies:
     ember-cli-string-utils "^1.0.0"
 
-ember-cli-test-loader@2.2.0, ember-cli-test-loader@^2.0.0:
+ember-cli-test-loader@2.2.0, ember-cli-test-loader@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ember-cli-test-loader/-/ember-cli-test-loader-2.2.0.tgz#3fb8d5d1357e4460d3f0a092f5375e71b6f7c243"
   dependencies:
@@ -3628,11 +3636,17 @@ ember-maybe-import-regenerator@^0.1.5:
     ember-cli-babel "^6.0.0-beta.4"
     regenerator-runtime "^0.9.5"
 
-ember-mocha@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/ember-mocha/-/ember-mocha-0.12.0.tgz#ea27ae9838c8c6e28ea72c48084586ef5fa00a7a"
+ember-mocha@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/ember-mocha/-/ember-mocha-0.13.0.tgz#36732e0f8b85413bd0a97ee7060bf7c2f0196e62"
   dependencies:
-    ember-test-helpers "^0.6.3"
+    "@ember/test-helpers" "^0.7.16"
+    broccoli-funnel "^2.0.1"
+    broccoli-merge-trees "^2.0.0"
+    common-tags "^1.5.1"
+    ember-cli-babel "^6.6.0"
+    ember-cli-test-loader "^2.2.0"
+    mocha "^2.5.3"
 
 ember-moment@^7.3.0:
   version "7.6.0"
@@ -3795,10 +3809,6 @@ ember-source@2.18.0:
     inflection "^1.12.0"
     jquery "^3.2.1"
     resolve "^1.3.3"
-
-ember-test-helpers@^0.6.3:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/ember-test-helpers/-/ember-test-helpers-0.6.3.tgz#f864cdf6f4e75f3f8768d6537785b5ab6e82d907"
 
 ember-test-selectors@0.3.8:
   version "0.3.8"


### PR DESCRIPTION
This PR updates `ember-cli-mocha` to test the changes in https://github.com/emberjs/ember-mocha/pull/173 and https://github.com/ember-cli/ember-cli-mocha/pull/229