### PR TITLE
[BUGFIX perf] don't fingerprint assets in development

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -92,7 +92,7 @@ module.exports = function (defaults) {
             }
         },
         fingerprint: {
-            enabled: true,
+            enabled: isProduction,
             extensions: ['js', 'css', 'png', 'jpg', 'jpeg', 'gif', 'map']
         },
         minifyJS: {


### PR DESCRIPTION
Doing so causes a double pass through asset-rewrite and forces both to take much longer. This cuts 3s off of rebuilds, bringing them to ~500-700ms on my mac.  Using asset-rewrite as is done in dev mode is also suspicious, likely a better setup could be devised that doesn't require rewrite to interop with the local ghost server. I'd estimate 250ms of savings on rebuilds by doing so.

The end result of the RFC for pre-built addons will likely reduce initial build times by 50%, and rebuilds by 250ms based on my observations using https://github.com/rwjblue/heimdalljs-visualizer

Reducing dependence on packages using ember-browserify would also help, rollup is often a better solution here, but that work overlaps with the RFC work.