### PR TITLE
⭐️  Improved delete user confirm dialog

### DIFF
--- a/app/styles/components/modals.css
+++ b/app/styles/components/modals.css
@@ -105,7 +105,7 @@
 
 .modal-header {
     position: relative;
-    margin-bottom: 18px;
+    margin-bottom: 22px;
 }
 
 .modal-header h1 {

--- a/app/templates/components/modal-delete-user.hbs
+++ b/app/templates/components/modal-delete-user.hbs
@@ -5,13 +5,26 @@
 
 <div class="modal-body">
     {{#if user.count.posts}}
-        <strong>WARNING:</strong> <span class="red">This user is the author of {{pluralize user.count.posts 'post'}}.</span> All posts and user data will be deleted. There is no way to recover this.
+        <p><strong>WARNING:</strong> There is no way to recover this.</p>
+        <ul>
+            <li>User will not have access to this blog anymore</li>
+            <li>{{pluralize user.count.posts 'post'}} created by this user will be deleted</li>
+            <li>All other user data will be deleted</li>
+        </ul>
     {{else}}
-        <strong>WARNING:</strong> All user data will be deleted. There is no way to recover this.
+        <p><strong>WARNING:</strong> There is no way to recover this.</p>
+        <ul>
+            <li>User will not have access to this blog anymore</li>
+            <li>All user data will be deleted.</li>
+        </ul>
     {{/if}}
 </div>
 
 <div class="modal-footer">
     <button {{action "closeModal"}} class="gh-btn"><span>Cancel</span></button>
-    {{gh-task-button "Delete" successText="Deleted" task=deleteUser class="gh-btn gh-btn-red gh-btn-icon"}}
+    {{#if user.count.posts}}
+        {{gh-task-button "Delete user and posts" successText="Deleted" task=deleteUser class="gh-btn gh-btn-red gh-btn-icon"}}
+    {{else}}
+        {{gh-task-button "Delete user" successText="Deleted" task=deleteUser class="gh-btn gh-btn-red gh-btn-icon"}}
+    {{/if}}
 </div>

--- a/app/templates/components/modal-delete-user.hbs
+++ b/app/templates/components/modal-delete-user.hbs
@@ -5,10 +5,10 @@
 
 <div class="modal-body">
     {{#if user.count.posts}}
-        <p><strong>WARNING:</strong> There is no way to recover this.</p>
+        <p><strong>WARNING:</strong>  You are about to delete the user '<strong>{{user.name}}</strong>'. There is no way to recover this data.</p>
         <ul>
-            <li>User will not have access to this blog anymore</li>
-            <li>{{pluralize user.count.posts 'post'}} created by this user will be deleted</li>
+            <li>The user will not have access to this blog anymore</li>
+            <li><strong>{{pluralize user.count.posts 'post'}}</strong> created by this user will be deleted</li>
             <li>All other user data will be deleted</li>
         </ul>
     {{else}}
@@ -23,7 +23,7 @@
 <div class="modal-footer">
     <button {{action "closeModal"}} class="gh-btn"><span>Cancel</span></button>
     {{#if user.count.posts}}
-        {{gh-task-button "Delete user and posts" successText="Deleted" task=deleteUser class="gh-btn gh-btn-red gh-btn-icon"}}
+        {{gh-task-button "Delete user and their posts" successText="Deleted" task=deleteUser class="gh-btn gh-btn-red gh-btn-icon"}}
     {{else}}
         {{gh-task-button "Delete user" successText="Deleted" task=deleteUser class="gh-btn gh-btn-red gh-btn-icon"}}
     {{/if}}

--- a/app/templates/components/modal-delete-user.hbs
+++ b/app/templates/components/modal-delete-user.hbs
@@ -4,15 +4,14 @@
 <a class="close" href="" title="Close" {{action "closeModal"}}>{{inline-svg "close"}}<span class="hidden">Close</span></a>
 
 <div class="modal-body">
+    <p><strong>WARNING:</strong> You are about to delete the user '<strong>{{user.name}}</strong>'. There is no way to recover this.</p>
     {{#if user.count.posts}}
-        <p><strong>WARNING:</strong>  You are about to delete the user '<strong>{{user.name}}</strong>'. There is no way to recover this data.</p>
         <ul>
             <li>The user will not have access to this blog anymore</li>
             <li><strong>{{pluralize user.count.posts 'post'}}</strong> created by this user will be deleted</li>
             <li>All other user data will be deleted</li>
         </ul>
     {{else}}
-        <p><strong>WARNING:</strong> There is no way to recover this.</p>
         <ul>
             <li>User will not have access to this blog anymore</li>
             <li>All user data will be deleted.</li>

--- a/tests/acceptance/team-test.js
+++ b/tests/acceptance/team-test.js
@@ -431,7 +431,7 @@ describe('Acceptance: Team', function () {
             await click('button.delete');
             // user has  posts so should warn about post deletion
             expect(
-                find('.fullscreen-modal .modal-content:contains("is the author of 1 post")').length,
+                find('.fullscreen-modal .modal-content:contains("1 post created by this user")').length,
                 'deleting user with posts has post count'
             ).to.equal(1);
 


### PR DESCRIPTION
closes TryGhost/Ghost#9405

Gives the user a clearer message before deleting a user.

User that is also author of posts:
![image](https://user-images.githubusercontent.com/8037602/35220084-9895f2b2-ffa7-11e7-9395-5a053642718b.png)

User that hasn't written any posts:
![image](https://user-images.githubusercontent.com/8037602/35220099-a3673412-ffa7-11e7-8f28-349f59f24b70.png)

---------

Todos:
- [x] change wording in modal
- [x] make it look good (@peterzimon)