### PR TITLE
🐛 Fixed `j` and `k` keys not working in editor after visiting Tags screen

### DIFF
--- a/app/mixins/shortcuts.js
+++ b/app/mixins/shortcuts.js
@@ -45,33 +45,27 @@ key.setScope('default');
  */
 export default Mixin.create({
 
-    _hasRegisteredShortcuts: false,
-
     registerShortcuts() {
-        if (!this._hasRegisteredShortcuts) {
-            let shortcuts = this.get('shortcuts');
+        let shortcuts = this.get('shortcuts');
 
-            Object.keys(shortcuts).forEach((shortcut) => {
-                let scope = shortcuts[shortcut].scope || 'default';
-                let action = shortcuts[shortcut];
-                let options;
+        Object.keys(shortcuts).forEach((shortcut) => {
+            let scope = shortcuts[shortcut].scope || 'default';
+            let action = shortcuts[shortcut];
+            let options;
 
-                if (typeOf(action) !== 'string') {
-                    options = action.options;
-                    action = action.action;
-                }
+            if (typeOf(action) !== 'string') {
+                options = action.options;
+                action = action.action;
+            }
 
-                key(shortcut, scope, (event) => {
-                    // stop things like ctrl+s from actually opening a save dialogue
-                    event.preventDefault();
-                    run(this, function () {
-                        this.send(action, options);
-                    });
+            key(shortcut, scope, (event) => {
+                // stop things like ctrl+s from actually opening a save dialogue
+                event.preventDefault();
+                run(this, function () {
+                    this.send(action, options);
                 });
             });
-
-            this._hasRegisteredShortcuts = true;
-        }
+        });
     },
 
     removeShortcuts() {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "google-caja-bower": "https://github.com/acburdine/google-caja-bower#ghost",
     "grunt": "1.0.2",
     "grunt-shell": "2.1.0",
-    "keymaster": "1.6.2",
+    "keymaster": "https://github.com/madrobby/keymaster.git",
     "liquid-fire": "0.29.2",
     "liquid-tether": "2.0.6",
     "liquid-wormhole": "2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6493,9 +6493,9 @@ just-extend@^1.1.27:
   version "1.1.27"
   resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-1.1.27.tgz#ec6e79410ff914e472652abfa0e603c03d60e905"
 
-keymaster@1.6.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/keymaster/-/keymaster-1.6.2.tgz#e1ae54d0ea9488f9f60b66b668f02e9a1946c6eb"
+"keymaster@https://github.com/madrobby/keymaster.git":
+  version "1.6.3"
+  resolved "https://github.com/madrobby/keymaster.git#3b1f2afabf1569848dea8b697ac418f19b601a30"
 
 kind-of@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/9543
- https://github.com/TryGhost/Ghost-Admin/pull/972 moved `keymaster` from Bower to NPM but version 1.6.3 is not published to NPM and it contains fixes for unbinding multiple keys (eg, `'down, j': 'moveDown'`). Switched to fetching directly from github to ensure we have the latest version
- removed the "has registered shortcuts" guard added in https://github.com/TryGhost/Ghost-Admin/pull/976 - it was working around the buggy keymaster version but was also buggy itself because it meant shortcuts could only be registered the first time a route was loaded even though we unregister all of the shortcuts when leaving the route