### PR TITLE
🎨 Improved code injection loading behaviour on slow connections

### DIFF
--- a/app/styles/components/settings-menu.css
+++ b/app/styles/components/settings-menu.css
@@ -143,6 +143,10 @@
     line-height: 1.3em;
 }
 
+.settings-menu-content .gh-cm-editor-textarea {
+    min-height: 170px;
+}
+
 .settings-menu-content .nav-list {
     margin-top: 3rem;
 }

--- a/app/styles/layouts/settings.css
+++ b/app/styles/layouts/settings.css
@@ -276,6 +276,14 @@
     line-height: 22px;
 }
 
+.settings-code-editor textarea {
+    width: 100%;
+    max-width: none;
+    min-height: 300px;
+    line-height: 22px;
+    border: none;
+}
+
 .settings-code-editor .CodeMirror {
     padding: 0;
     border: none;

--- a/app/templates/components/gh-cm-editor.hbs
+++ b/app/templates/components/gh-cm-editor.hbs
@@ -1,0 +1,4 @@
+{{!-- display a standard textarea whilst waiting for CodeMirror to load/initialize --}}
+{{#if isInitializingCodemirror}}
+    {{gh-textarea class="gh-cm-editor-textarea" value=_value update=(action 'updateFromTextarea')}}
+{{/if}}

--- a/app/templates/components/gh-post-settings-menu.hbs
+++ b/app/templates/components/gh-post-settings-menu.hbs
@@ -369,7 +369,7 @@
                             <div style="width:23px;"></div>
                         </div>
 
-                        <div class="settings-menu-content">
+                        <div class="settings-menu-content settings-menu-content-codeinjection">
                             <form {{action "discardEnter" on="submit"}}>
                                 {{#gh-form-group errors=model.errors hasValidated=model.hasValidated property="codeinjectionHead"}}
                                     <label for="codeinjection-head">Post Header <code>\{{ghost_head}}</code></label>


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/9249
- in `{{gh-cm-editor}}` display a standard textarea in place of the CodeMirror editor whilst CodeMirror assets are loading in the background, textarea will be upgraded to a CodeMirror editor when loading finishes
- update styles so that the switch from plain textarea to CodeMirror is not too jarring

![code-injection-loading](https://user-images.githubusercontent.com/415/34494722-aecfecf4-efe9-11e7-922f-28252ebba605.gif)
