### PR TITLE
Replaced config routeKeyword with hardcoded one

### DIFF
--- a/app/models/post.js
+++ b/app/models/post.js
@@ -180,10 +180,11 @@ export default Model.extend(Comparable, ValidationEngine, {
         return this.get('ghostPaths.url').join(blogUrl, postUrl);
     }),
 
-    previewUrl: computed('uuid', 'ghostPaths.url', 'config.{blogUrl,routeKeywords.preview}', function () {
+    previewUrl: computed('uuid', 'ghostPaths.url', 'config.blogUrl', function () {
         let blogUrl = this.get('config.blogUrl');
         let uuid = this.get('uuid');
-        let previewKeyword = this.get('config.routeKeywords.preview');
+        // routeKeywords.preview: 'p'
+        let previewKeyword = 'p';
         // New posts don't have a preview
         if (!uuid) {
             return '';

--- a/mirage/fixtures/configurations.js
+++ b/mirage/fixtures/configurations.js
@@ -6,12 +6,5 @@ export default [{
     fileStorage: 'true',
     internalTags: 'false',
     publicAPI: 'false',
-    routeKeywords: {
-        tag: 'tag',
-        author: 'author',
-        page: 'page',
-        preview: 'p',
-        private: 'private'
-    },
     useGravatar: 'true'
 }];


### PR DESCRIPTION
refs TryGhost/Ghost#9561

- use the hardcoded routeKeyword for `preview`
- removed `routeKeywords` from mirage configurations API fixtures
