### PR TITLE
Addresses issue #9296 (unexpected publishing of post)

### DIFF
--- a/app/mixins/editor-base-route.js
+++ b/app/mixins/editor-base-route.js
@@ -6,7 +6,8 @@ import styleBody from 'ghost-admin/mixins/style-body';
 import {run} from '@ember/runloop';
 
 let generalShortcuts = {};
-generalShortcuts[`${ctrlOrCmd}+alt+p`] = 'publish';
+
+generalShortcuts[`${ctrlOrCmd}+shift+p`] = 'publish';
 
 export default Mixin.create(styleBody, ShortcutsRoute, {
     classNames: ['editor'],


### PR DESCRIPTION
Addresses: https://github.com/TryGhost/Ghost/issues/9296

Also confirmed in ubuntu.

Shortcut changed to CTRL+SHIFT+P as CTRL+ALT+P is an already assigned shortcut in all platforms at:
https://github.com/TryGhost/Ghost-Admin/blob/312bd68f4c30b8b919ea4c0911c98faaca55ff8f/app/components/gh-markdown-editor.js#L113

A better fix would probably be a centralised or user controllable
shortcut config.

But for now, this or only setting the shift alternative for platforms
other than mac should fix this.