### PR TITLE
Fix invitation modal email validation

### DIFF
--- a/app/components/modal-invite-new-user.js
+++ b/app/components/modal-invite-new-user.js
@@ -4,7 +4,7 @@ import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 import {A as emberA} from '@ember/array';
 import {run} from '@ember/runloop';
 import {inject as service} from '@ember/service';
-import {task} from 'ember-concurrency';
+import {task, timeout} from 'ember-concurrency';
 
 const {Promise} = RSVP;
 
@@ -53,6 +53,11 @@ export default ModalComponent.extend(ValidationEngine, {
 
         confirm() {
             this.get('sendInvitation').perform();
+        },
+
+        setEmail(email) {
+            this.set('email', email);
+            this.get('debounceAndValidate').perform();
         }
     },
 
@@ -90,6 +95,12 @@ export default ModalComponent.extend(ValidationEngine, {
             reject();
         }));
     },
+
+    debounceAndValidate: task(function* () {
+        yield timeout(500);
+
+        yield this.validate();
+    }).restartable(),
 
     sendInvitation: task(function* () {
         let email = this.get('email');

--- a/app/templates/components/modal-invite-new-user.hbs
+++ b/app/templates/components/modal-invite-new-user.hbs
@@ -17,11 +17,10 @@
                 autocapitalize="off"
                 autocorrect="off"
                 value=(readonly email)
-                input=(action (mut email) value="target.value")
+                input=(action 'setEmail' value="target.value")
                 keyEvents=(hash
                     Enter=(action "confirm")
                 )
-                focus-out=(action "validate" "email")
             }}
             {{gh-error-message errors=errors property="email"}}
         {{/gh-form-group}}


### PR DESCRIPTION
The problem with issue https://github.com/TryGhost/Ghost/issues/7131 is that, on clicking submit button the focus out is triggered on the email box and save almost at the same time which, I am not sure how, but somehow prevents the `sendInvitation` action from being called.

So, I have moved the email validation from `focus-out` to on debounced input. This enables the email to be validated before the user can click on the "Invite" button.

Let me know if this is good from a requirements perspective.

Another option I would suggest is disabling the invite button till a "valid email" is entered.