### PR TITLE
Skip tests that touch vertical-collection to fix random Travis failures

### DIFF
--- a/tests/acceptance/settings/tags-test.js
+++ b/tests/acceptance/settings/tags-test.js
@@ -212,7 +212,10 @@ describe('Acceptance: Settings - Tags', function () {
                 .to.equal(2);
         });
 
-        it('loads tag via slug when accessed directly', async function () {
+        // TODO: Unskip and fix
+        // skipped because it was failing most of the time on Travis
+        // see https://github.com/TryGhost/Ghost/issues/8805
+        it.skip('loads tag via slug when accessed directly', async function () {
             server.createList('tag', 2);
 
             await visit('/settings/tags/tag-1');

--- a/tests/integration/components/gh-psm-tags-input-test.js
+++ b/tests/integration/components/gh-psm-tags-input-test.js
@@ -25,7 +25,10 @@ const assignPostWithTags = function postWithTags(context, ...slugs) {
     });
 };
 
-describe('Integration: Component: gh-psm-tags-input', function() {
+// TODO: Unskip and fix
+// skipped because it was failing most of the time on Travis
+// see https://github.com/TryGhost/Ghost/issues/8805
+describe.skip('Integration: Component: gh-psm-tags-input', function() {
     setupComponentTest('gh-psm-tags-input', {
         integration: true
     });


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/8805
- `{{vertical-collection}}` causes async issues and random failures in our tests
- we can't upgrade to the latest version which includes a test wait helper because it's buggy in Firefox
- skip the tests for now
