### PR TITLE
Added image validation error message to gallery card

### DIFF
--- a/lib/koenig-editor/addon/components/koenig-card-gallery.js
+++ b/lib/koenig-editor/addon/components/koenig-card-gallery.js
@@ -167,7 +167,7 @@ export default Component.extend({
             this.images.removeObject(image);
 
             this._buildAndSaveImagesPayload();
-            let fileName = (uploadResult.fileName.length > 20) ? `${this.substr(0, 20)}...` : uploadResult.fileName;
+            let fileName = (uploadResult.fileName.length > 20) ? `${uploadResult.fileName.substr(0, 20)}...` : uploadResult.fileName;
             this.set('errorMessage', `${fileName} failed to upload.`);
         },
         handleErrors(errors) {

--- a/lib/koenig-editor/addon/components/koenig-card-gallery.js
+++ b/lib/koenig-editor/addon/components/koenig-card-gallery.js
@@ -168,7 +168,7 @@ export default Component.extend({
 
             this._buildAndSaveImagesPayload();
             let fileName = (uploadResult.fileName.length > 20) ? `${uploadResult.fileName.substr(0, 20)}...` : uploadResult.fileName;
-            this.set('errorMessage', `${fileName} failed to upload.`);
+            this.set('errorMessage', `${fileName} failed to upload`);
         },
         handleErrors(errors) {
             let errorMssg = ((errors[0] && errors[0].message)) || 'Some images failed to upload';

--- a/lib/koenig-editor/addon/components/koenig-card-gallery.js
+++ b/lib/koenig-editor/addon/components/koenig-card-gallery.js
@@ -167,8 +167,12 @@ export default Component.extend({
             this.images.removeObject(image);
 
             this._buildAndSaveImagesPayload();
-
-            this.set('errorMessage', 'Some images failed to upload');
+            let fileName = (uploadResult.fileName.length > 20) ? `${this.substr(0, 20)}...` : uploadResult.fileName;
+            this.set('errorMessage', `${fileName} failed to upload.`);
+        },
+        handleErrors(errors) {
+            let errorMssg = ((errors[0] && errors[0].message)) || 'Some images failed to upload';
+            this.set('errorMessage', errorMssg);
         },
 
         clearErrorMessage() {

--- a/lib/koenig-editor/addon/templates/components/koenig-card-gallery.hbs
+++ b/lib/koenig-editor/addon/templates/components/koenig-card-gallery.hbs
@@ -21,6 +21,7 @@
         onUploadStart=(action "addImage")
         onUploadSuccess=(action "setImageSrc")
         onUploadFailure=(action "uploadFailed")
+        onFailed=(action "handleErrors")
         as |uploader|
     }}
         <div class="relative{{unless images " bg-whitegrey-l2"}}">


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/9840
- added error on trying to upload an invalid image format to gallery card
  - updated error message logic to use both overall error method(`onFailed`) to set error message as well as individual upload failures(`onUploadFailure`)
