### PR TITLE
[WIP] Improve unsaved changes modals

### DIFF
--- a/app/components/gh-post-settings-menu.js
+++ b/app/components/gh-post-settings-menu.js
@@ -27,6 +27,10 @@ export default Component.extend(SettingsMenuMixin, {
     _showSettingsMenu: false,
     _showThrobbers: false,
 
+    // closure actions
+    onMenuOpen() {},
+    onMenuClose() {},
+
     customExcerptScratch: alias('post.customExcerptScratch'),
     codeinjectionFootScratch: alias('post.codeinjectionFootScratch'),
     codeinjectionHeadScratch: alias('post.codeinjectionHeadScratch'),
@@ -99,6 +103,9 @@ export default Component.extend(SettingsMenuMixin, {
         // with something more ember-like
         if (this.get('showSettingsMenu') && !this._showSettingsMenu) {
             this.get('showThrobbers').perform();
+
+            // trigger onMenuOpen closure action
+            this.onMenuOpen();
         }
 
         // fired when menu is closed
@@ -111,6 +118,9 @@ export default Component.extend(SettingsMenuMixin, {
                 post.set('publishedAtBlogTZ', post.get('publishedAtUTC'));
                 post.validate({attribute: 'publishedAtBlog'});
             }
+
+            // save tags if they've changed
+            this.onMenuClose();
 
             // remove throbbers
             this.set('_showThrobbers', false);

--- a/app/components/gh-post-settings-menu.js
+++ b/app/components/gh-post-settings-menu.js
@@ -23,6 +23,8 @@ export default Component.extend(SettingsMenuMixin, {
     ui: service(),
 
     post: null,
+    savePost: null, // EC task
+    selectedAuthor: null,
 
     _showSettingsMenu: false,
     _showThrobbers: false,
@@ -157,12 +159,6 @@ export default Component.extend(SettingsMenuMixin, {
         togglePage() {
             this.toggleProperty('post.page');
 
-            // If this is a new post.  Don't save the post.  Defer the save
-            // to the user pressing the save button
-            if (this.get('post.isNew')) {
-                return;
-            }
-
             this.get('savePost').perform().catch((error) => {
                 this.showError(error);
                 this.get('post').rollbackAttributes();
@@ -171,12 +167,6 @@ export default Component.extend(SettingsMenuMixin, {
 
         toggleFeatured() {
             this.toggleProperty('post.featured');
-
-            // If this is a new post.  Don't save the post.  Defer the save
-            // to the user pressing the save button
-            if (this.get('post.isNew')) {
-                return;
-            }
 
             this.get('savePost').perform().catch((error) => {
                 this.showError(error);
@@ -276,13 +266,7 @@ export default Component.extend(SettingsMenuMixin, {
             post.set('metaTitle', metaTitle);
 
             // Make sure the meta title is valid and if so, save it into the post
-            return post.validate({property: 'metaTitle'}).then(() => {
-                if (post.get('isNew')) {
-                    return;
-                }
-
-                return this.get('savePost').perform();
-            });
+            return post.validate({property: 'metaTitle'}).then(() => this.get('savePost').perform());
         },
 
         setMetaDescription(metaDescription) {
@@ -299,13 +283,7 @@ export default Component.extend(SettingsMenuMixin, {
             post.set('metaDescription', metaDescription);
 
             // Make sure the meta title is valid and if so, save it into the post
-            return post.validate({property: 'metaDescription'}).then(() => {
-                if (post.get('isNew')) {
-                    return;
-                }
-
-                return this.get('savePost').perform();
-            });
+            return post.validate({property: 'metaDescription'}).then(() => this.get('savePost').perform());
         },
 
         setOgTitle(ogTitle) {
@@ -322,13 +300,7 @@ export default Component.extend(SettingsMenuMixin, {
             post.set('ogTitle', ogTitle);
 
             // Make sure the facebook title is valid and if so, save it into the post
-            return post.validate({property: 'ogTitle'}).then(() => {
-                if (post.get('isNew')) {
-                    return;
-                }
-
-                return this.get('savePost').perform();
-            });
+            return post.validate({property: 'ogTitle'}).then(() => this.get('savePost').perform());
         },
 
         setOgDescription(ogDescription) {
@@ -345,13 +317,7 @@ export default Component.extend(SettingsMenuMixin, {
             post.set('ogDescription', ogDescription);
 
             // Make sure the facebook description is valid and if so, save it into the post
-            return post.validate({property: 'ogDescription'}).then(() => {
-                if (post.get('isNew')) {
-                    return;
-                }
-
-                return this.get('savePost').perform();
-            });
+            return post.validate({property: 'ogDescription'}).then(() => this.get('savePost').perform());
         },
 
         setTwitterTitle(twitterTitle) {
@@ -368,13 +334,7 @@ export default Component.extend(SettingsMenuMixin, {
             post.set('twitterTitle', twitterTitle);
 
             // Make sure the twitter title is valid and if so, save it into the post
-            return post.validate({property: 'twitterTitle'}).then(() => {
-                if (post.get('isNew')) {
-                    return;
-                }
-
-                return this.get('savePost').perform();
-            });
+            return post.validate({property: 'twitterTitle'}).then(() => this.get('savePost').perform());
         },
 
         setTwitterDescription(twitterDescription) {
@@ -391,21 +351,11 @@ export default Component.extend(SettingsMenuMixin, {
             post.set('twitterDescription', twitterDescription);
 
             // Make sure the twitter description is valid and if so, save it into the post
-            return post.validate({property: 'twitterDescription'}).then(() => {
-                if (post.get('isNew')) {
-                    return;
-                }
-
-                return this.get('savePost').perform();
-            });
+            return post.validate({property: 'twitterDescription'}).then(() => this.get('savePost').perform());
         },
 
         setCoverImage(image) {
             this.set('post.featureImage', image);
-
-            if (this.get('post.isNew')) {
-                return;
-            }
 
             this.get('savePost').perform().catch((error) => {
                 this.showError(error);
@@ -416,10 +366,6 @@ export default Component.extend(SettingsMenuMixin, {
         clearCoverImage() {
             this.set('post.featureImage', '');
 
-            if (this.get('post.isNew')) {
-                return;
-            }
-
             this.get('savePost').perform().catch((error) => {
                 this.showError(error);
                 this.get('post').rollbackAttributes();
@@ -428,10 +374,6 @@ export default Component.extend(SettingsMenuMixin, {
 
         setOgImage(image) {
             this.set('post.ogImage', image);
-
-            if (this.get('post.isNew')) {
-                return;
-            }
 
             this.get('savePost').perform().catch((error) => {
                 this.showError(error);
@@ -442,10 +384,6 @@ export default Component.extend(SettingsMenuMixin, {
         clearOgImage() {
             this.set('post.ogImage', '');
 
-            if (this.get('post.isNew')) {
-                return;
-            }
-
             this.get('savePost').perform().catch((error) => {
                 this.showError(error);
                 this.get('post').rollbackAttributes();
@@ -455,10 +393,6 @@ export default Component.extend(SettingsMenuMixin, {
         setTwitterImage(image) {
             this.set('post.twitterImage', image);
 
-            if (this.get('post.isNew')) {
-                return;
-            }
-
             this.get('savePost').perform().catch((error) => {
                 this.showError(error);
                 this.get('post').rollbackAttributes();
@@ -467,10 +401,6 @@ export default Component.extend(SettingsMenuMixin, {
 
         clearTwitterImage() {
             this.set('post.twitterImage', '');
-
-            if (this.get('post.isNew')) {
-                return;
-            }
 
             this.get('savePost').perform().catch((error) => {
                 this.showError(error);
@@ -488,11 +418,6 @@ export default Component.extend(SettingsMenuMixin, {
 
             post.set('authors', newAuthors);
             post.validate({property: 'authors'});
-
-            // if this is a new post (never been saved before), don't try to save it
-            if (post.get('isNew')) {
-                return;
-            }
 
             this.get('savePost').perform().catch((error) => {
                 this.showError(error);

--- a/app/components/modal-invite-new-user.js
+++ b/app/components/modal-invite-new-user.js
@@ -71,9 +71,9 @@ export default ModalComponent.extend(ValidationEngine, {
             if (existingUser || existingInvite) {
                 this.get('errors').clear('email');
                 if (existingUser) {
-                    this.get('errors').add('email', 'A user with that email address already exists.');
+                    this.get('errors').add('email', 'Email already taken.');
                 } else {
-                    this.get('errors').add('email', 'A user with that email address was already invited.');
+                    this.get('errors').add('email', 'Email already invited.');
                 }
 
                 // TODO: this shouldn't be needed, ValidationEngine doesn't mark

--- a/app/components/modal-leave-editor.js
+++ b/app/components/modal-leave-editor.js
@@ -3,10 +3,14 @@ import RSVP from 'rsvp';
 
 export default ModalComponent.extend({
     actions: {
-        confirm() {
-            this.confirm().finally(() => {
-                this.send('closeModal');
-            });
+        save() {
+            let save = this.get('model.save') || RSVP.resolve();
+            return save();
+        },
+
+        discard() {
+            let discard = this.get('model.discard') || RSVP.resolve();
+            return discard();
         }
     },
 

--- a/app/controllers/editor.js
+++ b/app/controllers/editor.js
@@ -272,6 +272,16 @@ export default Controller.extend({
         // TODO: this should be part of the koenig component
         setWordcount(count) {
             this.set('wordcount', count);
+        },
+
+        rollbackAndLeave() {
+            this.send('leaveEditor');
+        },
+
+        saveAndLeave() {
+            this.get('save').perform().then(() => {
+                this.send('leaveEditor');
+            });
         }
     },
 
@@ -629,6 +639,7 @@ export default Controller.extend({
         this.set('hasDirtyAttributes', false);
         this.set('shouldFocusEditor', false);
         this.set('leaveEditorTransition', null);
+        this.set('showLeaveEditorModal', false);
 
         // remove the onbeforeunload handler as it's only relevant whilst on
         // the editor route

--- a/app/controllers/editor.js
+++ b/app/controllers/editor.js
@@ -234,7 +234,7 @@ export default Controller.extend({
                     this.send('cancelAutosave');
                     this.get('autosave').cancelAll();
 
-                    return this.get('autosave').perform().then(() => {
+                    return this.get('autosave').perform({silent: false}).then(() => {
                         transition.retry();
                     });
                 }
@@ -278,11 +278,11 @@ export default Controller.extend({
     /* Public tasks ----------------------------------------------------------*/
 
     // separate task for autosave so that it doesn't override a manual save
-    autosave: task(function* () {
+    autosave: task(function* ({silent = true, backgroundSave = true} = {}) {
         if (!this.get('save.isRunning')) {
             return yield this.get('save').perform({
-                silent: true,
-                backgroundSave: true
+                silent,
+                backgroundSave
             });
         }
     }).drop(),

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -183,9 +183,9 @@ export default Model.extend(Comparable, ValidationEngine, {
     twitterDescriptionScratch: boundOneWay('twitterDescription'),
     twitterTitleScratch: boundOneWay('twitterTitle'),
 
+    internalTags: filterBy('tags', 'isInternal', true),
     isPublished: equal('status', 'published'),
     isDraft: equal('status', 'draft'),
-    internalTags: filterBy('tags', 'isInternal', true),
     isScheduled: equal('status', 'scheduled'),
 
     absoluteUrl: computed('url', 'ghostPaths.url', 'config.blogUrl', function () {

--- a/app/services/ui.js
+++ b/app/services/ui.js
@@ -10,6 +10,7 @@ export default Service.extend({
     isFullScreen: false,
     showMobileMenu: false,
     showSettingsMenu: false,
+    skipMenuClose: false,
 
     hasSideNav: not('isSideNavHidden'),
     isMobile: reads('mediaQueries.isMobile'),
@@ -28,6 +29,10 @@ export default Service.extend({
     }),
 
     closeMenus() {
+        if (this.skipMenuClose) {
+            return this.set('skipMenuClose', false);
+        }
+
         this.get('dropdown').closeDropdowns();
         this.setProperties({
             showSettingsMenu: false,

--- a/app/styles/components/modals.css
+++ b/app/styles/components/modals.css
@@ -128,6 +128,10 @@
 .modal-footer {
     display: flex;
     justify-content: flex-end;
+    margin-top: 40px;
+}
+
+.modal-footer-small {
     margin-top: 20px;
 }
 
@@ -139,6 +143,10 @@
 
 .modal-footer button:first-of-type {
     margin-left: 0;
+}
+
+.modal-footer .modal-btn-left {
+    margin-right: auto;
 }
 
 .modal-body .gh-image-uploader {

--- a/app/templates/components/modal-delete-subscriber.hbs
+++ b/app/templates/components/modal-delete-subscriber.hbs
@@ -4,7 +4,7 @@
 <a class="close" href="" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
 
 <div class="modal-body">
-    <strong>WARNING:</strong> All data for this subscriber will be deleted. There is no way to recover this.
+    <p><strong>WARNING:</strong> All data for this subscriber will be deleted. There is no way to recover this.</p>
 </div>
 
 <div class="modal-footer">

--- a/app/templates/components/modal-delete-tag.hbs
+++ b/app/templates/components/modal-delete-tag.hbs
@@ -4,10 +4,12 @@
 <a class="close" href="" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
 
 <div class="modal-body">
-    {{#if tag.post_count}}
-        <span class="red">This tag is attached to {{tag.count.posts}} {{postInflection}}.</span>
-    {{/if}}
-    You're about to delete "<strong>{{tag.name}}</strong>". This is permanent! We warned you, k?
+    <p>
+        {{#if tag.post_count}}
+            <span class="red">This tag is attached to {{tag.count.posts}} {{postInflection}}.</span>
+        {{/if}}
+        You're about to delete "<strong>{{tag.name}}</strong>". This is permanent! We warned you, k?
+    </p>
 </div>
 
 <div class="modal-footer">

--- a/app/templates/components/modal-invite-new-user.hbs
+++ b/app/templates/components/modal-invite-new-user.hbs
@@ -44,6 +44,6 @@
     </fieldset>
 </div>
 
-<div class="modal-footer">
+<div class="modal-footer" style="{{if errors.email "margin-top: calc(40px - 27px)"}}">
     {{gh-task-button "Send invitation now" successText="Sent" task=sendInvitation class="gh-btn gh-btn-green gh-btn-icon"}}
 </div>

--- a/app/templates/components/modal-leave-editor.hbs
+++ b/app/templates/components/modal-leave-editor.hbs
@@ -1,18 +1,14 @@
 <header class="modal-header">
-    <h1>Are you sure you want to leave this page?</h1>
+    <h1>Review changes</h1>
 </header>
 <a class="close" href="" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
 
 <div class="modal-body">
-    <p>
-        Hey there! It looks like you're in the middle of writing something and
-        you haven't saved all of your content.
-    </p>
-
-    <p>Save before you go!</p>
+    <p>You have made changes. Do you want to discard or save them?</p>
 </div>
 
 <div class="modal-footer">
-    <button {{action "closeModal"}} class="gh-btn"><span>Stay</span></button>
-    <button {{action "confirm"}} class="gh-btn gh-btn-red"><span>Leave</span></button>
+    <button {{action "closeModal"}} class="gh-btn modal-btn-left"><span>Cancel</span></button>
+    <button {{action "discard"}} class="gh-btn gh-btn-hover-red"><span>Discard</span></button>
+    <button {{action "save"}} class="gh-btn gh-btn-blue"><span>Save</span></button>
 </div>

--- a/app/templates/components/modal-new-subscriber.hbs
+++ b/app/templates/components/modal-new-subscriber.hbs
@@ -23,7 +23,7 @@
     </fieldset>
 </div>
 
-<div class="modal-footer">
+<div class="modal-footer modal-footer-small" style="{{if subscriber.errors.email "margin-top: calc(20px - 27px)"}}">
     <button {{action "closeModal"}} class="gh-btn"><span>Cancel</span></button>
     {{gh-task-button "Add" successText="Added" task=addSubscriber class="gh-btn gh-btn-green gh-btn-icon"}}
 </div>

--- a/app/templates/components/modal-suspend-user.hbs
+++ b/app/templates/components/modal-suspend-user.hbs
@@ -4,7 +4,7 @@
 <a class="close" href="" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
 
 <div class="modal-body">
-    <strong>WARNING:</strong> This user will no longer be able to log in but their posts will be kept.
+    <p><strong>WARNING:</strong> This user will no longer be able to log in but their posts will be kept.</p>
 </div>
 
 <div class="modal-footer">

--- a/app/templates/components/modal-unsuspend-user.hbs
+++ b/app/templates/components/modal-unsuspend-user.hbs
@@ -4,7 +4,7 @@
 <a class="close" href="" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
 
 <div class="modal-body">
-    <strong>WARNING:</strong> This user will be able to log in again and will have the same permissions they had previously.
+    <p><strong>WARNING:</strong> This user will be able to log in again and will have the same permissions they had previously.</p>
 </div>
 
 <div class="modal-footer">

--- a/app/templates/components/modal-upload-image.hbs
+++ b/app/templates/components/modal-upload-image.hbs
@@ -21,7 +21,7 @@
     {{/if}}
 </div>
 
-<div class="modal-footer">
+<div class="modal-footer modal-footer-small">
     <button {{action "closeModal"}} class="gh-btn"><span>Cancel</span></button>
     {{#if _isUploading}}
         <button class="gh-btn gh-btn-blue right gh-btn-icon disabled"><span>Save</span></button>

--- a/app/templates/components/modal-upload-theme.hbs
+++ b/app/templates/components/modal-upload-theme.hbs
@@ -100,7 +100,7 @@
     {{/if}}
 </div>
 
-<div class="modal-footer">
+<div class="modal-footer modal-footer-small">
     <button {{action "closeModal"}} disabled={{closeDisabled}} class="gh-btn" data-test-close-button>
         <span>{{#if theme}}Close{{else}}Cancel{{/if}}</span>
     </button>

--- a/app/templates/editor.hbs
+++ b/app/templates/editor.hbs
@@ -168,7 +168,10 @@
 
     {{#if showLeaveEditorModal}}
         {{gh-fullscreen-modal "leave-editor"
-            confirm=(action "leaveEditor")
+            model=(hash
+                discard=(action "rollbackAndLeave")
+                save=(action "saveAndLeave")
+            )
             close=(action "toggleLeaveEditorModal")
             modifier="action wide"}}
     {{/if}}

--- a/app/templates/editor.hbs
+++ b/app/templates/editor.hbs
@@ -186,6 +186,7 @@
             deletePost=(action "toggleDeletePostModal")
             updateSlug=updateSlug
             savePost=savePost
+            onMenuClose=(perform autosave (hash silent=false))
         }}
     {{/liquid-wormhole}}
 {{/if}}

--- a/app/templates/editor.hbs
+++ b/app/templates/editor.hbs
@@ -188,8 +188,8 @@
             showSettingsMenu=ui.showSettingsMenu
             deletePost=(action "toggleDeletePostModal")
             updateSlug=updateSlug
-            savePost=savePost
-            onMenuClose=(perform autosave (hash silent=false))
+            savePost=psmSave
+            onMenuClose=(perform psmSave)
         }}
     {{/liquid-wormhole}}
 {{/if}}

--- a/app/validators/invite-user.js
+++ b/app/validators/invite-user.js
@@ -12,7 +12,7 @@ export default BaseValidator.create({
             model.get('errors').add('email', 'Please enter an email.');
             this.invalidate();
         } else if (!validator.isEmail(email)) {
-            model.get('errors').add('email', 'Invalid Email.');
+            model.get('errors').add('email', 'Invalid email.');
             this.invalidate();
         }
     }

--- a/app/validators/new-user.js
+++ b/app/validators/new-user.js
@@ -24,7 +24,7 @@ export default PasswordValidator.extend({
             model.get('errors').add('email', 'Please enter an email.');
             this.invalidate();
         } else if (!validator.isEmail(email)) {
-            model.get('errors').add('email', 'Invalid Email.');
+            model.get('errors').add('email', 'Invalid email.');
             this.invalidate();
         }
     },

--- a/tests/acceptance/team-test.js
+++ b/tests/acceptance/team-test.js
@@ -283,7 +283,7 @@ describe('Acceptance: Team', function () {
             expect(
                 find('.fullscreen-modal .error .response').text().trim(),
                 'inviting existing user error'
-            ).to.equal('A user with that email address already exists.');
+            ).to.equal('Email already exists.');
 
             // submit invite form with existing invite
             await fillIn('.fullscreen-modal input[name="email"]', 'invite1@example.com');
@@ -293,7 +293,7 @@ describe('Acceptance: Team', function () {
             expect(
                 find('.fullscreen-modal .error .response').text().trim(),
                 'inviting invited user error'
-            ).to.equal('A user with that email address was already invited.');
+            ).to.equal('Email already invited.');
 
             // submit invite form with an invalid email
             await fillIn('.fullscreen-modal input[name="email"]', 'test');
@@ -303,7 +303,7 @@ describe('Acceptance: Team', function () {
             expect(
                 find('.fullscreen-modal .error .response').text().trim(),
                 'inviting invalid email error'
-            ).to.equal('Invalid Email.');
+            ).to.equal('Invalid email.');
 
             await click('.fullscreen-modal a.close');
             // revoke latest invite


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/9514
- simplify wording and buttons for "unsaved changes" dialog when leaving the editor
- trigger save when closing post settings menu (allows saving of tags)
- standardise saving behaviour in the PSM
    - new/draft post = save every change automatically
    - published/scheduled post = explicit saves only (<kbd>Cmd-S</kbd>, publish menu, or unsaved changes dialog)
- increase and standardise modal footer spacing

TODO:
- [x] fix PSM closing when making changes on a new post
- [ ] standardise slug update/saving behaviour
- [ ] clean up usage of scratch values
  - many don't currently make sense because the actual model value is being changed in the PSM then set again to the scratch value when saving
- [ ] replace "unsaved changes" modal for settings screens with the newly updated modal
- [ ] tests