### PR TITLE
Fixed Japanese IME popup position

### DIFF
--- a/app/styles/layouts/editor.css
+++ b/app/styles/layouts/editor.css
@@ -482,6 +482,13 @@
     background: transparent;
 }
 
+.gh-editor .CodeMirror-wrap > div > textarea {
+    top: 0;
+    height: 26px;
+    min-height: 26px;
+    margin-bottom: -26px;
+}
+
 .gh-editor .CodeMirror pre {
     padding: 0;
     color: color(var(--darkgrey) l(+5%));


### PR DESCRIPTION
closes TryGhost/Ghost#9289
- add css to fix hidden textarea position

## found bug
Japanese IME popup position.
<img width="516" alt="34098096-9f24a208-e41e-11e7-859e-9ca2b51e082e" src="https://user-images.githubusercontent.com/1601198/34559199-4d72a838-f184-11e7-9749-bebcf2ab15f1.png">

hidden textarea size and position.
<img width="739" alt="34098036-70c695d8-e41e-11e7-8ac3-97683cf998b7" src="https://user-images.githubusercontent.com/1601198/34559225-6bf77d2e-f184-11e7-9fde-e9919d969cf0.png">

## fix version
Japanese IME popup position.
<img width="441" alt="2018-01-04 19 22 37" src="https://user-images.githubusercontent.com/1601198/34559331-c735caa6-f184-11e7-894b-f2ae38ac0e93.png">

hidden textarea size and position.
<img width="343" alt="2018-01-04 19 23 01" src="https://user-images.githubusercontent.com/1601198/34559348-d62f2b88-f184-11e7-9cfe-1b5499cbdcdc.png">


Please include a description of your change & check your PR against this list, thanks!
- [x] Commit message has a short title & issue references
- [x] Commits are squashed 
- [x] The build will pass (run `ember test` from the repo root - will be `core/client` if working from the submodule in Ghost).
