### PR TITLE
Bump ember-cli-mirage to 0.4.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,11 +2,9 @@
   "name": "ghost-admin",
   "dependencies": {
     "devicejs": "0.2.7",
-    "Faker": "3.1.0",
     "google-caja": "6005.0.0",
     "keymaster": "1.6.3",
     "normalize.css": "3.0.3",
-    "pretender": "1.1.0",
     "rangyinputs": "1.2.0",
     "validator-js": "3.39.0"
   }

--- a/config/environment.js
+++ b/config/environment.js
@@ -59,6 +59,11 @@ module.exports = function (environment) {
         ENV.APP.LOG_VIEW_LOOKUPS = false;
 
         ENV.APP.rootElement = '#ember-testing';
+
+        // Withuot manually setting this, pretender won't track requests
+        ENV['ember-cli-mirage'] = {
+            trackRequests: true
+        };
     }
 
     return ENV;

--- a/mirage/config/settings.js
+++ b/mirage/config/settings.js
@@ -1,16 +1,10 @@
 export default function mockSettings(server) {
-    // These endpoints use the raw database & fixtures without going
-    // through the ORM at all (meaning no setting model). This is due
-    // to https://github.com/samselikoff/ember-cli-mirage/issues/943
-    // as far as can be determined.
-    // potential TODO: update once the above issue is fixed? We don't really
-    // gain anything from using the ORM for settings so it may not be a good idea
     server.get('/settings/', function ({db}, {queryParams}) {
         let {type} = queryParams;
         let filters = type.split(',');
         let settings = [];
 
-        if (!db.settings) {
+        if (!db.settings.length) {
             server.loadFixtures('settings');
         }
 

--- a/mirage/factories/invite.js
+++ b/mirage/factories/invite.js
@@ -9,6 +9,5 @@ export default Factory.extend({
     createdBy() { return 1; },
     updatedAt() { return moment.utc().format(); },
     updatedBy() { return 1; },
-    status() { return 'sent'; },
-    roleId() { return 1; }
+    status() { return 'sent'; }
 });

--- a/mirage/factories/post.js
+++ b/mirage/factories/post.js
@@ -13,7 +13,6 @@ export default Factory.extend({
     status(i) { return faker.list.cycle('draft', 'published', 'scheduled')(i); },
     metaDescription(i) { return `Meta description for post ${i}.`; },
     metaTitle(i) { return `Meta Title for post ${i}`; },
-    authorId: 1,
     updatedAt: '2015-10-19T16:25:07.756Z',
     updatedBy: 1,
     publishedAt: '2015-12-19T16:25:07.000Z',

--- a/mirage/factories/user.js
+++ b/mirage/factories/user.js
@@ -19,5 +19,6 @@ export default Factory.extend({
     updatedAt: '2015-11-02T16:12:05.000Z',
     updatedBy: '1',
     website: 'http://example.com',
+    posts() { return []; },
     roles() { return []; }
 });

--- a/mirage/fixtures/roles.js
+++ b/mirage/fixtures/roles.js
@@ -35,5 +35,14 @@ export default [
         created_by: 1,
         updated_at: '2015-11-13T16:01:29.132Z',
         updated_by: 1
+    },
+    {
+        id: 5,
+        name: 'Contributor',
+        description: 'Contributors',
+        created_at: '2015-11-13T16:01:29.132Z',
+        created_by: 1,
+        updated_at: '2015-11-13T16:01:29.132Z',
+        updated_by: 1
     }
 ];

--- a/mirage/models/invite.js
+++ b/mirage/models/invite.js
@@ -1,4 +1,5 @@
-import {Model} from 'ember-cli-mirage';
+import {Model, belongsTo} from 'ember-cli-mirage';
 
 export default Model.extend({
+    role: belongsTo()
 });

--- a/mirage/models/post.js
+++ b/mirage/models/post.js
@@ -1,5 +1,6 @@
-import {Model, belongsTo} from 'ember-cli-mirage';
+import {Model, belongsTo, hasMany} from 'ember-cli-mirage';
 
 export default Model.extend({
-    author: belongsTo('user')
+    author: belongsTo('user'),
+    tags: hasMany()
 });

--- a/mirage/models/tag.js
+++ b/mirage/models/tag.js
@@ -1,4 +1,5 @@
-import {Model} from 'ember-cli-mirage';
+import {Model, hasMany} from 'ember-cli-mirage';
 
 export default Model.extend({
+    posts: hasMany()
 });

--- a/mirage/serializers/post.js
+++ b/mirage/serializers/post.js
@@ -5,8 +5,8 @@ export default BaseSerializer.extend({
     embed: true,
 
     include(request) {
-        if (request.queryParams.include && request.queryParams.include.indexOf('roles') >= 0) {
-            return ['roles'];
+        if (request.queryParams.include && request.queryParams.include.indexOf('tags') >= 0) {
+            return ['tags'];
         }
 
         return [];
@@ -17,14 +17,12 @@ export default BaseSerializer.extend({
             return BaseSerializer.prototype.serialize.apply(this, arguments);
         }
 
-        let {user} = RestSerializer.prototype.serialize.call(this, object, request);
+        let {post} = RestSerializer.prototype.serialize.call(this, object, request);
 
-        if (object.postCount) {
-            let posts = object.posts.models.length;
-
-            user.count = {posts};
+        if (object.author) {
+            post.author = object.author.id;
         }
 
-        return {users: [user]};
+        return {posts: [post]};
     }
 });

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "ember-cli-htmlbars": "2.0.3",
     "ember-cli-htmlbars-inline-precompile": "1.0.2",
     "ember-cli-inject-live-reload": "1.7.0",
-    "ember-cli-mirage": "0.2.8",
+    "ember-cli-mirage": "0.4.2",
     "ember-cli-mocha": "^0.15.0",
     "ember-cli-moment-shim": "3.5.0",
     "ember-cli-node-assets": "0.2.2",

--- a/tests/acceptance/content-test.js
+++ b/tests/acceptance/content-test.js
@@ -35,11 +35,11 @@ describe('Acceptance: Content', function () {
             let editorRole = server.create('role', {name: 'Editor'});
             editor = server.create('user', {roles: [editorRole]});
 
-            publishedPost = server.create('post', {authorId: admin.id, status: 'published', title: 'Published Post'});
-            scheduledPost = server.create('post', {authorId: admin.id, status: 'scheduled', title: 'Scheduled Post'});
-            draftPost = server.create('post', {authorId: admin.id, status: 'draft', title: 'Draft Post'});
-            publishedPage = server.create('post', {authorId: admin.id, status: 'published', page: true, title: 'Published Page'});
-            authorPost = server.create('post', {authorId: editor.id, status: 'published', title: 'Editor Published Post'});
+            publishedPost = server.create('post', {author: admin, status: 'published', title: 'Published Post'});
+            scheduledPost = server.create('post', {author: admin, status: 'scheduled', title: 'Scheduled Post'});
+            draftPost = server.create('post', {author: admin, status: 'draft', title: 'Draft Post'});
+            publishedPage = server.create('post', {author: admin, status: 'published', page: true, title: 'Published Page'});
+            authorPost = server.create('post', {author: editor, status: 'published', title: 'Editor Published Post'});
 
             return authenticateSession(application);
         });

--- a/tests/acceptance/subscribers-test.js
+++ b/tests/acceptance/subscribers-test.js
@@ -69,7 +69,6 @@ describe('Acceptance: Subscribers', function () {
         it('can manage subscribers', async function () {
             server.createList('subscriber', 40);
 
-            authenticateSession(application);
             await visit('/');
             await click('.gh-nav-main a:contains("Subscribers")');
 

--- a/tests/acceptance/team-test.js
+++ b/tests/acceptance/team-test.js
@@ -73,7 +73,7 @@ describe('Acceptance: Team', function () {
             admin = server.create('user', {email: 'admin@example.com', roles: [adminRole]});
 
             // add an expired invite
-            server.create('invite', {expires: moment.utc().subtract(1, 'day').valueOf()});
+            server.create('invite', {expires: moment.utc().subtract(1, 'day').valueOf(), role: adminRole});
 
             // add a suspended user
             suspendedUser = server.create('user', {email: 'suspended@example.com', roles: [adminRole], status: 'inactive'});
@@ -409,9 +409,7 @@ describe('Acceptance: Team', function () {
         it('can delete users', async function () {
             let user1 = server.create('user');
             let user2 = server.create('user');
-            let post = server.create('post');
-
-            user2.posts = [post];
+            server.create('post', {author: user2});
 
             await visit('/team');
             await click(`[data-test-user-id="${user1.id}"]`);
@@ -891,7 +889,7 @@ describe('Acceptance: Team', function () {
 
         it('can access the team page', async function () {
             server.create('user', {roles: [adminRole]});
-            server.create('invite', {roles: [authorRole]});
+            server.create('invite', {role: authorRole});
 
             errorOverride();
 

--- a/tests/integration/components/gh-psm-tags-input-test.js
+++ b/tests/integration/components/gh-psm-tags-input-test.js
@@ -37,12 +37,12 @@ describe.skip('Integration: Component: gh-psm-tags-input', function () {
 
     beforeEach(function () {
         server = startMirage();
-        server.create('user');
+        let author = server.create('user');
 
         mockPosts(server);
         mockTags(server);
 
-        server.create('post');
+        server.create('post', {author});
         server.create('tag', {name: 'Tag One', slug: 'one'});
         server.create('tag', {name: 'Tag Two', slug: 'two'});
         server.create('tag', {name: 'Tag Three', slug: 'three'});

--- a/yarn.lock
+++ b/yarn.lock
@@ -210,6 +210,14 @@ aot-test-generators@^0.1.0:
   dependencies:
     jsesc "^2.5.0"
 
+applause@1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/applause/-/applause-1.2.2.tgz#a8468579e81f67397bb5634c29953bedcd0f56c0"
+  dependencies:
+    cson-parser "^1.1.0"
+    js-yaml "^3.3.0"
+    lodash "^3.10.0"
+
 aproba@^1.0.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
@@ -1561,7 +1569,7 @@ broccoli-middleware@^1.0.0:
     handlebars "^4.0.4"
     mime "^1.2.11"
 
-broccoli-persistent-filter@1.4.3, broccoli-persistent-filter@^1.0.3, broccoli-persistent-filter@^1.1.5, broccoli-persistent-filter@^1.1.6, broccoli-persistent-filter@^1.2.13, broccoli-persistent-filter@^1.4.0, broccoli-persistent-filter@^1.4.2, broccoli-persistent-filter@^1.4.3:
+broccoli-persistent-filter@1.4.3, broccoli-persistent-filter@^1.0.3, broccoli-persistent-filter@^1.1.5, broccoli-persistent-filter@^1.1.6, broccoli-persistent-filter@^1.2.0, broccoli-persistent-filter@^1.2.13, broccoli-persistent-filter@^1.4.0, broccoli-persistent-filter@^1.4.2, broccoli-persistent-filter@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz#3511bc52fc53740cda51621f58a28152d9911bc1"
   dependencies:
@@ -1606,6 +1614,14 @@ broccoli-postcss@3.5.2:
     broccoli-persistent-filter "1.4.3"
     object-assign "4.1.1"
     postcss "6.0.14"
+
+broccoli-replace@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/broccoli-replace/-/broccoli-replace-0.12.0.tgz#36460a984c45c61731638c53068b0ab12ea8fdb7"
+  dependencies:
+    applause "1.2.2"
+    broccoli-persistent-filter "^1.2.0"
+    minimatch "^3.0.0"
 
 broccoli-rollup@^1.0.3, broccoli-rollup@^1.2.0:
   version "1.3.0"
@@ -2169,6 +2185,10 @@ codemirror@5.35.0:
   version "5.35.0"
   resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.35.0.tgz#280653d495455bc66aa87e6284292b02775ba878"
 
+coffee-script@^1.10.0:
+  version "1.12.7"
+  resolved "https://registry.yarnpkg.com/coffee-script/-/coffee-script-1.12.7.tgz#c05dae0cb79591d05b3070a8433a98c9a89ccc53"
+
 coffeescript@~1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/coffeescript/-/coffeescript-1.10.0.tgz#e7aa8301917ef621b35d8a39f348dcdd1db7e33e"
@@ -2534,6 +2554,12 @@ crypto-browserify@^3.0.0:
 crypto-random-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
+
+cson-parser@^1.1.0:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/cson-parser/-/cson-parser-1.3.5.tgz#7ec675e039145533bf2a6a856073f1599d9c2d24"
+  dependencies:
+    coffee-script "^1.10.0"
 
 css-color-function@~1.3.3:
   version "1.3.3"
@@ -3177,22 +3203,24 @@ ember-cli-lodash-subset@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ember-cli-lodash-subset/-/ember-cli-lodash-subset-2.0.1.tgz#20cb68a790fe0fde2488ddfd8efbb7df6fe766f2"
 
-ember-cli-mirage@0.2.8:
-  version "0.2.8"
-  resolved "https://registry.yarnpkg.com/ember-cli-mirage/-/ember-cli-mirage-0.2.8.tgz#878ece5b6fc07c195a0b8edb8e1785a65d346acf"
+ember-cli-mirage@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/ember-cli-mirage/-/ember-cli-mirage-0.4.2.tgz#410a2854baf33c5be27d5cbd5a6b548e243a0fee"
   dependencies:
     broccoli-funnel "^1.0.2"
     broccoli-merge-trees "^1.1.0"
-    broccoli-unwatched-tree "^0.1.1"
+    broccoli-replace "^0.12.0"
+    broccoli-stew "^1.5.0"
     chalk "^1.1.1"
-    ember-cli-babel "^5.1.7"
+    ember-cli-babel "^6.8.2"
     ember-cli-node-assets "^0.1.4"
-    ember-inflector "^1.9.2"
-    ember-lodash "^4.0"
+    ember-get-config "^0.2.2"
+    ember-inflector "^2.0.0"
+    ember-lodash "^4.17.3"
     exists-sync "0.0.3"
     fake-xml-http-request "^1.4.0"
     faker "^3.0.0"
-    pretender "^1.4.2"
+    pretender "^1.6.1"
     route-recognizer "^0.2.3"
 
 ember-cli-mocha@^0.15.0:
@@ -3557,6 +3585,13 @@ ember-get-config@0.2.1:
     broccoli-file-creator "^1.1.1"
     ember-cli-babel "^5.1.6"
 
+ember-get-config@^0.2.2:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/ember-get-config/-/ember-get-config-0.2.4.tgz#118492a2a03d73e46004ed777928942021fe1ecd"
+  dependencies:
+    broccoli-file-creator "^1.1.1"
+    ember-cli-babel "^6.3.0"
+
 "ember-getowner-polyfill@^1.1.0 || ^2.0.0", ember-getowner-polyfill@^2.0.0, ember-getowner-polyfill@^2.0.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz#38e7dccbcac69d5ec694000329ec0b2be651d2b2"
@@ -3598,12 +3633,6 @@ ember-infinity@1.0.0-alpha.9:
   dependencies:
     ember-cli-babel "^6.6.0"
     ember-in-viewport "~3.0.0"
-
-ember-inflector@^1.9.2:
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/ember-inflector/-/ember-inflector-1.12.1.tgz#d8bd2ca2f327b439720f89923fe614d46b5da1ca"
-  dependencies:
-    ember-cli-babel "^5.1.7"
 
 ember-inflector@^2.0.0:
   version "2.1.0"
@@ -3667,7 +3696,7 @@ ember-load@0.0.12:
     ember-cli-htmlbars "^2.0.1"
     ember-cli-version-checker "^2.0.0"
 
-ember-lodash@^4.0:
+ember-lodash@^4.17.3:
   version "4.18.0"
   resolved "https://registry.yarnpkg.com/ember-lodash/-/ember-lodash-4.18.0.tgz#45de700d6a4f68f1cd62888d90b50aa6477b9a83"
   dependencies:
@@ -5787,6 +5816,13 @@ js-yaml@3.x, js-yaml@^3.2.5, js-yaml@^3.2.7, js-yaml@^3.4.3, js-yaml@^3.6.1, js-
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^3.3.0:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.11.0.tgz#597c1a8bd57152f26d622ce4117851a51f5ebaef"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 js-yaml@~3.5.2:
   version "3.5.5"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.5.5.tgz#0377c38017cabc7322b0d1fbcd25a491641f2fbe"
@@ -7739,7 +7775,7 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-pretender@^1.4.2:
+pretender@^1.4.2, pretender@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/pretender/-/pretender-1.6.1.tgz#77d1e42ac8c6b298f5cd43534a87645df035db8c"
   dependencies:


### PR DESCRIPTION
closes TryGhost/Ghost#9433
- remove unnecessary bower deps
- update mirage usage
- fix tests

Took a bit longer than expected, but got this working as far as I can tell, minus some flaky tests. This will likely need a fairly significant update too once the multi-author stuff is merged in.