### PR TITLE
Adjust post URL handling for API v2's absolute URLs

### DIFF
--- a/app/controllers/editor.js
+++ b/app/controllers/editor.js
@@ -759,7 +759,7 @@ export default Controller.extend({
 
         if (status === 'published') {
             type = this.get('post.page') ? 'Page' : 'Post';
-            path = this.get('post.absoluteUrl');
+            path = this.get('post.url');
         } else {
             type = 'Preview';
             path = this.get('post.previewUrl');

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -147,12 +147,6 @@ export default Model.extend(Comparable, ValidationEngine, {
     internalTags: filterBy('tags', 'isInternal', true),
     isScheduled: equal('status', 'scheduled'),
 
-    absoluteUrl: computed('url', 'ghostPaths.url', 'config.blogUrl', function () {
-        let blogUrl = this.get('config.blogUrl');
-        let postUrl = this.get('url');
-        return this.get('ghostPaths.url').join(blogUrl, postUrl);
-    }),
-
     previewUrl: computed('uuid', 'ghostPaths.url', 'config.blogUrl', function () {
         let blogUrl = this.get('config.blogUrl');
         let uuid = this.get('uuid');

--- a/app/templates/components/gh-post-settings-menu.hbs
+++ b/app/templates/components/gh-post-settings-menu.hbs
@@ -21,7 +21,7 @@
                     {{!-- new posts don't have a preview link --}}
                     {{#unless post.isNew}}
                         {{#if post.isPublished}}
-                        <a class="post-view-link" target="_blank" href="{{post.absoluteUrl}}">
+                        <a class="post-view-link" target="_blank" href="{{post.url}}">
                             View post {{svg-jar "external"}}
                         </a>
                         {{else}}


### PR DESCRIPTION
no issue
- Admin API v2 outputs absolute URLs so we no longer need to construct full URLs ourselves