### PR TITLE
Optimised gallery image upload previews

### DIFF
--- a/lib/koenig-editor/addon/components/koenig-card-gallery.js
+++ b/lib/koenig-editor/addon/components/koenig-card-gallery.js
@@ -228,30 +228,22 @@ export default Component.extend({
     },
 
     _readDataFromImageFile(file) {
-        let reader = new FileReader();
+        let url = URL.createObjectURL(file);
         let image = EmberObject.create({
-            fileName: file.name
+            fileName: file.name,
+            previewSrc: url
         });
 
-        reader.onload = (e) => {
-            let imgElement = new Image();
-            let previewSrc = htmlSafe(e.target.result);
+        let imageElem = new Image();
+        imageElem.onload = () => {
+            // update current display images
+            image.set('width', imageElem.naturalWidth);
+            image.set('height', imageElem.naturalHeight);
 
-            image.set('previewSrc', previewSrc);
-
-            imgElement.onload = () => {
-                // update current display images
-                image.set('width', imgElement.width);
-                image.set('height', imgElement.height);
-
-                // ensure width/height makes it into the payload images
-                this._buildAndSaveImagesPayload();
-            };
-
-            imgElement.src = previewSrc;
+            // ensure width/height makes it into the payload images
+            this._buildAndSaveImagesPayload();
         };
-
-        reader.readAsDataURL(file);
+        imageElem.src = url;
 
         return image;
     },


### PR DESCRIPTION
no issue
- use `URL.createObjectURL(file)` to get a blob url rather than using `FileReader.readAsDataURL` which generates a very large data attribute
- speeds up the display of previews and associated browser hangs when an upload finishes, especially noticeable with large images and fast connections where multiple uploads finish around the same time