### PR TITLE
Trims the URL before saving or sending test notification

### DIFF
--- a/app/controllers/settings/apps/slack.js
+++ b/app/controllers/settings/apps/slack.js
@@ -65,6 +65,7 @@ export default Controller.extend({
         },
 
         updateURL(value) {
+            value = typeof value === 'string' ? value.trim() : value;
             this.set('model.url', value);
             this.get('model.errors').clear();
         },

--- a/app/validators/slack-integration.js
+++ b/app/validators/slack-integration.js
@@ -5,7 +5,7 @@ export default BaseValidator.create({
     properties: ['url'],
 
     url(model) {
-        let url = model.getWithDefault('url', '').trim();
+        let url = model.get('url');
         let hasValidated = model.get('hasValidated');
 
         // eslint-disable-next-line camelcase

--- a/app/validators/slack-integration.js
+++ b/app/validators/slack-integration.js
@@ -5,7 +5,7 @@ export default BaseValidator.create({
     properties: ['url'],
 
     url(model) {
-        let url = model.get('url');
+        let url = model.getWithDefault('url', '').trim();
         let hasValidated = model.get('hasValidated');
 
         // eslint-disable-next-line camelcase


### PR DESCRIPTION
Towards https://github.com/TryGhost/Ghost/issues/9263
- trimming the URL value in the validator

Having a space in the URL would cause Ghost to complain - 
> The URL must be in a format like https://hooks.slack.com/services/<your personal key>

Now trimming the URL before validating.

Signed-off-by: Abijeet <abijeetpatro@gmail.com>
- [x] Commit message has a short title & issue references
- [x] Commits are squashed 
- [x] The build will pass (run `ember test` from the repo root - will be `core/client` if working from the submodule in Ghost).
