### PR TITLE
🐛 Fixed non-existent error message for unexpected errors during import

### DIFF
--- a/app/controllers/settings/labs.js
+++ b/app/controllers/settings/labs.js
@@ -171,11 +171,11 @@ export default Controller.extend({
                 });
             }).catch((response) => {
                 if (isUnsupportedMediaTypeError(response) || isRequestEntityTooLargeError(response)) {
-                    return this.set('importErrors', [response]);
-                }
-
-                if (response && response.payload.errors && isEmberArray(response.payload.errors)) {
-                    return this.set('importErrors', response.payload.errors);
+                    this.set('importErrors', [response]);
+                } else if (response && response.payload.errors && isEmberArray(response.payload.errors)) {
+                    this.set('importErrors', response.payload.errors);
+                } else {
+                    this.set('importErrors', [{message: 'Import failed due to an unknown error. Check the Web Inspector console and network tabs for errors.'}]);
                 }
 
                 throw response;


### PR DESCRIPTION
no issue
- show an error message when a non-Ghost error is received, eg. when a proxy server times out due to a large import

<img width="788" alt="screen shot 2018-01-03 at 12 10 37" src="https://user-images.githubusercontent.com/415/34520186-81c1aa4a-f07f-11e7-84e8-f10312cd9e9f.png">
