### PR TITLE
Fix the link for Markdown guide documentation.

### DIFF
--- a/app/templates/components/modal-markdown-help.hbs
+++ b/app/templates/components/modal-markdown-help.hbs
@@ -81,6 +81,6 @@
             </tr>
             </tbody>
         </table>
-        For further Markdown syntax reference: <a href="https://help.ghost.org/hc/en-us/articles/224410728-Markdown-Guide" target="_blank">Markdown Documentation</a>
+        For further Markdown syntax reference: <a href="https://docs.ghost.org/faq/using-the-editor/#using-markdown" target="_blank">Markdown Documentation</a>
     </section>
 </div>


### PR DESCRIPTION
- [x] Commit message has a short title & issue references
- [x] Commits are squashed 
- [x] The build will pass (run `ember test` from the repo root - will be `core/client` if working from the submodule in Ghost).

Fixes https://github.com/TryGhost/Ghost/issues/10227
Corrected the link for the Markdown documentation. @kevinansfield Please review.