### PR TITLE
Remove misleading leading slash on tag slug

### DIFF
--- a/app/templates/components/gh-tag.hbs
+++ b/app/templates/components/gh-tag.hbs
@@ -1,7 +1,7 @@
 <div class="settings-tag" id="gh-tag-{{tag.id}}">
     {{#link-to 'settings.tags.tag' tag class="tag-edit-button"}}
         <span class="tag-title">{{tag.name}}</span>
-        <span class="label label-default">/{{tag.slug}}</span>
+        <span class="label label-default">{{tag.slug}}</span>
 
         {{#if tag.isInternal}}
             <span class="label label-blue">internal</span>


### PR DESCRIPTION
I’m a little fuzzy on why it’s there at all, frankly. If it’s supposed
to model the tag’s URL, it’s failing because it lacks the leading
`/tag`. If it’s supposed to be part of supporting tag hierarchies (which
don’t look to be supported at this stage, though `tag.parent` exists?),
then a leading slash has a *little* merit, but is still not necessary—
`foo/bar` works about as well as `/foo/bar`. In all, I reckon it’s best
to remove the leading slash, at the very least until tag hierarchies are
supported.