### PR TITLE
Fix for icon upload button hover state in Settings > General

### DIFF
--- a/app/templates/settings/general.hbs
+++ b/app/templates/settings/general.hbs
@@ -82,7 +82,7 @@
                         <span>delete</span>
                     </button>
                 {{else}}
-                    <button type="button" class="gh-btn" onclick={{action "triggerFileDialog"}} data-test-image-upload-btn="icon">
+                    <button type="button" class="gh-btn gh-btn-hover-blue" onclick={{action "triggerFileDialog"}} data-test-image-upload-btn="icon">
                         <span>Upload Image</span>
                     </button>
                 {{/if}}


### PR DESCRIPTION
Fixes hover state inconsistency between 'Expand' and 'Upload new image' buttons in Settings > General.

Please include a description of your change & check your PR against this list, thanks!
- [x] Commit message has a short title & issue references
- [x] Commits are squashed 
- [x] The build will pass (run `ember test` from the repo root - will be `core/client` if working from the submodule in Ghost).

More info can be found by clicking the "guidelines for contributing" link above.
