### PR TITLE
Fixed -If night-shift is enabled, checkbox has to be clicked three times

### DIFF
--- a/app/services/feature.js
+++ b/app/services/feature.js
@@ -119,7 +119,11 @@ export default Service.extend({
     },
 
     _setAdminTheme(enabled) {
-        let nightShift = enabled || this.get('nightShift');
+        let nightShift = enabled;
+
+        if (typeof nightShift === 'undefined') {
+            nightShift = enabled || this.get('nightShift');
+        }
 
         return this.get('lazyLoader').loadStyle('dark', 'assets/ghost-dark.css', true).then(() => {
             $('link[title=dark]').prop('disabled', !nightShift);


### PR DESCRIPTION
Fixed -If night-shift is enabled, checkbox has to be clicked three times to disable

Closes #9471
- added check for undefined value
- fixed the condition in feature.js _setAdminTheme