### PR TITLE
Color change in theme upload error dialog box.

### DIFF
--- a/app/styles/components/uploader.css
+++ b/app/styles/components/uploader.css
@@ -93,6 +93,7 @@
 .gh-image-uploader .failed {
     margin: 1em 2em;
     font-size: 16px;
+    color: color(var(--midgrey));
 }
 
 /* TODO: remove the gh-image-uploader classes once it's using gh-progrss-bar */


### PR DESCRIPTION
Closes #9476
- added midgrey color to text on upload fail while night mode is on
