### PR TITLE
Fixed calendar icon position and improved file input style for Edge

### DIFF
--- a/app/styles/components/publishmenu.css
+++ b/app/styles/components/publishmenu.css
@@ -181,7 +181,7 @@
     line-height: 1em;
     font-weight: 400;
     user-select: text;
-
+    min-width: 0px;
     -webkit-appearance: none;
 }
 

--- a/app/styles/patterns/forms.css
+++ b/app/styles/patterns/forms.css
@@ -350,6 +350,12 @@ textarea {
     width: auto;
     height: auto;
     font-size: 1.2rem;
+    background: inherit;
+}
+
+.gh-input-file::-ms-value {
+    background: inherit;
+    border: none;
 }
 
 .gh-input-file + .gh-btn {


### PR DESCRIPTION
refs <a href="https://github.com/TryGhost/Ghost/issues/8734">TryGhost/Ghost#8734</a>

- [x] calendar icon positioning in date input
added a "min-width: 0px" rule to correct the calendar icon position
- [x] file input styles
removed the border and changed the background of the file input element

TODO:

- [ ] animated checkmark is invisible (applies to success buttons and the setup steps)
(although version 42.17134.1.0 EdgeHTML 17.17134 is unaffected by the bug)
