### PR TITLE
Fix display bug on app icons

### DIFF
--- a/app/styles/layouts/apps.css
+++ b/app/styles/layouts/apps.css
@@ -209,6 +209,7 @@
     height: 47px;
     background-position: center center;
     background-size: cover;
+    background-repeat: no-repeat;
     border-radius: 15%;
 }
 


### PR DESCRIPTION
No issue

Resolves error with integration background icon images being tiled

Before:
![image](https://user-images.githubusercontent.com/120485/48411041-fce5b280-e772-11e8-9962-4ebe508402dc.png)

After:
![image](https://user-images.githubusercontent.com/120485/48411075-0ec75580-e773-11e8-8764-391c421a5dd8.png)
