### PR TITLE
Don't destructure Ember.testing

### DIFF
--- a/app/components/gh-download-count.js
+++ b/app/components/gh-download-count.js
@@ -3,9 +3,6 @@ import Ember from 'ember';
 import {inject as service} from '@ember/service';
 import {task, timeout} from 'ember-concurrency';
 
-const {testing} = Ember;
-const INTERVAL = testing ? 20 : 2000;
-
 export default Component.extend({
     ajax: service(),
     ghostPaths: service(),
@@ -27,8 +24,8 @@ export default Component.extend({
 
             this.set('count', count);
 
-            if (!testing) {
-                yield timeout(INTERVAL);
+            if (!Ember.testing) { // eslint-disable-line
+                yield timeout(2000);
                 this.get('_poll').perform();
             }
         } catch (e) {

--- a/app/components/gh-editor-post-status.js
+++ b/app/components/gh-editor-post-status.js
@@ -4,11 +4,6 @@ import {computed} from '@ember/object';
 import {reads} from '@ember/object/computed';
 import {task, timeout} from 'ember-concurrency';
 
-const {testing} = Ember;
-
-// TODO: reduce when in testing mode
-const SAVE_TIMEOUT_MS = testing ? 0 : 3000;
-
 export default Component.extend({
     post: null,
     isNew: reads('post.isNew'),
@@ -37,7 +32,7 @@ export default Component.extend({
 
     showSavingMessage: task(function* () {
         this.set('_isSaving', true);
-        yield timeout(SAVE_TIMEOUT_MS);
+        yield timeout(Ember.testing ? 0 : 3000); // eslint-disable-line
         this.set('_isSaving', false);
     }).drop()
 });

--- a/app/components/gh-simplemde.js
+++ b/app/components/gh-simplemde.js
@@ -5,9 +5,6 @@ import {assign} from '@ember/polyfills';
 import {computed} from '@ember/object';
 import {isEmpty} from '@ember/utils';
 
-// ember-cli-shims doesn't export Ember.testing
-const {testing} = Ember;
-
 export default TextArea.extend({
 
     // Public attributes
@@ -55,7 +52,7 @@ export default TextArea.extend({
 
         // disable spellchecker when testing so that the exterally loaded plugin
         // doesn't fail
-        if (testing) {
+        if (Ember.testing) { // eslint-disable-line
             editorOptions.spellChecker = false;
         }
 

--- a/app/controllers/settings/labs.js
+++ b/app/controllers/settings/labs.js
@@ -13,7 +13,6 @@ import {run} from '@ember/runloop';
 import {inject as service} from '@ember/service';
 import {task, timeout} from 'ember-concurrency';
 
-const {testing} = Ember;
 const {Promise} = RSVP;
 
 const IMPORT_MIME_TYPES =  [
@@ -109,7 +108,7 @@ export default Controller.extend({
         this.set('redirectSuccess', success);
         this.set('redirectFailure', !success);
 
-        yield timeout(testing ? 100 : 5000);
+        yield timeout(Ember.testing ? 100 : 5000); // eslint-disable-line
 
         this.set('redirectSuccess', null);
         this.set('redirectFailure', null);

--- a/app/mixins/editor-base-controller.js
+++ b/app/mixins/editor-base-controller.js
@@ -16,9 +16,6 @@ import {mapBy, reads} from '@ember/object/computed';
 import {inject as service} from '@ember/service';
 import {task, taskGroup, timeout} from 'ember-concurrency';
 
-// ember-cli-shims doesn't export Ember.testing
-const {testing} = Ember;
-
 // this array will hold properties we need to watch
 // to know if the model has been changed (`controller.hasDirtyAttributes`)
 const watchedProps = ['model.scratch', 'model.titleScratch', 'model.hasDirtyAttributes', 'model.tags.[]'];
@@ -66,7 +63,7 @@ export default Mixin.create({
     },
 
     _canAutosave: computed('model.isDraft', function () {
-        return !testing && this.get('model.isDraft');
+        return !Ember.testing && this.get('model.isDraft'); // eslint-disable-line
     }),
 
     // save 3 seconds after the last edit
@@ -90,8 +87,7 @@ export default Mixin.create({
             return;
         }
 
-        // eslint-disable-next-line no-constant-condition
-        while (!testing && true) {
+        while (!Ember.testing && true) { // eslint-disable-line
             yield timeout(TIMEDSAVE_TIMEOUT);
             this.get('autosave').perform();
         }

--- a/app/services/clock.js
+++ b/app/services/clock.js
@@ -3,9 +3,6 @@ import Service from '@ember/service';
 import moment from 'moment';
 import {run} from '@ember/runloop';
 
-// ember-cli-shims doesn't export Ember.testing
-const {testing} = Ember;
-
 const ONE_SECOND = 1000;
 
 // Creates a clock service to run intervals.
@@ -28,7 +25,7 @@ export default Service.extend({
             hour:   now.hours()
         });
 
-        if (!testing) {
+        if (!Ember.testing) { // eslint-disable-line
             run.later(() => {
                 this.tick();
             }, ONE_SECOND);

--- a/app/services/lazy-loader.js
+++ b/app/services/lazy-loader.js
@@ -3,20 +3,22 @@ import Ember from 'ember';
 import RSVP from 'rsvp';
 import Service, {inject as service} from '@ember/service';
 
-const {testing} = Ember;
-
 export default Service.extend({
     ajax: service(),
     ghostPaths: service(),
 
     // This is needed so we can disable it in unit tests
-    testing,
+    testing: undefined,
 
     scriptPromises: null,
 
     init() {
         this._super(...arguments);
         this.scriptPromises = {};
+
+        if (this.testing === undefined) {
+            this.testing = Ember.testing; // eslint-disable-line
+        }
     },
 
     loadScript(key, url) {


### PR DESCRIPTION
no issue
- `Ember.testing` is or will soon be a getter/setter in Ember with the value set during a test, however destructuring will read the value when the module is evaluated
- moves all uses of `Ember.testing` inline