### PR TITLE
Escape html for error messages

### DIFF
--- a/app/templates/reset.hbs
+++ b/app/templates/reset.hbs
@@ -18,7 +18,7 @@
                 {{gh-task-button "Reset Password" task=resetPassword class="gh-btn gh-btn-blue gh-btn-block gh-btn-icon" type="submit" autoWidth="false"}}
             </form>
 
-            <p class="main-error">{{flowErrors}}</p>
+            <p class="main-error">{{flowErrors}}&nbsp;</p>
         </section>
     </div>
 </div>

--- a/app/templates/reset.hbs
+++ b/app/templates/reset.hbs
@@ -18,7 +18,7 @@
                 {{gh-task-button "Reset Password" task=resetPassword class="gh-btn gh-btn-blue gh-btn-block gh-btn-icon" type="submit" autoWidth="false"}}
             </form>
 
-            <p class="main-error">{{{flowErrors}}}</p>
+            <p class="main-error">{{flowErrors}}</p>
         </section>
     </div>
 </div>

--- a/app/templates/setup/two.hbs
+++ b/app/templates/setup/two.hbs
@@ -92,4 +92,4 @@
     {{/gh-task-button}}
 </form>
 
-<p class="main-error">{{{flowErrors}}}</p>
+<p class="main-error">{{flowErrors}}</p>

--- a/app/templates/setup/two.hbs
+++ b/app/templates/setup/two.hbs
@@ -92,4 +92,4 @@
     {{/gh-task-button}}
 </form>
 
-<p class="main-error">{{flowErrors}}</p>
+<p class="main-error">{{flowErrors}}&nbsp;</p>

--- a/app/templates/signin.hbs
+++ b/app/templates/signin.hbs
@@ -50,7 +50,7 @@
                     tabindex="3"}}
             </form>
 
-            <p class="main-error">{{if flowErrors flowErrors}}</p>
+            <p class="main-error">{{if flowErrors flowErrors}}&nbsp;</p>
         </section>
     </div>
 </div>

--- a/app/templates/signin.hbs
+++ b/app/templates/signin.hbs
@@ -50,7 +50,7 @@
                     tabindex="3"}}
             </form>
 
-            <p class="main-error">{{{if flowErrors flowErrors "&nbsp;"}}}</p>
+            <p class="main-error">{{if flowErrors flowErrors}}</p>
         </section>
     </div>
 </div>

--- a/app/templates/signup.hbs
+++ b/app/templates/signup.hbs
@@ -67,7 +67,7 @@
                 class="gh-btn gh-btn-green gh-btn-lg gh-btn-block gh-btn-icon"
                 tabindex="3"}}
 
-            <p class="main-error">{{if flowErrors flowErrors}}</p>
+            <p class="main-error">{{if flowErrors flowErrors}}&nbsp;</p>
         </section>
     </div>
 

--- a/app/templates/signup.hbs
+++ b/app/templates/signup.hbs
@@ -67,7 +67,7 @@
                 class="gh-btn gh-btn-green gh-btn-lg gh-btn-block gh-btn-icon"
                 tabindex="3"}}
 
-            <p class="main-error">{{{if flowErrors flowErrors "&nbsp;"}}}</p>
+            <p class="main-error">{{if flowErrors flowErrors}}</p>
         </section>
     </div>
 

--- a/tests/acceptance/setup-test.js
+++ b/tests/acceptance/setup-test.js
@@ -226,7 +226,7 @@ describe('Acceptance: Setup', function () {
                 .to.equal(0);
             // we should show an error message
             expect(find('.main-error').text(), 'error text')
-                .to.equal('Access Denied from url: unknown.com. Please use the url configured in config.js.');
+                .to.have.string('Access Denied from url: unknown.com. Please use the url configured in config.js.');
         });
 
         it('handles validation errors in step 3', async function () {


### PR DESCRIPTION
no issue

- if we would like to re-add html in our error messages, we have to differentiate between static messages which can contain html and messages which are dynamic and can contain dynamic input, which should not allow html
- e.g. it is always possible that Ghost receives a message from a third party module, which concats static text with input text
- if we want to show html content from an error, we need to come up with a concept
- for now: no support for html in error messages

I just went through the code base, where `<p class="main-error">` is used. Maybe there are more.

@kevinansfield feel free to push if something is missing.

