### PR TITLE
Fixed sanitization of user invited emails for notification message

### DIFF
--- a/app/controllers/setup/three.js
+++ b/app/controllers/setup/three.js
@@ -1,4 +1,5 @@
 import Controller from 'ember-controller';
+import Ember from 'ember';
 import RSVP from 'rsvp';
 import computed, {alias} from 'ember-computed';
 import {A as emberA} from 'ember-array/utils';
@@ -200,7 +201,7 @@ export default Controller.extend({
                         if (erroredEmails.length > 0) {
                             invitationsString = erroredEmails.length > 1 ? ' invitations: ' : ' invitation: ';
                             message = `Failed to send ${erroredEmails.length} ${invitationsString}`;
-                            message += erroredEmails.join(', ');
+                            message += Ember.Handlebars.Utils.escapeExpression(erroredEmails.join(', '));
                             message += ". Please check your email configuration, see <a href=\'https://docs.ghost.org/v0.11.9/docs/mail-config\' target=\'_blank\'>https://docs.ghost.org/v0.11.9/docs/mail-config</a> for instructions";
 
                             message = htmlSafe(message);


### PR DESCRIPTION
cherry-picked https://github.com/TryGhost/Ghost-Admin/commit/4ca1cc556ef6f417ad70e771cf878eca03d7e71a
no issue

- Escaped email ids string sent to notification message during blog setup

Credits: Antony Garand
