### PR TITLE
Prevent Firefox Fieldset Scrolling

### DIFF
--- a/app/styles/components/modals.css
+++ b/app/styles/components/modals.css
@@ -119,7 +119,6 @@
 
 .modal-body {
     position: relative;
-    overflow-y: auto;
 }
 
 .modal-body p {

--- a/app/styles/components/modals.css
+++ b/app/styles/components/modals.css
@@ -152,7 +152,7 @@
 /* ---------------------------------------------------------- */
 
 .modal-body fieldset {
-    margin: 0;
+    margin: 1px;
 }
 
 /* Login styles */

--- a/app/styles/components/modals.css
+++ b/app/styles/components/modals.css
@@ -151,6 +151,10 @@
 /* Content Modifiers
 /* ---------------------------------------------------------- */
 
+.modal-body fieldset {
+    margin: 0;
+}
+
 /* Login styles */
 .modal-body .login-form {
     display: block;

--- a/app/styles/components/modals.css
+++ b/app/styles/components/modals.css
@@ -151,10 +151,6 @@
 /* Content Modifiers
 /* ---------------------------------------------------------- */
 
-.modal-body fieldset {
-    margin: 1px;
-}
-
 /* Login styles */
 .modal-body .login-form {
     display: block;

--- a/app/styles/patterns/forms.css
+++ b/app/styles/patterns/forms.css
@@ -15,7 +15,7 @@ form .word-count {
 }
 
 fieldset {
-    margin: 0 0 3em 0;
+    margin: 0 0 0.5em 0;
     padding: 0;
     border: none;
     user-select: text;

--- a/app/styles/patterns/forms.css
+++ b/app/styles/patterns/forms.css
@@ -15,7 +15,7 @@ form .word-count {
 }
 
 fieldset {
-    margin: 0 0 0.5em 0;
+    margin: 0 0 3em 0;
     padding: 0;
     border: none;
     user-select: text;


### PR DESCRIPTION
Super small issue but I noticed when I was using the Ghost Admin in Firefox, when I opened the "Invite Team" modal, a scrollbar would briefly appear and the form would be scrollable by 1px. This PR fixes it so it no longer scrolls.

![screencast-2018-03-18-23-03-11](https://user-images.githubusercontent.com/37122500/37575057-ef21c25a-2b1c-11e8-9d66-70851c38a4df.gif)
