### PR TITLE
🐛 Fixed theme download links

### DIFF
--- a/app/controllers/settings/design.js
+++ b/app/controllers/settings/design.js
@@ -171,7 +171,7 @@ export default Controller.extend({
         },
 
         downloadTheme(theme) {
-            let downloadURL = `${this.get('ghostPaths.apiRoot')}/themes/${theme.name}`;
+            let downloadURL = `${this.get('ghostPaths.apiRoot')}/themes/${theme.name}/download/`;
             let iframe = $('#iframeDownload');
 
             if (iframe.length === 0) {


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/10011
- theme download URLs were missing the `/download/` portion