### PR TITLE
Update `ember-simple-auth` to v1.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "ember-resolver": "4.5.0",
     "ember-responsive": "2.0.5",
     "ember-route-action-helper": "2.0.6",
-    "ember-simple-auth": "1.4.0",
+    "ember-simple-auth": "1.4.2",
     "ember-sinon": "1.0.1",
     "ember-source": "2.17.0",
     "ember-test-selectors": "0.3.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1415,7 +1415,7 @@ broccoli-funnel@1.0.2:
     symlink-or-copy "^1.0.0"
     walk-sync "^0.2.6"
 
-broccoli-funnel@2.0.1, broccoli-funnel@^2.0.0:
+broccoli-funnel@2.0.1, "broccoli-funnel@^1.2.0 || ^2.0.0", broccoli-funnel@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz#6823c73b675ef78fffa7ab800f083e768b51d449"
   dependencies:
@@ -3398,12 +3398,12 @@ ember-concurrency@0.8.12, ember-concurrency@^0.8.1, ember-concurrency@^0.8.12:
     ember-getowner-polyfill "^2.0.0"
     ember-maybe-import-regenerator "^0.1.5"
 
-ember-cookies@^0.0.13:
-  version "0.0.13"
-  resolved "https://registry.yarnpkg.com/ember-cookies/-/ember-cookies-0.0.13.tgz#18350df766240793d46744e4ee5c9a55ae6b4e0a"
+ember-cookies@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/ember-cookies/-/ember-cookies-0.1.2.tgz#f652efcb289534cdc1425832ed3c77aeb432ef72"
   dependencies:
-    ember-cli-babel "^5.1.7"
-    ember-getowner-polyfill "^1.2.2"
+    ember-cli-babel "^6.8.2"
+    ember-getowner-polyfill "^1.1.0 || ^2.0.0"
 
 ember-data-filter@1.13.0:
   version "1.13.0"
@@ -3491,20 +3491,20 @@ ember-get-config@0.2.1:
     broccoli-file-creator "^1.1.1"
     ember-cli-babel "^5.1.6"
 
-ember-getowner-polyfill@^1.1.0, ember-getowner-polyfill@^1.1.1, ember-getowner-polyfill@^1.2.2:
+"ember-getowner-polyfill@^1.1.0 || ^2.0.0", ember-getowner-polyfill@^2.0.0, ember-getowner-polyfill@^2.0.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz#38e7dccbcac69d5ec694000329ec0b2be651d2b2"
+  dependencies:
+    ember-cli-version-checker "^2.1.0"
+    ember-factory-for-polyfill "^1.3.1"
+
+ember-getowner-polyfill@^1.1.1:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-1.2.5.tgz#ceff8a09897d0d7e05c821bb71666a95eb26dc92"
   dependencies:
     ember-cli-babel "^5.1.6"
     ember-cli-version-checker "^1.2.0"
     ember-factory-for-polyfill "^1.1.0"
-
-ember-getowner-polyfill@^2.0.0, ember-getowner-polyfill@^2.0.1:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz#38e7dccbcac69d5ec694000329ec0b2be651d2b2"
-  dependencies:
-    ember-cli-version-checker "^2.1.0"
-    ember-factory-for-polyfill "^1.3.1"
 
 ember-hash-helper-polyfill@^0.2.0:
   version "0.2.0"
@@ -3751,19 +3751,19 @@ ember-scrollable@^0.4.4:
     ember-element-resize-detector "0.1.5"
     ember-lifeline "^2.0.0"
 
-ember-simple-auth@1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/ember-simple-auth/-/ember-simple-auth-1.4.0.tgz#b989fb94a334ca1634e62f9ca99b0b94f16167ec"
+ember-simple-auth@1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/ember-simple-auth/-/ember-simple-auth-1.4.2.tgz#d8de79f4bcfb5830f43e61e43464885801544e94"
   dependencies:
     base-64 "^0.1.0"
     broccoli-file-creator "^1.1.1"
-    broccoli-funnel "^1.2.0"
+    broccoli-funnel "^1.2.0 || ^2.0.0"
     broccoli-merge-trees "^2.0.0"
-    ember-cli-babel "^6.0.0"
+    ember-cli-babel "^6.8.2"
     ember-cli-is-package-missing "^1.0.0"
-    ember-cookies "^0.0.13"
+    ember-cookies "^0.1.0"
     ember-fetch "^2.1.0 || ^3.0.0"
-    ember-getowner-polyfill "^1.1.0"
+    ember-getowner-polyfill "^1.1.0 || ^2.0.0"
     silent-error "^1.0.0"
 
 ember-sinon@1.0.1:


### PR DESCRIPTION
This PR updates `ember-simple-auth` to v1.4.2 to take advantage of the bug fix in https://github.com/simplabs/ember-simple-auth/pull/1477

This will enable/unblock https://github.com/TryGhost/Ghost-Admin/pull/922

- [x] Commit message has a short title & issue references
- [x] Commits are squashed 
- [ ] The build will pass (run `ember test` from the repo root - will be `core/client` if working from the submodule in Ghost).

