### PR TITLE
[SPIKE] Koenig - Second render pass to apply Spirit vertical riddem classes

### DIFF
--- a/lib/koenig-editor/addon/components/koenig-editor.js
+++ b/lib/koenig-editor/addon/components/koenig-editor.js
@@ -9,6 +9,7 @@ import Ember from 'ember';
 import EmberObject from '@ember/object';
 import defaultAtoms from '../options/atoms';
 import defaultCards from '../options/cards';
+import kgStyleDom from '../utils/kg-style-dom';
 import layout from '../templates/components/koenig-editor';
 import registerKeyCommands from '../options/key-commands';
 import registerTextExpansions from '../options/text-expansions';
@@ -275,6 +276,12 @@ export default Component.extend({
             }
         });
         editor.didRender(() => {
+            // apply kg-style render pass in the next runloop so that it
+            // happens after cards have been rendered via afterRender
+            run.next(this, function () {
+                kgStyleDom(editor.element);
+            });
+
             // if we had explicitly started a runloop in `editor.willRender`,
             // we must explicitly end it here
             if (this._startedRunLoop) {

--- a/lib/koenig-editor/addon/utils/kg-style-dom.js
+++ b/lib/koenig-editor/addon/utils/kg-style-dom.js
@@ -1,0 +1,36 @@
+import spirit from 'spirit-product';
+
+function styleElement(element, nextSibling) {
+    let elemName = element.tagName.toLowerCase();
+    let nextName = nextSibling && nextSibling.tagName.toLowerCase();
+    let kgStyle = elemName;
+
+    if (nextName) {
+        if (/^h\d$/.test(nextName)) {
+            nextName = 'h';
+        } else if (nextName === 'div') {
+            let card = nextSibling.querySelector('.__mobiledoc-card > div > div');
+            if (card) {
+                let cardElement = card.childNodes[0].tagName.toLowerCase();
+                if (cardElement === 'figure' || cardElement === 'iframe') {
+                    nextName = 'media';
+                }
+            }
+        }
+
+        kgStyle = `${elemName}-${nextName}`;
+    }
+
+    let classes = spirit.koenig(kgStyle);
+    if (classes) {
+        classes.split(' ').forEach((cls) => {
+            element.classList.add(cls);
+        });
+    }
+}
+
+export default function kgStyleDom(dom) {
+    for (let i = 0; i < dom.childNodes.length; i++) {
+        styleElement(dom.childNodes[i], dom.childNodes[i + 1]);
+    }
+}


### PR DESCRIPTION
no issue
- walk the DOM after the editor renders to apply relevant `{{kg-style}}` classes for Spirit styling and consistent vertical rhythm