### PR TITLE
Correct errors in /settings/general descriptions

### DIFF
--- a/app/templates/settings/general.hbs
+++ b/app/templates/settings/general.hbs
@@ -204,7 +204,7 @@
         <div class="gh-setting">
             <div class="gh-setting-content">
                 <div class="gh-setting-title">Use dated permalinks</div>
-                <div class="gh-setting-desc">Include the date in your post URLs, eg. <strong>blogurl.com/2017/01/post-title/</strong></div>
+                <div class="gh-setting-desc">Include the date in your post URLs, e.g. <strong>blogurl.com/2017/01/01/post-title/</strong></div>
             </div>
             <div class="gh-setting-action">
                 <div class="for-checkbox">
@@ -219,7 +219,7 @@
             <div class="gh-setting-content">
                 <div class="gh-setting-title">Make this site private</div>
                 <div class="gh-setting-desc">
-                    Enable protection with simple shared password, All search engine optimization and social features will be disabled.
+                    Enable protection with simple shared password. All search engine optimization and social features will be disabled.
 
                     {{#if settings.isPrivate}}
                         <span class="avoid-break-out">


### PR DESCRIPTION
Two spelling and grammar fixes, and one technical.

- eg. → e.g.
- /yyyy/mm/slug/ → /yyyy/mm/dd/slug/
- , → .