### PR TITLE
Feature image alt text

### DIFF
--- a/app/components/gh-post-settings-menu.js
+++ b/app/components/gh-post-settings-menu.js
@@ -179,6 +179,16 @@ export default Component.extend(SettingsMenuMixin, {
                 });
         },
 
+        setFeaturedAltText(featuredAltText) {
+            let post = this.get('post');
+            let altText = post.get('featuredAltText');
+            if (featuredAltText === altText) {
+                return;
+            }
+            post.set('featuredAltText', featuredAltText);
+            return post.validate({property: 'featuredAltText'}).then(() => this.get('savePost').perform());
+        },
+
         setPublishedAtBlogDate(date) {
             let post = this.get('post');
             let dateString = moment(date).format('YYYY-MM-DD');

--- a/app/components/gh-post-settings-menu.js
+++ b/app/components/gh-post-settings-menu.js
@@ -29,6 +29,7 @@ export default Component.extend(SettingsMenuMixin, {
     customExcerptScratch: alias('post.customExcerptScratch'),
     codeinjectionFootScratch: alias('post.codeinjectionFootScratch'),
     codeinjectionHeadScratch: alias('post.codeinjectionHeadScratch'),
+    featuredAltText: alias('post.featuredAltTextScratch'),
     metaDescriptionScratch: alias('post.metaDescriptionScratch'),
     metaTitleScratch: alias('post.metaTitleScratch'),
     ogDescriptionScratch: alias('post.ogDescriptionScratch'),
@@ -178,7 +179,7 @@ export default Component.extend(SettingsMenuMixin, {
                     this.get('post').rollbackAttributes();
                 });
         },
-
+           
         setFeaturedAltText(featuredAltText) {
             let post = this.get('post');
             let altText = post.get('featuredAltText');
@@ -188,7 +189,7 @@ export default Component.extend(SettingsMenuMixin, {
             post.set('featuredAltText', featuredAltText);
             return post.validate({property: 'featuredAltText'}).then(() => this.get('savePost').perform());
         },
-
+        
         setPublishedAtBlogDate(date) {
             let post = this.get('post');
             let dateString = moment(date).format('YYYY-MM-DD');

--- a/app/controllers/editor.js
+++ b/app/controllers/editor.js
@@ -332,6 +332,7 @@ export default Controller.extend({
 
         this.set('post.title', this.get('post.titleScratch'));
         this.set('post.customExcerpt', this.get('post.customExcerptScratch'));
+        this.set('post.featuredAltText', this.get('post.featuredAltTextScratch'));
         this.set('post.footerInjection', this.get('post.footerExcerptScratch'));
         this.set('post.headerInjection', this.get('post.headerExcerptScratch'));
         this.set('post.metaTitle', this.get('post.metaTitleScratch'));
@@ -533,6 +534,7 @@ export default Controller.extend({
 
         // triggered any time the admin tab is closed, we need to use a native
         // dialog here instead of our custom modal
+        // Misleading line break before '+'; readers may interpret this as an expression boundary. (W014)
         window.onbeforeunload = () => {
             if (this.get('hasDirtyAttributes')) {
                 return '==============================\n\n'

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -136,6 +136,7 @@ export default Model.extend(Comparable, ValidationEngine, {
     customExcerptScratch: boundOneWay('customExcerpt'),
     codeinjectionFootScratch: boundOneWay('codeinjectionFoot'),
     codeinjectionHeadScratch: boundOneWay('codeinjectionHead'),
+    featuredAltTextScratch: boundOneWay('featuredAltText'),
     metaDescriptionScratch: boundOneWay('metaDescription'),
     metaTitleScratch: boundOneWay('metaTitle'),
     ogDescriptionScratch: boundOneWay('ogDescription'),

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -78,6 +78,7 @@ export default Model.extend(Comparable, ValidationEngine, {
     customExcerpt: attr('string'),
     featured: attr('boolean', {defaultValue: false}),
     featureImage: attr('string'),
+    featuredAltText: attr('string'),
     codeinjectionFoot: attr('string', {defaultValue: ''}),
     codeinjectionHead: attr('string', {defaultValue: ''}),
     customTemplate: attr('string'),

--- a/app/templates/components/gh-post-settings-menu.hbs
+++ b/app/templates/components/gh-post-settings-menu.hbs
@@ -16,6 +16,18 @@
                     remove=(action "clearCoverImage")
                 }}
                 <form>
+                    {{#gh-form-group errors=post.errors hasValidated=post.hasValidated property="featuredAltText"}}
+                        <label for="featured-alt-text">Alt Text</label>
+                        {{gh-textarea
+                        class="post-setting-featured-alt-text"
+                        id="featured-alt-text"
+                        name="post-setting-featured-alt-text"
+                        value=(readonly featuredAltText)
+                        input=(action (mut featuredAltText) value="target.value")
+                        focus-out=(action "setFeaturedAltText" featuredAltText)
+                        stopEnterKeyDownPropagation="true"
+                        }}
+                    {{/gh-form-group}}
                 <div class="form-group">
                     <label for="url">Post URL</label>
                     {{!-- new posts don't have a preview link --}}


### PR DESCRIPTION
Added a text box for featured image alt text in the posts settings.

no issue

- SEO team I work with requested this feature
- brand new to ghost - learning curve
- must add field to model in ghost:
    - /core/server/data/schema/schema.js
- any feature_image reference in theme must add:
    - alt='{{featured_alt_text}}' to set the text