### PR TITLE
Remove tabindex from role selection field

### DIFF
--- a/app/templates/components/modal-invite-new-user.hbs
+++ b/app/templates/components/modal-invite-new-user.hbs
@@ -28,7 +28,7 @@
 
         <div class="form-group for-select">
             <label for="new-user-role">Role</label>
-            <span class="gh-select" tabindex="0">
+            <span class="gh-select">
                 {{one-way-select
                     id="new-user-role"
                     name="role"


### PR DESCRIPTION
Issue https://github.com/TryGhost/Ghost/issues/7132
- Removed tabindex from role selection on invite user field.
- Removing the tabindex defaults the tabindex to "-1".

👋 Hey y'all, this solves this issue with not being able to tab over to the role dropdown after putting in an email address. It does not, however, solve the issue of autofocusing the email field when the modal is created.

When digging into the autofocus I found that it seems to be an issue with the ember component lifecycle hooks and the modal itself. From what I can tell, the `didInsertElement` method in the `text-input` mixin gets called before the element is visible on the screen. By the time the element is visible on the screen, it has lost its focus.

I was able to make it work by placing a `setTimeout` around the `this.element.focus();` in the `_focus` method:

```js
_focus() {
  if (this.get('shouldFocus') && !device.ios()) {
    setTimeout(() => {
      this.element.focus()
    }, 182)
  }
}
```

182ms is the shortest time I could get it to work, sometimes in async issues just wrapping it in a `setTimeout` without a time is enough to reorder things, but this needed at least 182ms in order to autofocus properly. My assumption is that maybe the modal is fading in at a rate of ~181ms as part of some kind of CSS or animation. 

I'd recommend _not_ wrapping this call into a `setTimeout` (which is why it isn't included in this PR). I don't know a ton about Ember so maybe there is an obvious solution to this.

Anyway, I know this doesn't solve the whole issue, but thought it might make a valuable addition as it allows people to tab over after filling in their email. Feel free to close if not adequate, any feedback is appreciated! 

THANKS!