### PR TITLE
🐛 Fixed editor and drag/drop image uploads in IE11

### DIFF
--- a/app/components/gh-editor.js
+++ b/app/components/gh-editor.js
@@ -89,8 +89,10 @@ export default Component.extend({
 
         // this is needed to work around inconsistencies with dropping files
         // from Chrome's downloads bar
-        let eA = event.dataTransfer.effectAllowed;
-        event.dataTransfer.dropEffect = (eA === 'move' || eA === 'linkMove') ? 'move' : 'copy';
+        if (navigator.userAgent.indexOf('Chrome') > -1) {
+            let eA = event.dataTransfer.effectAllowed;
+            event.dataTransfer.dropEffect = (eA === 'move' || eA === 'linkMove') ? 'move' : 'copy';
+        }
 
         event.preventDefault();
         event.stopPropagation();

--- a/app/components/gh-file-input.js
+++ b/app/components/gh-file-input.js
@@ -6,8 +6,10 @@ import XFileInput from 'emberx-file-input/components/x-file-input';
 export default XFileInput.extend({
     change(e) {
         let action = this.get('action');
-        if (action) {
-            action(this.files(e), this.resetInput.bind(this));
+        let files = this.files(e);
+
+        if (files.length && action) {
+            action(files, this.resetInput.bind(this));
         }
     },
 

--- a/app/components/gh-file-uploader.js
+++ b/app/components/gh-file-uploader.js
@@ -109,8 +109,10 @@ export default Component.extend({
 
         // this is needed to work around inconsistencies with dropping files
         // from Chrome's downloads bar
-        let eA = event.dataTransfer.effectAllowed;
-        event.dataTransfer.dropEffect = (eA === 'move' || eA === 'linkMove') ? 'move' : 'copy';
+        if (navigator.userAgent.indexOf('Chrome') > -1) {
+            let eA = event.dataTransfer.effectAllowed;
+            event.dataTransfer.dropEffect = (eA === 'move' || eA === 'linkMove') ? 'move' : 'copy';
+        }
 
         event.stopPropagation();
         event.preventDefault();

--- a/app/components/gh-image-uploader.js
+++ b/app/components/gh-image-uploader.js
@@ -100,8 +100,10 @@ export default Component.extend({
 
         // this is needed to work around inconsistencies with dropping files
         // from Chrome's downloads bar
-        let eA = event.dataTransfer.effectAllowed;
-        event.dataTransfer.dropEffect = (eA === 'move' || eA === 'linkMove') ? 'move' : 'copy';
+        if (navigator.userAgent.indexOf('Chrome') > -1) {
+            let eA = event.dataTransfer.effectAllowed;
+            event.dataTransfer.dropEffect = (eA === 'move' || eA === 'linkMove') ? 'move' : 'copy';
+        }
 
         event.stopPropagation();
         event.preventDefault();

--- a/app/components/gh-profile-image.js
+++ b/app/components/gh-profile-image.js
@@ -62,8 +62,10 @@ export default Component.extend({
 
         // this is needed to work around inconsistencies with dropping files
         // from Chrome's downloads bar
-        let eA = event.dataTransfer.effectAllowed;
-        event.dataTransfer.dropEffect = (eA === 'move' || eA === 'linkMove') ? 'move' : 'copy';
+        if (navigator.userAgent.indexOf('Chrome') > -1) {
+            let eA = event.dataTransfer.effectAllowed;
+            event.dataTransfer.dropEffect = (eA === 'move' || eA === 'linkMove') ? 'move' : 'copy';
+        }
 
         event.stopPropagation();
         event.preventDefault();

--- a/lib/gh-koenig/addon/components/cards/card-image.js
+++ b/lib/gh-koenig/addon/components/cards/card-image.js
@@ -86,8 +86,10 @@ export default Component.extend({
 
         // this is needed to work around inconsistencies with dropping files
         // from Chrome's downloads bar
-        let eA = event.dataTransfer.effectAllowed;
-        event.dataTransfer.dropEffect = (eA === 'move' || eA === 'linkMove') ? 'move' : 'copy';
+        if (navigator.userAgent.indexOf('Chrome') > -1) {
+            let eA = event.dataTransfer.effectAllowed;
+            event.dataTransfer.dropEffect = (eA === 'move' || eA === 'linkMove') ? 'move' : 'copy';
+        }
 
         event.stopPropagation();
         event.preventDefault();


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/9321
- don't use `dataTransfer.effectAllowed` in IE11
- only fire the action in `{{gh-file-input}}` if there are files selected to prevent a double call to the action due to resetting the input