### PR TITLE
✨ Koenig - Keep cursor on screen whilst typing or moving via keyboard

### DIFF
--- a/app/templates/components/gh-koenig-editor.hbs
+++ b/app/templates/components/gh-koenig-editor.hbs
@@ -21,5 +21,8 @@
         onChange=(action "onBodyChange")
         didCreateEditor=(action "onEditorCreated")
         cursorDidExitAtTop=(action "focusTitle")
+        scrollContainerSelector=scrollContainerSelector
+        scrollOffsetTopSelector=scrollOffsetTopSelector
+        scrollOffsetBottomSelector=scrollOffsetBottomSelector
     }}
 </div>

--- a/app/templates/editor.hbs
+++ b/app/templates/editor.hbs
@@ -71,6 +71,9 @@
                 bodyAutofocus=shouldFocusEditor
                 onBodyChange=(action "updateScratch")
                 headerOffset=editor.headerHeight
+                scrollContainerSelector=".gh-koenig-editor"
+                scrollOffsetTopSelector=".gh-editor-header-small"
+                scrollOffsetBottomSelector=".gh-mobile-nav-bar"
             }}
 
         {{else}}

--- a/lib/koenig-editor/addon/options/key-commands.js
+++ b/lib/koenig-editor/addon/options/key-commands.js
@@ -10,7 +10,7 @@ import {
 
 export const DEFAULT_KEY_COMMANDS = [{
     str: 'ENTER',
-    run(editor) {
+    run(editor, koenig) {
         let {isCollapsed, head: {offset, section}} = editor.range;
 
         // if cursor is at beginning of a heading, insert a blank paragraph above
@@ -20,6 +20,7 @@ export const DEFAULT_KEY_COMMANDS = [{
                 let collection = section.parent.sections;
                 postEditor.insertSectionBefore(collection, newPara, section);
             });
+            koenig._scrollCursorIntoView();
             return;
         }
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/9505
- when cursor changes through the normal `cursorDidChange` or through certain programmatic changes we trigger a check to see if the cursor is out of the viewport and scroll it into view if necessary
- disable our scroll-into-view routine if the mouse button or shift key is down so that we don't interfere with default browser behaviour which works well in that situation
- for scroll-into-view at the bottom there are two slightly different methods
    - if the cursor is near the bottom of the document we scroll so that the bottom padding of the editor is visible
    - if the cursor is mid-document then we scroll just enough to bring the cursor into the viewport

TODO:
- [x] appears to break /-menu
- [x] investigate performance
  - doesn't appear to be too much of a problem. Timing the main `__scrollIntoView` function shows typical collapsed cursor checks take ~0.1ms. For large selections (30 paragraphs) it can reach ~1.5ms but that is an edge case and in any case we throttle checks to every 200ms
- [x] disable auto-scroll if mouse or shift key is down so we don't tread on browser's default drag-select behaviour
- [x] investigate odd issues with backspace deleting more than one char (not sure if related to this PR)
  - couldn't reproduce
- [x] ~can we restrict checks to happen one time only after a scroll has occurred?~
  - no need, routine is fast enough without needing this optimisation
- [x] improve offset element handling (top header and mobile nav at smaller screen sizes)