### PR TITLE
Subscribers: Hide Export CSV button if there's no data to export

### DIFF
--- a/app/templates/subscribers.hbs
+++ b/app/templates/subscribers.hbs
@@ -3,7 +3,9 @@
         <h2 class="gh-canvas-title" data-test-screen-title>Subscribers <span style="font-weight:200;margin-left:10px;display:inline-block;" data-test-total-subscribers> ({{total}})</span></h2>
         <div class="view-actions">
             {{#link-to "subscribers.import" class="gh-btn gh-btn-hover-green"}}<span>Import CSV</span>{{/link-to}}
-            <a href="#" {{action 'exportData'}} class="gh-btn gh-btn-hover-blue"><span>Export CSV</span></a>
+            {{#if total}}
+                <a href="#" {{action 'exportData'}} class="gh-btn gh-btn-hover-blue"><span>Export CSV</span></a>
+            {{/if}}
             {{#link-to "subscribers.new" class="gh-btn gh-btn-green"}}<span>Add Subscriber</span>{{/link-to}}
         </div>
     </header>


### PR DESCRIPTION
- made sense to only show the button to export subscriber data if there’s actually subscriber data to export. If the total number of subscribers is above 0, then the button to export them will show as normal.