### PR TITLE
🐛 Fixed gallery image changing order randomly when dropped on itself

### DIFF
--- a/lib/koenig-editor/addon/components/koenig-card-gallery.js
+++ b/lib/koenig-editor/addon/components/koenig-card-gallery.js
@@ -482,8 +482,8 @@ export default Component.extend({
     // we don't allow an image to be dropped where it would end up in the
     // same position within the gallery
     _isDropAllowed(draggableIndex, droppableIndex, position = '') {
-        // can't drop on itself
-        if (draggableIndex === droppableIndex) {
+        // can't drop on itself or when droppableIndex doesn't exist
+        if (draggableIndex === droppableIndex || typeof droppableIndex === 'undefined') {
             return false;
         }
 

--- a/lib/koenig-editor/addon/services/koenig-drag-drop-handler.js
+++ b/lib/koenig-editor/addon/services/koenig-drag-drop-handler.js
@@ -409,6 +409,9 @@ export default Service.extend({
         // make sure the indicator isn't shown due to a running timeout
         run.cancel(this._dropIndicatorTimeout);
 
+        // clear droppable insert index
+        delete this.draggableInfo.insertIndex;
+
         // reset all transforms
         this._transformedDroppables.forEach((elem) => {
             elem.style.transform = '';


### PR DESCRIPTION
no issue
- clear the cached `insertIndex` when hiding the drop position indicator
- update the gallery card's `_isDropAllowed` function to return `false` if the `droppabeIndex` (`insertIndex`) doesn't exist