### PR TITLE
🐛 Fixed navigation url inputs when configured URL has special characters

### DIFF
--- a/tests/acceptance/settings/design-test.js
+++ b/tests/acceptance/settings/design-test.js
@@ -157,7 +157,7 @@ describe('Acceptance: Settings - Design', function () {
 
             expect(
                 find('.gh-blognav-url:last input').val()
-            ).to.equal(`${window.location.protocol}//${window.location.host}/new/`);
+            ).to.equal(`${window.location.protocol}//${window.location.host}/new`);
 
             await click('.gh-blognav-add');
 

--- a/tests/integration/components/gh-navitem-url-input-test.js
+++ b/tests/integration/components/gh-navitem-url-input-test.js
@@ -187,6 +187,26 @@ describe('Integration: Component: gh-navitem-url-input', function () {
         expect($input.val()).to.equal(`${currentUrl} /test`);
     });
 
+    // https://github.com/TryGhost/Ghost/issues/9373
+    it('doesn\'t mangle urls when baseUrl has unicode characters', function () {
+        this.on('updateUrl', () => {
+            return null;
+        });
+
+        this.set('baseUrl', 'http://exämple.com');
+
+        this.render(hbs`
+            {{gh-navitem-url-input baseUrl=baseUrl url=url isNew=isNew update=(action "updateUrl") clearErrors=(action "clearErrors")}}
+        `);
+        let $input = this.$('input');
+
+        run(() => {
+            $input.val(`${currentUrl}/test`).trigger('input').trigger('blur');
+        });
+
+        expect($input.val()).to.equal(`${currentUrl}/test`);
+    });
+
     it('triggers "update" action on blur', function () {
         let changeActionCallCount = 0;
         this.on('updateUrl', () => {


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/9373
- using an `<a>` element to parse a URL does not behave as expected when the URL has special characters because the `host` attribute will show the Puny URL version. Eg. `exämple.com` will become `xn--exmple-cua.com`
- `{{gh-navitem-url-input}}` was failing to manipulate the URL value because of the difference between the Puny URL encoded URL and the raw configured URL with unicode chars
- uses the `URI` module that's bundled with the imported version of `google-caja` to parse the URL via regexes rather than relying on native browser parsing