### PR TITLE
Multiple authors

### DIFF
--- a/app/adapters/embedded-relation-adapter.js
+++ b/app/adapters/embedded-relation-adapter.js
@@ -115,15 +115,25 @@ export default BaseAdapter.extend({
     getEmbeddedRelations(store, modelName) {
         let model = store.modelFor(modelName);
         let ret = [];
+        let embedded = [];
 
         // Iterate through the model's relationships and build a list
         // of those that need to be pulled in via "include" from the API
-        model.eachRelationship(function (name, meta) {
-            if (meta.kind === 'hasMany'
+        model.eachRelationship((name, meta) => {
+            if (
+                meta.kind === 'hasMany'
                 && Object.prototype.hasOwnProperty.call(meta.options, 'embedded')
-                && meta.options.embedded === 'always') {
+                && meta.options.embedded === 'always'
+            ) {
                 ret.push(name);
+                embedded.push([name, meta.type]);
             }
+        });
+
+        embedded.forEach(([relName, modelName]) => {
+            this.getEmbeddedRelations(store, modelName).forEach((name) => {
+                ret.push(`${relName}.${name}`);
+            });
         });
 
         return ret;

--- a/app/components/gh-posts-list-item.js
+++ b/app/components/gh-posts-list-item.js
@@ -1,13 +1,9 @@
 import $ from 'jquery';
 import Component from '@ember/component';
-import Ember from 'ember';
 import {alias, equal} from '@ember/object/computed';
 import {computed} from '@ember/object';
-import {htmlSafe} from '@ember/string';
 import {isBlank} from '@ember/utils';
 import {inject as service} from '@ember/service';
-
-const {Handlebars} = Ember;
 
 export default Component.extend({
     ghostPaths: service(),
@@ -29,19 +25,10 @@ export default Component.extend({
     isPublished: equal('post.status', 'published'),
     isScheduled: equal('post.status', 'scheduled'),
 
-    authorName: computed('post.author.{name,email}', function () {
-        return this.get('post.author.name') || this.get('post.author.email');
-    }),
+    authorNames: computed('post.authors.[]', function () {
+        let authors = this.get('post.authors');
 
-    authorAvatar: computed('post.author.profileImage', function () {
-        let defaultImage = '/img/user-image.png';
-        return this.get('post.author.profileImage') || `${this.get('ghostPaths.assetRoot')}${defaultImage}`;
-    }),
-
-    authorAvatarBackground: computed('authorAvatar', function () {
-        let authorAvatar = this.get('authorAvatar');
-        let safeUrl = Handlebars.Utils.escapeExpression(authorAvatar);
-        return htmlSafe(`background-image: url(${safeUrl})`);
+        return authors.map(author => author.get('name') || author.get('email')).join(', ');
     }),
 
     // HACK: this is intentionally awful due to time constraints

--- a/app/components/gh-psm-authors-input.js
+++ b/app/components/gh-psm-authors-input.js
@@ -1,0 +1,32 @@
+import Component from '@ember/component';
+import {computed} from '@ember/object';
+import {inject as service} from '@ember/service';
+
+export default Component.extend({
+
+    store: service(),
+
+    // public attrs
+    selectedAuthors: null,
+    tagName: '',
+    triggerId: '',
+
+    // closure actions
+    updateAuthors() {},
+
+    // live-query of all users for author input autocomplete
+    availableAuthors: computed(function () {
+        return this.get('store').filter('user', {limit: 'all'}, () => true);
+    }),
+
+    availableAuthorNames: computed('availableAuthors.@each.name', function () {
+        return this.get('availableAuthors').map(author => author.get('name').toLowerCase());
+    }),
+
+    actions: {
+        updateAuthors(newAuthors) {
+            this.updateAuthors(newAuthors);
+        }
+    }
+
+});

--- a/app/components/gh-publishmenu.js
+++ b/app/components/gh-publishmenu.js
@@ -9,7 +9,9 @@ export default Component.extend({
     clock: service(),
 
     classNames: 'gh-publishmenu',
+    displayState: 'draft',
     post: null,
+    postStatus: 'draft',
     saveTask: null,
     runningText: null,
 
@@ -101,6 +103,28 @@ export default Component.extend({
 
         return buttonText;
     }),
+
+    didReceiveAttrs() {
+        this._super(...arguments);
+
+        // update the displayState based on the post status but only after a
+        // save has finished to avoid swapping the menu prematurely and triggering
+        // calls to `setSaveType` due to the component re-rendering
+        // TODO: we should have a better way of dealing with this where we don't
+        // rely on the side-effect of component rendering calling setSaveType
+        let postStatus = this.get('postStatus');
+        if (postStatus !== this._postStatus) {
+            if (this.get('saveTask.isRunning')) {
+                this.get('saveTask.last').then(() => {
+                    this.set('displayState', postStatus);
+                });
+            } else {
+                this.set('displayState', postStatus);
+            }
+        }
+
+        this._postStatus = this.get('postStatus');
+    },
 
     actions: {
         setSaveType(saveType) {

--- a/app/components/gh-token-input.js
+++ b/app/components/gh-token-input.js
@@ -1,7 +1,7 @@
 /* global key */
 import Component from '@ember/component';
 import Ember from 'ember';
-import {A} from '@ember/array';
+import {A, isArray} from '@ember/array';
 import {
     advanceSelectableOption,
     defaultMatcher,
@@ -21,6 +21,7 @@ const TAB = 9;
 export default Component.extend({
 
     // public attrs
+    allowCreation: true,
     closeOnSelect: false,
     labelField: 'name',
     matcher: defaultMatcher,
@@ -85,6 +86,10 @@ export default Component.extend({
     }),
 
     shouldShowCreateOption(term, options) {
+        if (!this.get('allowCreation')) {
+            return false;
+        }
+
         if (this.get('showCreateWhen')) {
             return this.get('showCreateWhen')(term, options);
         } else {
@@ -137,6 +142,11 @@ export default Component.extend({
         // allow tokens to be created with spaces
         if (keyboardEvent && keyboardEvent.code === 'Space') {
             select.actions.search(`${select.searchText} `);
+            return;
+        }
+
+        // guard against return being pressed when nothing is selected
+        if (!isArray(selection)) {
             return;
         }
 

--- a/app/components/gh-token-input/tag-token.js
+++ b/app/components/gh-token-input/tag-token.js
@@ -7,29 +7,19 @@ export default DraggableObject.extend({
     attributeBindings: ['title'],
     classNames: ['tag-token'],
     classNameBindings: [
-        'primary:tag-token--primary',
         'internal:tag-token--internal'
     ],
 
-    content: readOnly('option'),
-    internal: readOnly('option.isInternal'),
+    internal: readOnly('content.isInternal'),
 
     primary: computed('idx', 'internal', function () {
         return !this.get('internal') && this.get('idx') === 0;
     }),
 
-    title: computed('option.name', 'primary', 'internal', function () {
-        let name = this.get('option.name');
-
+    title: computed('internal', function () {
         if (this.get('internal')) {
-            return `${name} (internal)`;
+            return `Internal tag`;
         }
-
-        if (this.get('primary')) {
-            return `${name} (primary tag)`;
-        }
-
-        return name;
     })
 
 });

--- a/app/components/gh-token-input/trigger.js
+++ b/app/components/gh-token-input/trigger.js
@@ -7,6 +7,10 @@ import {isBlank} from '@ember/utils';
 export default EmberPowerSelectMultipleTrigger.extend({
 
     actions: {
+        chooseOption(option) {
+            this.get('select').actions.choose(option);
+        },
+
         handleOptionMouseDown(event) {
             let action = this.get('extra.optionMouseDown');
             if (action) {

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -77,7 +77,6 @@ export default Model.extend(Comparable, ValidationEngine, {
 
     validationType: 'post',
 
-    authorId: attr('string'),
     createdAtUTC: attr('moment-utc'),
     customExcerpt: attr('string'),
     featured: attr('boolean', {defaultValue: false}),
@@ -107,12 +106,19 @@ export default Model.extend(Comparable, ValidationEngine, {
     url: attr('string'),
     uuid: attr('string'),
 
-    author: belongsTo('user', {async: true}),
+    authors: hasMany('user', {
+        embedded: 'always',
+        async: false
+    }),
     createdBy: belongsTo('user', {async: true}),
     publishedBy: belongsTo('user', {async: true}),
     tags: hasMany('tag', {
         embedded: 'always',
         async: false
+    }),
+
+    primaryAuthor: computed('authors.[]', function () {
+        return this.get('authors.firstObject');
     }),
 
     init() {
@@ -282,7 +288,7 @@ export default Model.extend(Comparable, ValidationEngine, {
     },
 
     isAuthoredByUser(user) {
-        return user.get('id') === this.get('authorId');
+        return this.get('authors').includes(user);
     },
 
     // a custom sort function is needed in order to sort the posts list the same way the server would:

--- a/app/routes/editor/new.js
+++ b/app/routes/editor/new.js
@@ -3,7 +3,7 @@ import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 export default AuthenticatedRoute.extend({
     model() {
         return this.get('session.user').then(user => (
-            this.store.createRecord('post', {author: user})
+            this.store.createRecord('post', {authors: [user]})
         ));
     },
 

--- a/app/serializers/post.js
+++ b/app/serializers/post.js
@@ -6,21 +6,11 @@ import {pluralize} from 'ember-inflector';
 export default ApplicationSerializer.extend(EmbeddedRecordsMixin, {
     // settings for the EmbeddedRecordsMixin.
     attrs: {
+        authors: {embedded: 'always'},
         tags: {embedded: 'always'},
         publishedAtUTC: {key: 'published_at'},
         createdAtUTC: {key: 'created_at'},
         updatedAtUTC: {key: 'updated_at'}
-    },
-
-    normalize(model, hash, prop) {
-        // this is to enable us to still access the raw authorId
-        // without requiring an extra get request (since it is an
-        // async relationship).
-        if ((prop === 'post' || prop === 'posts') && hash.author !== undefined) {
-            hash.author_id = hash.author;
-        }
-
-        return this._super(...arguments);
     },
 
     normalizeSingleResponse(store, primaryModelClass, payload) {
@@ -62,6 +52,8 @@ export default ApplicationSerializer.extend(EmbeddedRecordsMixin, {
         delete data.author_id;
         // Read-only virtual property.
         delete data.url;
+        // Deprecated property (replaced with data.authors)
+        delete data.author;
 
         hash[root] = [data];
     }

--- a/app/styles/components/power-select.css
+++ b/app/styles/components/power-select.css
@@ -165,11 +165,26 @@
 
 .ember-power-select-multiple-option {
     margin: 2px;
-    padding: 2px 4px;
+    padding: 2px 6px;
+    border: 1px solid #3fb0ef;
     border-radius: 3px;
-    border: 0;
-    background: #3eb0ef;
+    font-size: 0.93em;
     color: white;
+    background: #3fb0ef;
+}
+
+.ember-power-select-multiple-remove-btn:not(:hover) {
+    opacity: 0.75;
+}
+
+.ember-power-select-multiple-remove-btn svg {
+    width: 0.6em;
+    height: auto;
+}
+
+.ember-power-select-multiple-remove-btn svg path {
+    stroke: white;
+    fill: white;
 }
 
 .ember-power-select-trigger-multiple-input {
@@ -187,6 +202,13 @@
 }
 
 /* Tag input */
-.tag-token--primary {
-    background: color(#3eb0ef lightness(-20%));
+
+.tag-token--internal {
+    background: #ebf7fd;
+    color: #3fb0ef;
+}
+
+.tag-token--internal svg path {
+    stroke: #3fb0ef;
+    fill: #3fb0ef;
 }

--- a/app/styles/patterns/forms.css
+++ b/app/styles/patterns/forms.css
@@ -148,6 +148,7 @@ select {
 
 .gh-input.error,
 .error .gh-input,
+.error .ember-power-select-multiple-trigger,
 .gh-select.error,
 select.error {
     border-color: var(--red);

--- a/app/templates/components/gh-post-settings-menu.hbs
+++ b/app/templates/components/gh-post-settings-menu.hbs
@@ -88,24 +88,11 @@
                 {{/gh-form-group}}
 
                 {{#unless session.user.isAuthorOrContributor}}
-                <div class="form-group for-select">
-                    <label for="author-list">Author</label>
-                    <span class="gh-input-icon gh-icon-user">
-                        {{svg-jar "user-circle"}}
-                        <span class="gh-select" tabindex="0">
-                        {{one-way-select
-                            selectedAuthor
-                            id="author-list"
-                            name="post-setting-author"
-                            options=authors
-                            optionValuePath="id"
-                            optionLabelPath="name"
-                            update=(action "changeAuthor")
-                        }}
-                        {{svg-jar "arrow-down-small"}}
-                        </span>
-                    </span>
-                </div>
+                    {{#gh-form-group class="for-select" errors=post.errors hasValidated=post.hasValidated property="authors" data-test-input="authors"}}
+                        <label for="author-list">Authors</label>
+                        {{gh-psm-authors-input selectedAuthors=post.authors updateAuthors=(action "changeAuthors") triggerId="author-list"}}
+                        {{gh-error-message errors=post.errors property="authors" data-test-error="authors"}}
+                    {{/gh-form-group}}
                 {{/unless}}
 
                 <ul class="nav-list nav-list-block">

--- a/app/templates/components/gh-posts-list-item.hbs
+++ b/app/templates/components/gh-posts-list-item.hbs
@@ -22,7 +22,7 @@
         <span class="gh-content-status-published">Published</span>
     {{/if}}
 
-    by <span class="gh-content-entry-author">{{authorName}}</span> &mdash;
+    by <span class="gh-content-entry-author">{{authorNames}}</span> &mdash;
 
     {{#if isPublished}}
         {{gh-format-post-time post.publishedAtUTC published=true}}

--- a/app/templates/components/gh-psm-authors-input.hbs
+++ b/app/templates/components/gh-psm-authors-input.hbs
@@ -1,0 +1,8 @@
+{{gh-token-input
+    options=availableAuthors
+    selected=selectedAuthors
+    onchange=(action "updateAuthors")
+    allowCreation=false
+    renderInPlace=true
+    triggerId=triggerId
+}}

--- a/app/templates/components/gh-publishmenu.hbs
+++ b/app/templates/components/gh-publishmenu.hbs
@@ -4,12 +4,12 @@
     {{/dd.trigger}}
 
     {{#dd.content class="gh-publishmenu-dropdown"}}
-        {{#if (eq postState "published")}}
+        {{#if (eq displayState "published")}}
         {{gh-publishmenu-published
             saveType=saveType
             setSaveType=(action "setSaveType")}}
 
-        {{else if (eq postState "scheduled")}}
+        {{else if (eq displayState "scheduled")}}
         {{gh-publishmenu-scheduled
             post=post
             saveType=saveType

--- a/app/templates/components/gh-token-input/trigger.hbs
+++ b/app/templates/components/gh-token-input/trigger.hbs
@@ -7,11 +7,11 @@
     sortEndAction=(action "reorderItems")
 }}
     {{#each select.selected as |opt idx|}}
-        {{#component (or extra.tokenComponent draggable-object)
+        {{#component (or extra.tokenComponent "draggable-object")
             tagName="li"
             class="ember-power-select-multiple-option"
             select=select
-            option=(readonly opt)
+            content=(readonly opt)
             idx=idx
             isSortable=true
             mouseDown=(action "handleOptionMouseDown")
@@ -26,8 +26,10 @@
                 <span role="button"
                     aria-label="remove element"
                     class="ember-power-select-multiple-remove-btn"
-                    data-selected-index={{idx}}>
-                    &times;
+                    data-selected-index={{idx}}
+                    onmousedown={{action "chooseOption" opt}}
+                >
+                    {{svg-jar "close" data-selected-index=idx}}
                 </span>
             {{/unless}}
         {{/component}}

--- a/app/templates/editor.hbs
+++ b/app/templates/editor.hbs
@@ -28,6 +28,7 @@
                     {{else}}
                         {{gh-publishmenu
                             post=post
+                            postStatus=post.status
                             saveTask=save
                             setSaveType=(action "setSaveType")
                             onOpen=(action "cancelAutosave")}}

--- a/app/validators/post.js
+++ b/app/validators/post.js
@@ -6,6 +6,7 @@ import {isBlank, isEmpty, isPresent} from '@ember/utils';
 export default BaseValidator.create({
     properties: [
         'title',
+        'authors',
         'customExcerpt',
         'codeinjectionHead',
         'codeinjectionFoot',
@@ -29,6 +30,15 @@ export default BaseValidator.create({
 
         if (!validator.isLength(title || '', 0, 255)) {
             model.get('errors').add('title', 'Title cannot be longer than 255 characters.');
+            this.invalidate();
+        }
+    },
+
+    authors(model) {
+        let authors = model.get('authors');
+
+        if (isEmpty(authors)) {
+            model.get('errors').add('authors', 'At least one author is required.');
             this.invalidate();
         }
     },

--- a/mirage/config/posts.js
+++ b/mirage/config/posts.js
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import {Response} from 'ember-cli-mirage';
 import {dasherize} from '@ember/string';
 import {isBlank} from '@ember/utils';
@@ -73,6 +74,8 @@ export default function mockPosts(server) {
         });
 
         attrs.authors = authors;
+
+        attrs.updatedAt = moment.utc().toDate();
 
         return post.update(attrs);
     });

--- a/mirage/config/users.js
+++ b/mirage/config/users.js
@@ -1,5 +1,5 @@
 import {Response} from 'ember-cli-mirage';
-import {paginateModelArray} from '../utils';
+import {paginateModelCollection} from '../utils';
 
 export default function mockUsers(server) {
     // /users/me = Always return the user with ID=1
@@ -20,7 +20,7 @@ export default function mockUsers(server) {
 
         // NOTE: this is naive and only set up to work with queries that are
         // actually used - if you use a different filter in the app, add it here!
-        let {models} = users.where(function (user) {
+        let collection = users.where(function (user) {
             let statusMatch = true;
 
             if (queryParams.filter === 'status:-inactive') {
@@ -34,7 +34,7 @@ export default function mockUsers(server) {
             return statusMatch;
         });
 
-        return paginateModelArray('users', models, page, queryParams.limit);
+        return paginateModelCollection('users', collection, page, queryParams.limit);
     });
 
     server.get('/users/slug/:slug/', function ({users}, {params, queryParams}) {

--- a/mirage/factories/post.js
+++ b/mirage/factories/post.js
@@ -1,4 +1,5 @@
 import {Factory, faker} from 'ember-cli-mirage';
+import {isEmpty} from '@ember/utils';
 
 export default Factory.extend({
     codeinjectionFoot: null,
@@ -21,14 +22,29 @@ export default Factory.extend({
     plaintext(i) { return `Plaintext for post ${i}.`; },
     publishedAt: '2015-12-19T16:25:07.000Z',
     publishedBy: 1,
-    slug(i) { return `post-${i}`; },
     status(i) { return faker.list.cycle('draft', 'published', 'scheduled')(i); },
-    tags() { return []; },
     title(i) { return `Post ${i}`; },
     twitterDescription: null,
     twitterImage: null,
     twitterTitle: null,
     updatedAt: '2015-10-19T16:25:07.756Z',
     updatedBy: 1,
-    uuid(i) { return `post-${i}`; }
+    uuid(i) { return `post-${i}`; },
+
+    authors() { return []; },
+    tags() { return []; },
+
+    afterCreate(post, server) {
+        if (isEmpty(post.authors)) {
+            let user = server.schema.users.find(1);
+
+            if (!user) {
+                let role = server.schema.roles.find({name: 'Administrator'}) || server.create('role', {name: 'Administrator'});
+                user = server.create('user', {roles: [role]});
+            }
+
+            post.authors = [user];
+            post.save();
+        }
+    }
 });

--- a/mirage/factories/user.js
+++ b/mirage/factories/user.js
@@ -19,6 +19,7 @@ export default Factory.extend({
     updatedAt: '2015-11-02T16:12:05.000Z',
     updatedBy: '1',
     website: 'http://example.com',
+
     posts() { return []; },
     roles() { return []; }
 });

--- a/mirage/models/post.js
+++ b/mirage/models/post.js
@@ -1,6 +1,6 @@
-import {Model, belongsTo, hasMany} from 'ember-cli-mirage';
+import {Model, hasMany} from 'ember-cli-mirage';
 
 export default Model.extend({
-    author: belongsTo('user'),
-    tags: hasMany()
+    tags: hasMany(),
+    authors: hasMany('user')
 });

--- a/mirage/models/user.js
+++ b/mirage/models/user.js
@@ -6,5 +6,5 @@ export default Model.extend({
     postCount: false,
 
     roles: hasMany(),
-    posts: hasMany('post', {inverse: 'author'})
+    posts: hasMany()
 });

--- a/mirage/serializers/post.js
+++ b/mirage/serializers/post.js
@@ -1,28 +1,19 @@
 import BaseSerializer from './application';
-import {RestSerializer} from 'ember-cli-mirage';
 
 export default BaseSerializer.extend({
     embed: true,
 
     include(request) {
+        let includes = [];
+
         if (request.queryParams.include && request.queryParams.include.indexOf('tags') >= 0) {
-            return ['tags'];
+            includes.push('tags');
         }
 
-        return [];
-    },
-
-    serialize(object, request) {
-        if (this.isCollection(object)) {
-            return BaseSerializer.prototype.serialize.apply(this, arguments);
+        if (request.queryParams.include && request.queryParams.include.indexOf('authors') >= 0) {
+            includes.push('authors');
         }
 
-        let {post} = RestSerializer.prototype.serialize.call(this, object, request);
-
-        if (object.author) {
-            post.author = object.author.id;
-        }
-
-        return {posts: [post]};
+        return includes;
     }
 });

--- a/mirage/serializers/user.js
+++ b/mirage/serializers/user.js
@@ -14,7 +14,7 @@ export default BaseSerializer.extend({
 
     serialize(object, request) {
         if (this.isCollection(object)) {
-            return BaseSerializer.prototype.serialize.apply(this, arguments);
+            return BaseSerializer.prototype.serialize.call(this, object, request);
         }
 
         let {user} = RestSerializer.prototype.serialize.call(this, object, request);

--- a/mirage/utils.js
+++ b/mirage/utils.js
@@ -5,13 +5,13 @@ export function paginatedResponse(modelName) {
     return function (schema, request) {
         let page = +request.queryParams.page || 1;
         let limit = +request.queryParams.limit || 15;
-        let allModels = this.serialize(schema[modelName].all())[modelName];
+        let collection = schema[modelName].all();
 
-        return paginateModelArray(modelName, allModels, page, limit);
+        return paginateModelCollection(modelName, collection, page, limit);
     };
 }
 
-export function paginateModelArray(modelName, allModels, page, limit) {
+export function paginateModelCollection(modelName, collection, page, limit) {
     let pages, next, prev, models;
 
     if (limit === 'all') {
@@ -22,31 +22,34 @@ export function paginateModelArray(modelName, allModels, page, limit) {
         let start = (page - 1) * limit;
         let end = start + limit;
 
-        pages = Math.ceil(allModels.length / limit);
-        models = allModels.slice(start, end);
+        pages = Math.ceil(collection.models.length / limit);
+        models = collection.models.slice(start, end);
 
         if (start > 0) {
             prev = page - 1;
         }
 
-        if (end < allModels.length) {
+        if (end < collection.models.length) {
             next = page + 1;
         }
     }
 
-    return {
-        meta: {
-            pagination: {
-                page,
-                limit,
-                pages,
-                total: allModels.length,
-                next: next || null,
-                prev: prev || null
-            }
-        },
-        [modelName]: models || allModels
+    collection.meta = {
+        pagination: {
+            page,
+            limit,
+            pages,
+            total: collection.models.length,
+            next: next || null,
+            prev: prev || null
+        }
     };
+
+    if (models) {
+        collection.models = models;
+    }
+
+    return collection;
 }
 
 export function maintenanceResponse() {

--- a/tests/acceptance/content-test.js
+++ b/tests/acceptance/content-test.js
@@ -35,11 +35,11 @@ describe('Acceptance: Content', function () {
             let editorRole = server.create('role', {name: 'Editor'});
             editor = server.create('user', {roles: [editorRole]});
 
-            publishedPost = server.create('post', {author: admin, status: 'published', title: 'Published Post'});
-            scheduledPost = server.create('post', {author: admin, status: 'scheduled', title: 'Scheduled Post'});
-            draftPost = server.create('post', {author: admin, status: 'draft', title: 'Draft Post'});
-            publishedPage = server.create('post', {author: admin, status: 'published', page: true, title: 'Published Page'});
-            authorPost = server.create('post', {author: editor, status: 'published', title: 'Editor Published Post'});
+            publishedPost = server.create('post', {authors: [admin], status: 'published', title: 'Published Post'});
+            scheduledPost = server.create('post', {authors: [admin], status: 'scheduled', title: 'Scheduled Post'});
+            draftPost = server.create('post', {authors: [admin], status: 'draft', title: 'Draft Post'});
+            publishedPage = server.create('post', {authors: [admin], status: 'published', page: true, title: 'Published Page'});
+            authorPost = server.create('post', {authors: [editor], status: 'published', title: 'Editor Published Post'});
 
             return authenticateSession(application);
         });
@@ -138,8 +138,8 @@ describe('Acceptance: Content', function () {
             let admin = server.create('user', {roles: [adminRole]});
 
             // create posts
-            authorPost = server.create('post', {authorId: author.id, status: 'published', title: 'Author Post'});
-            server.create('post', {authorId: admin.id, status: 'scheduled', title: 'Admin Post'});
+            authorPost = server.create('post', {authors: [author], status: 'published', title: 'Author Post'});
+            server.create('post', {authors: [admin], status: 'scheduled', title: 'Admin Post'});
 
             return authenticateSession(application);
         });
@@ -169,9 +169,9 @@ describe('Acceptance: Content', function () {
             let admin = server.create('user', {roles: [adminRole]});
 
             // Create posts
-            contributorPost = server.create('post', {authorId: contributor.id, status: 'draft', title: 'Contributor Post Draft'});
-            server.create('post', {authorId: contributor.id, status: 'published', title: 'Contributor Published Post'});
-            server.create('post', {authorId: admin.id, status: 'scheduled', title: 'Admin Post'});
+            contributorPost = server.create('post', {authors: [contributor], status: 'draft', title: 'Contributor Post Draft'});
+            server.create('post', {authors: [contributor], status: 'published', title: 'Contributor Published Post'});
+            server.create('post', {authors: [admin], status: 'scheduled', title: 'Admin Post'});
 
             return authenticateSession(application);
         });

--- a/tests/acceptance/editor-test.js
+++ b/tests/acceptance/editor-test.js
@@ -434,7 +434,7 @@ describe('Acceptance: Editor', function () {
                 });
             });
 
-            let post = server.create('post', 1, {authors: [author]});
+            let post = server.create('post', 1, {authors: [author], status: 'draft'});
             let plusTenMin = moment().utc().add(10, 'minutes');
 
             await visit(`/editor/${post.id}`);
@@ -444,6 +444,7 @@ describe('Acceptance: Editor', function () {
             await datepickerSelect('[data-test-publishmenu-draft] [data-test-date-time-picker-datepicker]', plusTenMin);
             await fillIn('[data-test-publishmenu-draft] [data-test-date-time-picker-time-input]', plusTenMin.format('HH:mm'));
             await triggerEvent('[data-test-publishmenu-draft] [data-test-date-time-picker-time-input]', 'blur');
+
             await click('[data-test-publishmenu-save]');
 
             expect(

--- a/tests/acceptance/team-test.js
+++ b/tests/acceptance/team-test.js
@@ -409,7 +409,12 @@ describe('Acceptance: Team', function () {
         it('can delete users', async function () {
             let user1 = server.create('user');
             let user2 = server.create('user');
-            server.create('post', {author: user2});
+            let post = server.create('post', {authors: [user2]});
+
+            // we don't have a full many-to-many relationship in mirage so we
+            // need to add the inverse manually
+            user2.posts = [post];
+            user2.save();
 
             await visit('/team');
             await click(`[data-test-user-id="${user1.id}"]`);

--- a/tests/unit/models/post-test.js
+++ b/tests/unit/models/post-test.js
@@ -1,4 +1,3 @@
-import EmberObject from '@ember/object';
 import {describe, it} from 'mocha';
 import {run} from '@ember/runloop';
 import {setupModelTest} from 'ember-mocha';
@@ -54,17 +53,19 @@ describe('Unit: Model: post', function () {
     });
 
     it('isAuthoredByUser is correct', function () {
-        let model = this.subject({
-            authorId: 'abcd1234'
-        });
-        let user = EmberObject.create({id: 'abcd1234'});
+        let user1 = this.store().createRecord('user', {id: 'abcd1234'});
+        let user2 = this.store().createRecord('user', {id: 'wxyz9876'});
 
-        expect(model.isAuthoredByUser(user)).to.be.ok;
+        let model = this.subject({
+            authors: [user1]
+        });
+
+        expect(model.isAuthoredByUser(user1)).to.be.ok;
 
         run(function () {
-            model.set('authorId', 'wxyz9876');
+            model.set('authors', [user2]);
 
-            expect(model.isAuthoredByUser(user)).to.not.be.ok;
+            expect(model.isAuthoredByUser(user1)).to.not.be.ok;
         });
     });
 


### PR DESCRIPTION
requires https://github.com/TryGhost/Ghost/pull/9426
- update `embedded-relation-adapter` to fetch deep-nested embedded relationships
- fixed default token component display in {{gh-token-input}}
    - if no `tokenComponent` is passed to `{{gh-token-input}}` then it should default to the ember-drag-drop `draggable-object` component but instead it didn't output anything
    - put `draggable-object` in quotes because `{{component}}` needs a component name rather than an object
    - rename `option` attribute to `content` to match the default `{{draggable-object}}` interface
- add embedded `authors` attr to the Post model
    - ensure authors is populated when starting new post
    - add validation for empty authors list
- swap author dropdown for a token input in PSM
- show all post authors in posts list
- update tests for `post.authors`
  - always provide through an authors array
  - fix mirage serialisation for paginated responses (embedded records were not being serialised)
- unify tags and author inputs design
  - remove highlight of primary tags
  - highlight internal tags
  - remove unnecessary/redundant title attributes on tags
  - use SVG icon for "remove option" button in token inputs

TODO:
- [x] show list of authors on posts list
- [x] ~update permissions to handle multiple authors~ (same as existing perms)
- [x] ensure authors list is populated when creating new post
- [x] handle situation where all authors are removed from the list
- [x] add option to remove "Add x..." option in `{{gh-token-input}}`
- [x] update mirage mocks to use authors list
- [x] tests