### PR TITLE
[WIP] Add routes.yaml upload to Labs screen

### DIFF
--- a/app/controllers/settings/labs.js
+++ b/app/controllers/settings/labs.js
@@ -25,6 +25,14 @@ const IMPORT_MIME_TYPES = [
 const JSON_EXTENSION = ['json'];
 const JSON_MIME_TYPE = ['application/json'];
 
+const YAML_EXTENSION = ['yml', 'yaml'];
+const YAML_MIME_TYPE = [
+    'text/vnd.yaml',
+    'application/vnd.yaml',
+    'text/x-yaml',
+    'application/x-yaml'
+];
+
 export default Controller.extend({
     ajax: service(),
     config: service(),
@@ -43,12 +51,16 @@ export default Controller.extend({
     importMimeType: null,
     jsonExtension: null,
     jsonMimeType: null,
+    yamlExtension: null,
+    yamlMimeType: null,
 
     init() {
         this._super(...arguments);
         this.importMimeType = IMPORT_MIME_TYPES;
         this.jsonExtension = JSON_EXTENSION;
         this.jsonMimeType = JSON_MIME_TYPE;
+        this.yamlExtension = YAML_EXTENSION;
+        this.yamlMimeType = YAML_MIME_TYPE;
     },
 
     actions: {
@@ -211,6 +223,17 @@ export default Controller.extend({
 
         this.set('redirectSuccess', null);
         this.set('redirectFailure', null);
+        return true;
+    }).drop(),
+
+    routesUploadResult: task(function* (success) {
+        this.set('routesSuccess', success);
+        this.set('routesFailure', !success);
+
+        yield timeout(config.environment === 'test' ? 100 : 5000);
+
+        this.set('routesSuccess', null);
+        this.set('routesFailure', null);
         return true;
     }).drop(),
 

--- a/app/templates/settings/labs.hbs
+++ b/app/templates/settings/labs.hbs
@@ -163,7 +163,51 @@
             </div>
             {{/gh-uploader}}
         </div>
+        <div class="gh-setting">
+            {{#gh-uploader
+                extensions=yamlExtension
+                uploadUrl="/settings/routes/yaml/"
+                paramName="routes"
+                onUploadSuccess=(perform routesUploadResult true)
+                onUploadFailure=(perform routesUploadResult false)
+                as |uploader|
+            }}
+            <div class="gh-setting-content">
+                <div class="gh-setting-title">Routes</div>
+                <div class="gh-setting-desc">Configure dynamic routing by modifying the routes.yaml file</div>
+                {{#each uploader.errors as |error|}}
+                    <div class="gh-setting-error" data-test-error="routes">{{error.message}}</div>
+                {{/each}}
+            </div>
+            <div class="gh-setting-action" style="display: flex; flex-direction: column">
+                {{#if uploader.isUploading}}
+                    {{uploader.progressBar}}
+                {{else}}
+                    <button
+                        type="button"
+                        class="gh-btn gh-btn-icon {{if routesSuccess "gh-btn-green"}} {{if routesFailure "gh-btn-red"}}"
+                        onclick={{action "triggerFileDialog"}}
+                        data-test-button="upload-redirects"
+                    >
+                        <span>
+                            {{#if routesSuccess}}
+                                {{svg-jar "check-circle"}} Uploaded
+                            {{else if routesFailure}}
+                                {{svg-jar "retry"}} Upload Failed
+                            {{else}}
+                                Upload routes YAML
+                            {{/if}}
+                        </span>
+                    </button>
+                    <span><a href="#" {{action "downloadFile" "settings/routes/yaml"}} data-test-link="download-routes">Download current routes.yml</a></span>
+                {{/if}}
 
+                <div style="display:none">
+                    {{gh-file-input multiple=false action=uploader.setFiles accept=yamlMimeType data-test-file-input="routes"}}
+                </div>
+            </div>
+            {{/gh-uploader}}
+        </div>
     </section>
 </section>
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/9744
- adds `routes.yaml` upload using the same UI as the `redirects.json` upload
  - upload: `POST /settings/routes/yaml/`
  - download: `GET /settings/routes/yaml/`

TODO:
- [ ] check mime-types across various OS's
- [ ] tests