### PR TITLE
fixed suspended users list so it now shows image and last seen time

### DIFF
--- a/app/templates/team/index.hbs
+++ b/app/templates/team/index.hbs
@@ -106,7 +106,7 @@
         <div class="apps-grid">
             {{#each sortedSuspendedUsers key="id" as |user|}}
                 {{#gh-user-active user=user as |component|}}
-                    {{gh-user-list-item user=user}}
+                    {{gh-user-list-item user=user component=component}}
                 {{/gh-user-active}}
             {{/each}}
         </div>


### PR DESCRIPTION
When you suspend a user, it moves out of the "Active Users" list, to the "Suspended Users" list. Each user in this list currently looks like this:

![screenshot-2018-3-30 team - testing](https://user-images.githubusercontent.com/37122500/38122886-b7ab2972-33cf-11e8-9ec3-833975463e6c.png)

It does not pull through the user image or the last seen time and it looks a bit odd. This PR fixes this so both an image and last seen time now show and it looks like this:

![screenshot-2018-3-30 team - testing 1](https://user-images.githubusercontent.com/37122500/38122907-ed03b1e8-33cf-11e8-871b-ed59a56a1676.png)
