### PR TITLE
Updated docs links to best equivalents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Ghost-Admin
 
-[![Build Status](https://travis-ci.org/TryGhost/Ghost-Admin.svg?branch=master)](https://travis-ci.org/TryGhost/Ghost-Admin) 
+[![Build Status](https://travis-ci.org/TryGhost/Ghost-Admin.svg?branch=master)](https://travis-ci.org/TryGhost/Ghost-Admin)
 [![Coverage Status](https://coveralls.io/repos/github/TryGhost/Ghost-Admin/badge.svg)](https://coveralls.io/github/TryGhost/Ghost-Admin)
 
 This is the home of Ember.js based admin client that ships with [Ghost](https://github.com/tryghost/ghost).
 
-**Do you want to set up a Ghost blog?** Check the [getting started guide](https://docs.ghost.org/docs/getting-started-guide)
+**Do you want to set up a Ghost blog?** Check the [getting started guide](https://docs.ghost.org/concepts/introduction/)
 
-**Do you want to modify or contribute to Ghost-Admin?** Please read the [working with Ghost-Admin](https://docs.ghost.org/docs/working-with-the-admin-client) section of our contributing guide for setup details and swing by our [forum](https://forum.ghost.org) if you need any help 😄
+**Do you want to modify or contribute to Ghost-Admin?** Please read how to [install from source](https://docs.ghost.org/install/source/) and swing by our [forum](https://forum.ghost.org) if you need any help 😄
 
 ## Have a bug or issue?
 

--- a/app/controllers/setup/three.js
+++ b/app/controllers/setup/three.js
@@ -230,7 +230,7 @@ export default Controller.extend({
             invitationsString = erroredEmails.length > 1 ? ' invitations: ' : ' invitation: ';
             message = `Failed to send ${erroredEmails.length} ${invitationsString}`;
             message += Ember.Handlebars.Utils.escapeExpression(erroredEmails.join(', '));
-            message += '. Please check your email configuration, see <a href=\'https://docs.ghost.org/docs/mail-config\' target=\'_blank\'>https://docs.ghost.org/v1.0.0/docs/mail-config</a> for instructions';
+            message += '. Please check your email configuration, see <a href=\'https://docs.ghost.org/mail/\' target=\'_blank\'>https://docs.ghost.org/mail/</a> for instructions';
 
             message = htmlSafe(message);
             notifications.showAlert(message, {type: 'error', delayed: successCount > 0, key: 'signup.send-invitations.failed'});

--- a/app/services/tour.js
+++ b/app/services/tour.js
@@ -64,7 +64,7 @@ export default Service.extend(Evented, {
         }, {
             id: 'upload-a-theme',
             title: 'Customising your publication',
-            message: 'Using custom themes, you can completely control the look and feel of your site to suit your branch. Here\'s a full guide to help: <strong><a href="https://themes.ghost.org" target="_blank">https://themes.ghost.org</a></strong>'
+            message: 'Using custom themes, you can completely control the look and feel of your site to suit your branch. Here\'s a full guide to help: <strong><a href="https://docs.ghost.org/api/handlebars-themes/" target="_blank">https://docs.ghost.org/api/handlebars-themes/</a></strong>'
         }];
     },
 

--- a/app/templates/about.hbs
+++ b/app/templates/about.hbs
@@ -11,7 +11,7 @@
                 <li><strong>Mail</strong> {{#if about.mail}}{{about.mail}}{{else}}Native{{/if}}</li>
             </ul>
             <div class="gh-env-help">
-                <a class="gh-btn" href="https://help.ghost.org" target="_blank"><span>User Documentation</span></a>
+                <a class="gh-btn" href="https://docs.ghost.org" target="_blank"><span>User Documentation</span></a>
                 <a class="gh-btn" href="https://forum.ghost.org/" target="_blank"><span>Get Help With Ghost</span></a>
             </div>
         </section>
@@ -33,7 +33,7 @@
 
             <p>Ghost is built by an incredible group of contributors from all over the world. Here are just a few of the people who helped create the version you’re using right now.</p>
 
-            <a class="gh-btn gh-btn-blue" href="https://ghost.org/developers/" target="_blank"><span>Find out how you can get involved</span></a>
+            <a class="gh-btn gh-btn-blue" href="https://docs.ghost.org/concepts/contributing/" target="_blank"><span>Find out how you can get involved</span></a>
 
         </section>
 

--- a/app/templates/components/gh-nav-menu.hbs
+++ b/app/templates/components/gh-nav-menu.hbs
@@ -12,9 +12,9 @@
             <li role="presentation">{{#link-to "about" classNames="dropdown-item" role="menuitem" tabindex="-1" data-test-nav="about"}}{{svg-jar "store"}} About Ghost{{/link-to}}</li>
             <li class="divider"></li>
             <li role="presentation">{{#link-to "team.user" session.user.slug classNames="dropdown-item" role="menuitem" tabindex="-1" data-test-nav="user-profile"}}{{svg-jar "user-circle"}} Your Profile{{/link-to}}</li>
-            <li role="presentation"><a class="dropdown-item" role="menuitem" tabindex="-1" href="https://help.ghost.org/" target="_blank">{{svg-jar "ambulance"}} Support Center</a></li>
+            <li role="presentation"><a class="dropdown-item" role="menuitem" tabindex="-1" href="https://docs.ghost.org/" target="_blank">{{svg-jar "ambulance"}} Support Center</a></li>
             <li role="presentation"><a class="dropdown-item" role="menuitem" tabindex="-1" href="https://twitter.com/intent/tweet?text=%40TryGhost+Hi%21+Can+you+help+me+with+&related=TryGhost" target="_blank" onclick="window.open(this.href, 'twitter-share', 'width=550,height=235');return false;">{{svg-jar "twitter"}} Tweet @TryGhost!</a></li>
-            <li role="presentation"><a class="dropdown-item" role="menuitem" tabindex="-1" href="https://help.ghost.org/article/7-how-to-use-ghost" target="_blank">{{svg-jar "book-open"}} How to Use Ghost</a></li>
+            <li role="presentation"><a class="dropdown-item" role="menuitem" tabindex="-1" href="https://docs.ghost.org/faq/using-ghost/" target="_blank">{{svg-jar "book-open"}} How to Use Ghost</a></li>
             <li class="divider"></li>
 
             {{#if showDropdownExtension}}

--- a/app/templates/editor.hbs
+++ b/app/templates/editor.hbs
@@ -90,7 +90,7 @@
             <div class="midgrey-l2 {{if editor.headerClass "f-supersmall pl2 pr2" "f8 pl4 pr3"}} fw3">
                 {{pluralize wordCount.wordCount "word"}}
             </div>
-            <a href="https://help.ghost.org/article/29-ghost-editor-overview" class="flex {{if editor.headerClass "pa2" "pa3"}}" target="_blank">{{svg-jar "help" class="w4 h4 stroke-midgrey-l2"}}</a>
+            <a href="https://docs.ghost.org/faq/using-the-editor/" class="flex {{if editor.headerClass "pa2" "pa3"}}" target="_blank">{{svg-jar "help" class="w4 h4 stroke-midgrey-l2"}}</a>
         </div>
 
     {{/gh-editor}}

--- a/app/templates/settings/general.hbs
+++ b/app/templates/settings/general.hbs
@@ -81,7 +81,7 @@
                             data-test-default-locale-input=true
                         }}
                         {{gh-error-message errors=settings.errors property="defaultLocale"}}
-                        <p>Default: English (<strong>en</strong>); you can add translation files to your theme for <a href="https://themes.ghost.org/docs/i18n" target="_blank" rel="noopener">any language</a></p>
+                        <p>Default: English (<strong>en</strong>); you can add translation files to your theme for <a href="https://docs.ghost.org/api/handlebars-themes/helpers/translate/" target="_blank" rel="noopener">any language</a></p>
                     {{/gh-form-group}}
                 </div>
                 {{/liquid-if}}

--- a/app/templates/settings/labs.hbs
+++ b/app/templates/settings/labs.hbs
@@ -105,7 +105,7 @@
         <div class="gh-setting">
             <div class="gh-setting-content">
                 <div class="gh-setting-title">Subscribers</div>
-                <div class="gh-setting-desc">Collect email addresses from your readers, more info in <a href="https://help.ghost.org/hc/en-us/articles/224089787-Subscribers-Beta">the docs</a></div>
+                <div class="gh-setting-desc">Collect email addresses from your readers, more info in <a href="https://docs.ghost.org/faq/enable-subscribers-feature/">the docs</a></div>
             </div>
             <div class="gh-setting-action">
                 <div class="for-checkbox">{{gh-feature-flag "subscribers"}}</div>
@@ -122,7 +122,7 @@
             }}
             <div class="gh-setting-content">
                 <div class="gh-setting-title">Redirects</div>
-                <div class="gh-setting-desc">Configure redirects for old or moved content, more info in <a href="https://docs.ghost.org/docs/redirects">the docs</a></div>
+                <div class="gh-setting-desc">Configure redirects for old or moved content, more info in <a href="https://docs.ghost.org/tutorials/implementing-redirects/">the docs</a></div>
                 {{#each uploader.errors as |error|}}
                     <div class="gh-setting-error" data-test-error="redirects">{{error.message}}</div>
                 {{/each}}

--- a/tests/acceptance/settings/design-test.js
+++ b/tests/acceptance/settings/design-test.js
@@ -384,7 +384,7 @@ describe('Acceptance: Settings - Design', function () {
                 theme.warnings = [{
                     level: 'warning',
                     rule: 'Assets such as CSS & JS must use the <code>{{asset}}</code> helper',
-                    details: '<p>The listed files should be included using the <code>{{asset}}</code> helper.  For more information, please see the <a href="http://themes.ghost.org/docs/asset">asset helper documentation</a>.</p>',
+                    details: '<p>The listed files should be included using the <code>{{asset}}</code> helper.  For more information, please see the <a href="https://docs.ghost.org/api/handlebars-themes/helpers/asset/">asset helper documentation</a>.</p>',
                     failures: [
                         {
                             ref: '/assets/dist/img/apple-touch-icon.png'
@@ -563,7 +563,7 @@ describe('Acceptance: Settings - Design', function () {
                 theme.update({warnings: [{
                     level: 'warning',
                     rule: 'Assets such as CSS & JS must use the <code>{{asset}}</code> helper',
-                    details: '<p>The listed files should be included using the <code>{{asset}}</code> helper.  For more information, please see the <a href="http://themes.ghost.org/docs/asset">asset helper documentation</a>.</p>',
+                    details: '<p>The listed files should be included using the <code>{{asset}}</code> helper.  For more information, please see the <a href="https://docs.ghost.org/api/handlebars-themes/helpers/asset/">asset helper documentation</a>.</p>',
                     failures: [
                         {
                             ref: '/assets/dist/img/apple-touch-icon.png'


### PR DESCRIPTION
This updates the all the old-style documentation links sprinkled through Ghost-Admin. Most of them were already redirecting, but it seems like a good idea to clean this up.

I've done my best to match up the context of the URL with best piece of documentation available.

@JohnONolan One thing that you might want to review more closely is the README.md file.

Matching PR for Ghost to follow.