### PR TITLE
Update title of page in editor to current title of post.

### DIFF
--- a/app/controllers/editor.js
+++ b/app/controllers/editor.js
@@ -474,6 +474,8 @@ export default Controller.extend({
         if (this.get('post.isDraft')) {
             yield this.get('autosave').perform();
         }
+
+        this.send('collectTitleTokens', []);
     }),
 
     generateSlug: task(function* () {

--- a/app/controllers/editor.js
+++ b/app/controllers/editor.js
@@ -475,7 +475,7 @@ export default Controller.extend({
             yield this.get('autosave').perform();
         }
 
-        this.send('collectTitleTokens', []);
+        this.get('target').updateTitle();
     }),
 
     generateSlug: task(function* () {

--- a/app/controllers/editor.js
+++ b/app/controllers/editor.js
@@ -475,7 +475,7 @@ export default Controller.extend({
             yield this.get('autosave').perform();
         }
 
-        this.get('target').updateTitle();
+        this.send('updateDocumentTitle');
     }),
 
     generateSlug: task(function* () {

--- a/app/controllers/settings/general.js
+++ b/app/controllers/settings/general.js
@@ -274,7 +274,7 @@ export default Controller.extend({
 
             // this forces the document title to recompute after
             // a blog title change
-            this.send('collectTitleTokens', []);
+            this.send('updateDocumentTitle');
 
             return settings;
         } catch (error) {

--- a/app/routes/editor.js
+++ b/app/routes/editor.js
@@ -82,6 +82,10 @@ export default AuthenticatedRoute.extend(ShortcutsRoute, {
         }
     },
 
+    titleToken() {
+        return this.get('controller.post.title') || 'Editor';
+    },
+
     _blurAndScheduleAction(func) {
         let selectedElement = $(document.activeElement);
 
@@ -92,11 +96,5 @@ export default AuthenticatedRoute.extend(ShortcutsRoute, {
 
         // wait for actions triggered by the focusout to finish before saving
         run.scheduleOnce('actions', this, func);
-    },
-
-    titleToken: function () {
-        const title = this.get('controller.post.title');
-
-        return title === '' ? 'Editor' : title;
     }
 });

--- a/app/routes/editor.js
+++ b/app/routes/editor.js
@@ -14,7 +14,6 @@ export default AuthenticatedRoute.extend(ShortcutsRoute, {
     notifications: service(),
     userAgent: service(),
     ui: service(),
-    router: service(),
 
     classNames: ['editor'],
     shortcuts: generalShortcuts,

--- a/app/routes/editor.js
+++ b/app/routes/editor.js
@@ -14,10 +14,10 @@ export default AuthenticatedRoute.extend(ShortcutsRoute, {
     notifications: service(),
     userAgent: service(),
     ui: service(),
+    router: service(),
 
     classNames: ['editor'],
     shortcuts: generalShortcuts,
-    titleToken: 'Editor',
 
     activate() {
         this._super(...arguments);
@@ -92,5 +92,11 @@ export default AuthenticatedRoute.extend(ShortcutsRoute, {
 
         // wait for actions triggered by the focusout to finish before saving
         run.scheduleOnce('actions', this, func);
+    },
+
+    titleToken: function () {
+        const title = this.get('controller.post.title');
+
+        return title === '' ? 'Editor' : title;
     }
 });

--- a/app/utils/document-title.js
+++ b/app/utils/document-title.js
@@ -18,6 +18,10 @@ export default function () {
         title: null,
 
         actions: {
+            updateDocumentTitle() {
+                this.send('collectTitleTokens', []);
+            },
+
             collectTitleTokens(tokens) {
                 let {titleToken} = this;
                 let finalTitle;
@@ -49,7 +53,7 @@ export default function () {
 
     Router.reopen({
         updateTitle: on('didTransition', function () {
-            this.send('collectTitleTokens', []);
+            this.send('updateDocumentTitle');
         })
     });
 }

--- a/tests/unit/controllers/editor-test.js
+++ b/tests/unit/controllers/editor-test.js
@@ -90,6 +90,9 @@ describe('Unit: Controller: editor', function () {
             expect(controller.get('post.titleScratch')).to.not.be.ok;
 
             controller.set('post.titleScratch', 'test');
+            controller.set('target', {
+                updateTitle: () => {}
+            });
 
             run(() => {
                 controller.get('saveTitle').perform();
@@ -117,6 +120,9 @@ describe('Unit: Controller: editor', function () {
             expect(controller.get('post.titleScratch')).to.not.be.ok;
 
             controller.set('post.titleScratch', 'New Title');
+            controller.set('target', {
+                updateTitle: () => {}
+            });
 
             run(() => {
                 controller.get('saveTitle').perform();
@@ -148,6 +154,9 @@ describe('Unit: Controller: editor', function () {
             expect(controller.get('post.titleScratch')).to.not.be.ok;
 
             controller.set('post.titleScratch', 'test');
+            controller.set('target', {
+                updateTitle: () => {}
+            });
 
             run(() => {
                 controller.get('saveTitle').perform();
@@ -175,6 +184,9 @@ describe('Unit: Controller: editor', function () {
             expect(controller.get('post.title')).to.not.be.ok;
 
             controller.set('post.titleScratch', 'title');
+            controller.set('target', {
+                updateTitle: () => {}
+            });
 
             run(() => {
                 controller.get('saveTitle').perform();
@@ -183,6 +195,39 @@ describe('Unit: Controller: editor', function () {
             wait().then(() => {
                 expect(controller.get('post.titleScratch')).to.equal('title');
                 expect(controller.get('post.slug')).to.not.be.ok;
+                done();
+            });
+        });
+
+        it('should invoke updateTitle after the title has changed', function (done) {
+            let controller = this.subject();
+
+            run(() => {
+                controller.set('generateSlug', task(function * () {
+                    expect(false, 'generateSlug should not be called').to.equal(true);
+                    yield RSVP.resolve();
+                }));
+                controller.set('post', EmberObject.create({isNew: false}));
+            });
+
+            expect(controller.get('post.isNew')).to.be.false;
+            expect(controller.get('post.title')).to.not.be.ok;
+
+            let updateTitleCalled = false;
+
+            controller.set('post.titleScratch', 'title');
+            controller.set('target', {
+                updateTitle: () => updateTitleCalled = true
+            });
+
+            run(() => {
+                controller.get('saveTitle').perform();
+            });
+
+            wait().then(() => {
+                expect(controller.get('post.titleScratch')).to.equal('title');
+                expect(controller.get('post.slug')).to.not.be.ok;
+                expect(updateTitleCalled).to.be.true;
                 done();
             });
         });

--- a/tests/unit/controllers/editor-test.js
+++ b/tests/unit/controllers/editor-test.js
@@ -1,189 +1,143 @@
 import EmberObject from '@ember/object';
 import RSVP from 'rsvp';
-import wait from 'ember-test-helpers/wait';
 import {describe, it} from 'mocha';
 import {expect} from 'chai';
-import {run} from '@ember/runloop';
+import {settled} from '@ember/test-helpers';
 import {setupTest} from 'ember-mocha';
 import {task} from 'ember-concurrency';
 
 describe('Unit: Controller: editor', function () {
-    setupTest('controller:editor', {
-        needs: [
-            'controller:application',
-            'service:feature',
-            'service:notifications',
-            'service:slugGenerator',
-            'service:session',
-            'service:ui'
-        ]
-    });
+    setupTest();
 
     describe('generateSlug', function () {
-        it('should generate a slug and set it on the post', function (done) {
-            run(() => {
-                let controller = this.subject();
+        it('should generate a slug and set it on the post', async function () {
+            let controller = this.owner.lookup('controller:editor');
 
-                controller.set('slugGenerator', EmberObject.create({
-                    generateSlug(slugType, str) {
-                        return RSVP.resolve(`${str}-slug`);
-                    }
-                }));
-                controller.set('post', EmberObject.create({slug: ''}));
+            controller.set('slugGenerator', EmberObject.create({
+                generateSlug(slugType, str) {
+                    return RSVP.resolve(`${str}-slug`);
+                }
+            }));
+            controller.set('post', EmberObject.create({slug: ''}));
 
-                controller.set('post.titleScratch', 'title');
+            controller.set('post.titleScratch', 'title');
+            await settled();
 
-                expect(controller.get('post.slug')).to.equal('');
+            expect(controller.get('post.slug')).to.equal('');
 
-                run(() => {
-                    controller.get('generateSlug').perform();
-                });
+            await controller.get('generateSlug').perform();
 
-                wait().then(() => {
-                    expect(controller.get('post.slug')).to.equal('title-slug');
-                    done();
-                });
-            });
+            expect(controller.get('post.slug')).to.equal('title-slug');
         });
 
-        it('should not set the destination if the title is "(Untitled)" and the post already has a slug', function (done) {
-            let controller = this.subject();
+        it('should not set the destination if the title is "(Untitled)" and the post already has a slug', async function () {
+            let controller = this.owner.lookup('controller:editor');
 
-            run(() => {
-                controller.set('slugGenerator', EmberObject.create({
-                    generateSlug(slugType, str) {
-                        return RSVP.resolve(`${str}-slug`);
-                    }
-                }));
-                controller.set('post', EmberObject.create({slug: 'whatever'}));
-            });
+            controller.set('slugGenerator', EmberObject.create({
+                generateSlug(slugType, str) {
+                    return RSVP.resolve(`${str}-slug`);
+                }
+            }));
+            controller.set('post', EmberObject.create({slug: 'whatever'}));
 
             expect(controller.get('post.slug')).to.equal('whatever');
 
             controller.set('post.titleScratch', '(Untitled)');
+            await controller.get('generateSlug').perform();
 
-            run(() => {
-                controller.get('generateSlug').perform();
-            });
-
-            wait().then(() => {
-                expect(controller.get('post.slug')).to.equal('whatever');
-                done();
-            });
+            expect(controller.get('post.slug')).to.equal('whatever');
         });
     });
 
     describe('saveTitle', function () {
-        it('should invoke generateSlug if the post is new and a title has not been set', function (done) {
-            let controller = this.subject();
+        beforeEach(function () {
+            this.controller = this.owner.lookup('controller:editor');
+            this.controller.set('target', {send() {}});
+        });
 
-            run(() => {
-                controller.set('generateSlug', task(function * () {
-                    this.set('post.slug', 'test-slug');
-                    yield RSVP.resolve();
-                }));
-                controller.set('post', EmberObject.create({isNew: true}));
-            });
+        it('should invoke generateSlug if the post is new and a title has not been set', async function () {
+            let {controller} = this;
+
+            controller.set('target', {send() {}});
+            controller.set('generateSlug', task(function * () {
+                this.set('post.slug', 'test-slug');
+                yield RSVP.resolve();
+            }));
+            controller.set('post', EmberObject.create({isNew: true}));
 
             expect(controller.get('post.isNew')).to.be.true;
             expect(controller.get('post.titleScratch')).to.not.be.ok;
 
             controller.set('post.titleScratch', 'test');
+            await controller.get('saveTitle').perform();
 
-            run(() => {
-                controller.get('saveTitle').perform();
-            });
-
-            wait().then(() => {
-                expect(controller.get('post.titleScratch')).to.equal('test');
-                expect(controller.get('post.slug')).to.equal('test-slug');
-                done();
-            });
+            expect(controller.get('post.titleScratch')).to.equal('test');
+            expect(controller.get('post.slug')).to.equal('test-slug');
         });
 
-        it('should invoke generateSlug if the post is not new and it\'s title is "(Untitled)"', function (done) {
-            let controller = this.subject();
+        it('should invoke generateSlug if the post is not new and it\'s title is "(Untitled)"', async function () {
+            let {controller} = this;
 
-            run(() => {
-                controller.set('generateSlug', task(function * () {
-                    this.set('post.slug', 'test-slug');
-                    yield RSVP.resolve();
-                }));
-                controller.set('post', EmberObject.create({isNew: false, title: '(Untitled)'}));
-            });
+            controller.set('target', {send() {}});
+            controller.set('generateSlug', task(function * () {
+                this.set('post.slug', 'test-slug');
+                yield RSVP.resolve();
+            }));
+            controller.set('post', EmberObject.create({isNew: false, title: '(Untitled)'}));
 
             expect(controller.get('post.isNew')).to.be.false;
             expect(controller.get('post.titleScratch')).to.not.be.ok;
 
             controller.set('post.titleScratch', 'New Title');
 
-            run(() => {
-                controller.get('saveTitle').perform();
-            });
+            await controller.get('saveTitle').perform();
 
-            wait().then(() => {
-                expect(controller.get('post.titleScratch')).to.equal('New Title');
-                expect(controller.get('post.slug')).to.equal('test-slug');
-                done();
-            });
+            expect(controller.get('post.titleScratch')).to.equal('New Title');
+            expect(controller.get('post.slug')).to.equal('test-slug');
         });
 
-        it('should not invoke generateSlug if the post is new but has a title', function (done) {
-            let controller = this.subject();
+        it('should not invoke generateSlug if the post is new but has a title', async function () {
+            let {controller} = this;
 
-            run(() => {
-                controller.set('generateSlug', task(function * () {
-                    expect(false, 'generateSlug should not be called').to.equal(true);
-                    yield RSVP.resolve();
-                }));
-                controller.set('post', EmberObject.create({
-                    isNew: true,
-                    title: 'a title'
-                }));
-            });
+            controller.set('target', {send() {}});
+            controller.set('generateSlug', task(function * () {
+                expect(false, 'generateSlug should not be called').to.equal(true);
+                yield RSVP.resolve();
+            }));
+            controller.set('post', EmberObject.create({
+                isNew: true,
+                title: 'a title'
+            }));
 
             expect(controller.get('post.isNew')).to.be.true;
             expect(controller.get('post.title')).to.equal('a title');
             expect(controller.get('post.titleScratch')).to.not.be.ok;
 
             controller.set('post.titleScratch', 'test');
+            await controller.get('saveTitle').perform();
 
-            run(() => {
-                controller.get('saveTitle').perform();
-            });
-
-            wait().then(() => {
-                expect(controller.get('post.titleScratch')).to.equal('test');
-                expect(controller.get('post.slug')).to.not.be.ok;
-                done();
-            });
+            expect(controller.get('post.titleScratch')).to.equal('test');
+            expect(controller.get('post.slug')).to.not.be.ok;
         });
 
-        it('should not invoke generateSlug if the post is not new and the title is not "(Untitled)"', function (done) {
-            let controller = this.subject();
+        it('should not invoke generateSlug if the post is not new and the title is not "(Untitled)"', async function () {
+            let {controller} = this;
 
-            run(() => {
-                controller.set('generateSlug', task(function * () {
-                    expect(false, 'generateSlug should not be called').to.equal(true);
-                    yield RSVP.resolve();
-                }));
-                controller.set('post', EmberObject.create({isNew: false}));
-            });
+            controller.set('target', {send() {}});
+            controller.set('generateSlug', task(function * () {
+                expect(false, 'generateSlug should not be called').to.equal(true);
+                yield RSVP.resolve();
+            }));
+            controller.set('post', EmberObject.create({isNew: false}));
 
             expect(controller.get('post.isNew')).to.be.false;
             expect(controller.get('post.title')).to.not.be.ok;
 
             controller.set('post.titleScratch', 'title');
+            await controller.get('saveTitle').perform();
 
-            run(() => {
-                controller.get('saveTitle').perform();
-            });
-
-            wait().then(() => {
-                expect(controller.get('post.titleScratch')).to.equal('title');
-                expect(controller.get('post.slug')).to.not.be.ok;
-                done();
-            });
+            expect(controller.get('post.titleScratch')).to.equal('title');
+            expect(controller.get('post.slug')).to.not.be.ok;
         });
     });
 });

--- a/tests/unit/controllers/editor-test.js
+++ b/tests/unit/controllers/editor-test.js
@@ -13,7 +13,6 @@ describe('Unit: Controller: editor', function () {
             'controller:application',
             'service:feature',
             'service:notifications',
-            // 'service:router',
             'service:slugGenerator',
             'service:session',
             'service:ui'
@@ -90,9 +89,6 @@ describe('Unit: Controller: editor', function () {
             expect(controller.get('post.titleScratch')).to.not.be.ok;
 
             controller.set('post.titleScratch', 'test');
-            controller.set('target', {
-                updateTitle: () => {}
-            });
 
             run(() => {
                 controller.get('saveTitle').perform();
@@ -120,9 +116,6 @@ describe('Unit: Controller: editor', function () {
             expect(controller.get('post.titleScratch')).to.not.be.ok;
 
             controller.set('post.titleScratch', 'New Title');
-            controller.set('target', {
-                updateTitle: () => {}
-            });
 
             run(() => {
                 controller.get('saveTitle').perform();
@@ -154,9 +147,6 @@ describe('Unit: Controller: editor', function () {
             expect(controller.get('post.titleScratch')).to.not.be.ok;
 
             controller.set('post.titleScratch', 'test');
-            controller.set('target', {
-                updateTitle: () => {}
-            });
 
             run(() => {
                 controller.get('saveTitle').perform();
@@ -184,9 +174,6 @@ describe('Unit: Controller: editor', function () {
             expect(controller.get('post.title')).to.not.be.ok;
 
             controller.set('post.titleScratch', 'title');
-            controller.set('target', {
-                updateTitle: () => {}
-            });
 
             run(() => {
                 controller.get('saveTitle').perform();
@@ -195,39 +182,6 @@ describe('Unit: Controller: editor', function () {
             wait().then(() => {
                 expect(controller.get('post.titleScratch')).to.equal('title');
                 expect(controller.get('post.slug')).to.not.be.ok;
-                done();
-            });
-        });
-
-        it('should invoke updateTitle after the title has changed', function (done) {
-            let controller = this.subject();
-
-            run(() => {
-                controller.set('generateSlug', task(function * () {
-                    expect(false, 'generateSlug should not be called').to.equal(true);
-                    yield RSVP.resolve();
-                }));
-                controller.set('post', EmberObject.create({isNew: false}));
-            });
-
-            expect(controller.get('post.isNew')).to.be.false;
-            expect(controller.get('post.title')).to.not.be.ok;
-
-            let updateTitleCalled = false;
-
-            controller.set('post.titleScratch', 'title');
-            controller.set('target', {
-                updateTitle: () => updateTitleCalled = true
-            });
-
-            run(() => {
-                controller.get('saveTitle').perform();
-            });
-
-            wait().then(() => {
-                expect(controller.get('post.titleScratch')).to.equal('title');
-                expect(controller.get('post.slug')).to.not.be.ok;
-                expect(updateTitleCalled).to.be.true;
                 done();
             });
         });


### PR DESCRIPTION
refs TryGhost/Ghost#10088
The change moved the title information into a function that returns the
correct title or if no title is set for now "Editor" for the editor route. That should help
with multiple Editor tabs open since it now displays the correct title.

Before:
![47715178-8bd1d580-dc71-11e8-9aa8-e239736225cc](https://user-images.githubusercontent.com/1591511/48420532-ed5a6f80-e75a-11e8-9e76-6810a84e1028.png)

After:
<img width="1014" alt="screenshot 2018-11-13 at 15 43 42" src="https://user-images.githubusercontent.com/1591511/48420538-f2b7ba00-e75a-11e8-8165-db044a3f18d2.png">


Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!
- [x] Commit message has a short title & issue references
- [x] Commits are squashed 
- [x] The build will pass (run `ember test` from the repo root - will be `core/client` if working from the submodule in Ghost).
