### PR TITLE
Fixed drop indicator not showing if placed directly between images

### DIFF
--- a/lib/koenig-editor/addon/components/koenig-card-gallery.js
+++ b/lib/koenig-editor/addon/components/koenig-card-gallery.js
@@ -85,7 +85,8 @@ export default Component.extend({
 
         this.images.forEach((image, idx) => {
             let row = image.row;
-            let classes = ['relative', 'hide-child'];
+            let classes = [];
+            let overlayClasses = [];
 
             // start a new display row if necessary
             if (maxImagesInRow(idx)) {
@@ -96,13 +97,16 @@ export default Component.extend({
             if (!rows[row]) {
                 // first image in row
                 rows[row] = [];
-                classes.push('mr2');
+                classes.push('pr2');
+                overlayClasses.push('ml2');
             } else if (((idx + 1) % 3 === 0) || maxImagesInRow(idx + 1) || idx + 1 === noOfImages) {
                 // last image in row
-                classes.push('ml2');
+                classes.push('pl2');
+                overlayClasses.push('ml2');
             } else {
                 // middle of row
-                classes.push('ml2', 'mr2');
+                classes.push('pl2', 'pr2');
+                overlayClasses.push('ml2', 'mr2');
             }
 
             if (row > 0) {
@@ -112,7 +116,8 @@ export default Component.extend({
             let styledImage = Object.assign({}, image);
             let aspectRatio = (image.width || 1) / (image.height || 1);
             styledImage.style = htmlSafe(`flex: ${aspectRatio} 1 0%`);
-            styledImage.classes = classes.join(' ');
+            styledImage.classes = htmlSafe(classes.join(' '));
+            styledImage.overlayClasses = htmlSafe(overlayClasses.join(' '));
 
             rows[row].push(styledImage);
         });

--- a/lib/koenig-editor/addon/templates/components/koenig-card-gallery.hbs
+++ b/lib/koenig-editor/addon/templates/components/koenig-card-gallery.hbs
@@ -34,7 +34,7 @@
                             {{#each row as |image|}}
                                 <div
                                     style={{image.style}}
-                                    class={{image.classes}}
+                                    class="relative hide-child {{image.classes}}"
                                     data-image
                                 >
                                     <img
@@ -44,7 +44,7 @@
                                         class="w-100 h-100 db pe-none"
                                     >
                                     {{#unless koenigDragDropHandler.isDragging}}
-                                        <div class="bg-image-overlay-top child pe-none">
+                                        <div class="bg-image-overlay-top child pe-none {{image.overlayClasses}}">
                                             <div class="flex flex-row-reverse">
                                                 <button class="bg-white-90 pl3 pr3 br3 pe-auto" {{action "deleteImage" image}}>
                                                     {{svg-jar "koenig/kg-trash" class="fill-darkgrey w4 h4"}}


### PR DESCRIPTION
no issue
- when dragging an image, if you dragged out of the gallery then back in directly over the space between images then no indicator was shown
- switch to using padding around images rather than margin so that the mouse can be detected over the gap. Added classes to the image overlays to account for the change in sizing