### PR TITLE
fix editor's loading state

### DIFF
--- a/app/routes/editor/edit.js
+++ b/app/routes/editor/edit.js
@@ -1,13 +1,18 @@
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 
 export default AuthenticatedRoute.extend({
-    beforeModel() {
+    beforeModel(transition) {
         this._super(...arguments);
-        let editor = this.controllerFor('editor');
-        editor.set('post', null);
-        editor.reset();
+
+        // if the transition is not new->edit, reset the post on the controller
+        // so that the editor view is cleared before showing the loading state
+        if (transition.urlMethod !== 'replace') {
+            let editor = this.controllerFor('editor');
+            editor.set('post', null);
+            editor.reset();
+        }
     },
-    
+
     model(params) {
         let query = {
             id: params.post_id,

--- a/app/routes/editor/edit.js
+++ b/app/routes/editor/edit.js
@@ -1,6 +1,13 @@
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 
 export default AuthenticatedRoute.extend({
+    beforeModel() {
+        this._super(...arguments);
+        let editor = this.controllerFor('editor');
+        editor.set('post', null);
+        editor.reset();
+    },
+    
     model(params) {
         let query = {
             id: params.post_id,


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/9582

fix editor's loading bug by deleting the loading template

- [X] Commit message has a short title & issue references
- [X] Commits are squashed 
- [X] The build will pass (run `ember test` from the repo root - will be `core/client` if working from the submodule in Ghost).