### PR TITLE
Change font-color of weekdays in Post Settings > Publish Date > Calender pop-up, to white

### DIFF
--- a/app/styles/app-dark.css
+++ b/app/styles/app-dark.css
@@ -320,3 +320,6 @@ input,
 .CodeMirror .CodeMirror-code .cm-string {
     color: color(#183691 l(+25%));
 }
+.ember-power-calendar-weekdays {
+    color: #fff;
+}


### PR DESCRIPTION
Addresses issue: #9244 (https://github.com/TryGhost/Ghost/issues/9244)

Currently font-color of weekdays is set to a near dark value "#33333",
which is not visible in dark theme (Admin)

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!
- [Yes] Commit message has a short title & issue references
- [ Single Commit ] Commits are squashed 
- [ Yes ] The build will pass (run `ember test` from the repo root - will be `core/client` if working from the submodule in Ghost).

More info can be found by clicking the "guidelines for contributing" link above.
