### PR TITLE
Night Shift Code Injection Styling

### DIFF
--- a/app/styles/app-dark.css
+++ b/app/styles/app-dark.css
@@ -333,3 +333,14 @@ input,
 .CodeMirror .CodeMirror-code .cm-string {
     color: color(#183691 l(+25%));
 }
+
+.settings-code-editor .CodeMirror {
+    background: rgb(51, 63, 68);
+    border-color: rgb(51, 63, 68);
+    color: #e5eff5;
+}
+
+.CodeMirror-gutters {
+    background: #212A2E;
+    border-right-color: rgb(48, 59, 64);
+}


### PR DESCRIPTION
I use Night Shift mode in Ghost Admin which really helps my eyes on every page, other than the Code Injection page, which is still really bright. This PR does nothing fancy, but it just darkens the colours to fit into the mode a bit better. Instead of this:

![screenshot-2018-3-22 settings - code injection - before](https://user-images.githubusercontent.com/37122500/37746128-8c4ef61a-2d70-11e8-9a98-b24b13f7baf4.png)

We now have this:

![screenshot-2018-3-22 settings - code injection - after](https://user-images.githubusercontent.com/37122500/37746127-8c3478c6-2d70-11e8-8732-a76eec1acb37.png)

Like I said, nothing fancy, but it makes that one screen less bright! 😄 