### PR TITLE
Update Invite User Modal

### DIFF
--- a/app/styles/layouts/users.css
+++ b/app/styles/layouts/users.css
@@ -147,7 +147,7 @@
 }
 
 .invite-new-user .form-group {
-    margin-bottom: 0;
+    margin-bottom: 1.6rem;
     padding: 0;
 }
 
@@ -185,10 +185,5 @@
 }
 
 .invite-new-user .form-group input {
-    width: 100%;
-}
-
-.invite-new-user .gh-btn-green {
-    margin: 0;
     width: 100%;
 }

--- a/app/templates/components/modal-invite-new-user.hbs
+++ b/app/templates/components/modal-invite-new-user.hbs
@@ -1,5 +1,5 @@
 <header class="modal-header">
-    <h1>Invite a New User</h1>
+    <h1>Invite a Team Member</h1>
 </header>
 <a class="close" href="" title="Close" {{action "closeModal"}}>{{inline-svg "close"}}<span class="hidden">Close</span></a>
 
@@ -45,5 +45,6 @@
 </div>
 
 <div class="modal-footer">
-    {{gh-task-button "Send invitation now" successText="Sent" task=sendInvitation class="gh-btn gh-btn-green gh-btn-icon"}}
+    <button {{action "closeModal"}} class="gh-btn"><span>Cancel</span></button>
+    {{gh-task-button "Send Invite" successText="Sent" task=sendInvitation class="gh-btn gh-btn-green gh-btn-icon"}}
 </div>


### PR DESCRIPTION
This PR does 4 things to the Add New User modal:

* Updates the title of the Invite User modal to "Invite a Team Member".
* Adds a cancel button
* Removes styling which previously made the "Send" button full width
* Altered wording of send button to "Send Invite"

How the modal looks in this PR:
![screenshot-2018-3-21 team - testing](https://user-images.githubusercontent.com/37122500/37692077-55c7ce68-2cae-11e8-832d-264122170bbf.png)

![screenshot-2018-3-21 team - testing 1](https://user-images.githubusercontent.com/37122500/37692078-58b27088-2cae-11e8-95ad-92cf9eb95d67.png)

This was done so that this modal matches the "Add New Subscriber" modal a bit better.