### PR TITLE
Drop uploads in admin api

### DIFF
--- a/app/components/gh-image-uploader.js
+++ b/app/components/gh-image-uploader.js
@@ -44,7 +44,7 @@ export default Component.extend({
 
     _defaultAccept: IMAGE_MIME_TYPES,
     _defaultExtensions: IMAGE_EXTENSIONS,
-    _defaultUploadUrl: '/uploads/',
+    _defaultUploadUrl: '/images/',
     _showUnsplash: false,
 
     // Allowed actions

--- a/app/components/gh-image-uploader.js
+++ b/app/components/gh-image-uploader.js
@@ -7,6 +7,7 @@ import {
     isVersionMismatchError
 } from 'ghost-admin/services/ajax';
 import {computed} from '@ember/object';
+import {get} from '@ember/object';
 import {htmlSafe} from '@ember/string';
 import {isBlank} from '@ember/utils';
 import {isArray as isEmberArray} from '@ember/array';
@@ -245,7 +246,7 @@ export default Component.extend({
                 return xhr;
             }
         }).then((response) => {
-            let url = JSON.parse(response);
+            let url = get(JSON.parse(response), 'url');
             this._uploadSuccess(url);
         }).catch((error) => {
             this._uploadFailed(error);

--- a/app/components/gh-uploader.js
+++ b/app/components/gh-uploader.js
@@ -2,6 +2,7 @@ import Component from '@ember/component';
 import EmberObject from '@ember/object';
 import ghostPaths from 'ghost-admin/utils/ghost-paths';
 import {all, task} from 'ember-concurrency';
+import {get} from '@ember/object';
 import {isArray as isEmberArray} from '@ember/array';
 import {isEmpty} from '@ember/utils';
 import {run} from '@ember/runloop';
@@ -239,11 +240,10 @@ export default Component.extend({
             tracker.update({loaded: file.size, total: file.size});
             this._updateProgress();
 
-            // TODO: is it safe to assume we'll only get a url back?
-            let uploadUrl = JSON.parse(response);
+            let uploadResponse = JSON.parse(response);
             let result = {
                 fileName: file.name,
-                url: uploadUrl
+                url: get(uploadResponse, 'url')
             };
 
             this.get('uploadUrls')[index] = result;

--- a/app/components/gh-uploader.js
+++ b/app/components/gh-uploader.js
@@ -61,7 +61,7 @@ export default Component.extend({
     uploadUrls: null, // [{filename: 'x', url: 'y'}],
 
     // Private
-    _defaultUploadUrl: '/uploads/',
+    _defaultUploadUrl: '/images/',
     _files: null,
     _uploadTrackers: null,
 

--- a/app/controllers/setup/two.js
+++ b/app/controllers/setup/two.js
@@ -2,6 +2,7 @@
 import Controller, {inject as controller} from '@ember/controller';
 import RSVP from 'rsvp';
 import ValidationEngine from 'ghost-admin/mixins/validation-engine';
+import {get} from '@ember/object';
 import {isInvalidError} from 'ember-ajax/errors';
 import {isVersionMismatchError} from 'ghost-admin/services/ajax';
 import {inject as service} from '@ember/service';
@@ -85,7 +86,7 @@ export default Controller.extend(ValidationEngine, {
     _sendImage(user) {
         let formData = new FormData();
         let imageFile = this.get('profileImage');
-        let uploadUrl = this.get('ghostPaths.url').api('uploads');
+        let uploadUrl = this.get('ghostPaths.url').api('images');
 
         formData.append('uploadimage', imageFile, imageFile.name);
 
@@ -95,7 +96,7 @@ export default Controller.extend(ValidationEngine, {
             contentType: false,
             dataType: 'text'
         }).then((response) => {
-            let imageUrl = JSON.parse(response);
+            let imageUrl = get(JSON.parse(response), 'url');
             let usersUrl = this.get('ghostPaths.url').api('users', user.id.toString());
             user.profile_image = imageUrl;
 

--- a/app/controllers/signup.js
+++ b/app/controllers/signup.js
@@ -1,5 +1,6 @@
 import Controller from '@ember/controller';
 import {alias} from '@ember/object/computed';
+import {get} from '@ember/object';
 import {isArray as isEmberArray} from '@ember/array';
 import {
     isVersionMismatchError
@@ -98,7 +99,7 @@ export default Controller.extend({
     _sendImage: task(function* () {
         let formData = new FormData();
         let imageFile = this.get('profileImage');
-        let uploadUrl = this.get('ghostPaths.url').api('uploads');
+        let uploadUrl = this.get('ghostPaths.url').api('images');
 
         if (imageFile) {
             formData.append('uploadimage', imageFile, imageFile.name);
@@ -111,7 +112,7 @@ export default Controller.extend({
                 dataType: 'text'
             });
 
-            let imageUrl = JSON.parse(response);
+            let imageUrl = get(JSON.parse(response), 'url');
             let usersUrl = this.get('ghostPaths.url').api('users', user.id.toString());
 
             user.profile_image = imageUrl;

--- a/app/templates/settings/general.hbs
+++ b/app/templates/settings/general.hbs
@@ -95,7 +95,7 @@
         <div class="gh-setting" data-test-setting="icon">
             {{#gh-uploader
                 extensions=iconExtensions
-                uploadUrl="/uploads/icon/"
+                uploadUrl="/images/icon/"
                 onComplete=(action "imageUploaded" "icon")
                 as |uploader|
             }}

--- a/app/templates/staff/user.hbs
+++ b/app/templates/staff/user.hbs
@@ -111,7 +111,7 @@
               <button type="button" {{action "toggleUploadImageModal"}} class="edit-user-image">Edit Picture</button>
               {{#if showUploadImageModal}}
                   {{gh-fullscreen-modal "upload-image"
-                                        model=(hash model=user imageProperty="profileImage" uploadUrl="/uploads/profile-image")
+                                        model=(hash model=user imageProperty="profileImage" uploadUrl="/images/profile-image")
                                         close=(action "toggleUploadImageModal")
                                         modifier="action wide"}}
               {{/if}}

--- a/mirage/config/uploads.js
+++ b/mirage/config/uploads.js
@@ -8,7 +8,9 @@ const fileUploadResponse = function (db, {requestBody}) {
         month = `0${month}`;
     }
 
-    return `"/content/images/${year}/${month}/${file.name}"`;
+    return {
+        url: `/content/images/${year}/${month}/${file.name}`
+    };
 };
 
 export default function mockUploads(server) {

--- a/mirage/config/uploads.js
+++ b/mirage/config/uploads.js
@@ -12,6 +12,6 @@ const fileUploadResponse = function (db, {requestBody}) {
 };
 
 export default function mockUploads(server) {
-    server.post('/uploads/', fileUploadResponse, 200, {timing: 100});
-    server.post('/uploads/icon/', fileUploadResponse, 200, {timing: 100});
+    server.post('/images/', fileUploadResponse, 200, {timing: 100});
+    server.post('/images/icon/', fileUploadResponse, 200, {timing: 100});
 }

--- a/tests/acceptance/settings/general-test.js
+++ b/tests/acceptance/settings/general-test.js
@@ -130,7 +130,7 @@ describe('Acceptance: Settings - General', function () {
             ).to.not.exist;
 
             // failed upload shows error
-            this.server.post('/uploads/icon/', function () {
+            this.server.post('/images/icon/', function () {
                 return {
                     errors: [{
                         errorType: 'ValidationError',
@@ -199,7 +199,7 @@ describe('Acceptance: Settings - General', function () {
             ).to.not.exist;
 
             // failed upload shows error
-            this.server.post('/uploads/', function () {
+            this.server.post('/images/', function () {
                 return {
                     errors: [{
                         errorType: 'ValidationError',
@@ -268,7 +268,7 @@ describe('Acceptance: Settings - General', function () {
             ).to.not.exist;
 
             // failed upload shows error
-            this.server.post('/uploads/', function () {
+            this.server.post('/images/', function () {
                 return {
                     errors: [{
                         errorType: 'ValidationError',

--- a/tests/integration/components/gh-file-uploader-test.js
+++ b/tests/integration/components/gh-file-uploader-test.js
@@ -19,7 +19,7 @@ const notificationsStub = Service.extend({
 
 const stubSuccessfulUpload = function (server, delay = 0) {
     server.post('/ghost/api/v2/admin/images/', function () {
-        return [200, {'Content-Type': 'application/json'}, '"/content/images/test.png"'];
+        return [200, {'Content-Type': 'application/json'}, '{"url":"/content/images/test.png"}'];
     }, delay);
 };
 
@@ -99,7 +99,7 @@ describe('Integration: Component: gh-file-uploader', function () {
         await fileUpload('input[type="file"]', ['test'], {name: 'test.csv'});
 
         expect(uploadSuccess.calledOnce).to.be.true;
-        expect(uploadSuccess.firstCall.args[0]).to.equal('/content/images/test.png');
+        expect(uploadSuccess.firstCall.args[0]).to.eql({url: '/content/images/test.png'});
     });
 
     it('doesn\'t fire uploadSuccess action on failed upload', async function () {
@@ -313,7 +313,7 @@ describe('Integration: Component: gh-file-uploader', function () {
         await settled();
 
         expect(uploadSuccess.calledOnce).to.be.true;
-        expect(uploadSuccess.firstCall.args[0]).to.equal('/content/images/test.png');
+        expect(uploadSuccess.firstCall.args[0]).to.eql({url: '/content/images/test.png'});
     });
 
     it('validates extension by default', async function () {

--- a/tests/integration/components/gh-file-uploader-test.js
+++ b/tests/integration/components/gh-file-uploader-test.js
@@ -18,13 +18,13 @@ const notificationsStub = Service.extend({
 });
 
 const stubSuccessfulUpload = function (server, delay = 0) {
-    server.post('/ghost/api/v2/admin/uploads/', function () {
+    server.post('/ghost/api/v2/admin/images/', function () {
         return [200, {'Content-Type': 'application/json'}, '"/content/images/test.png"'];
     }, delay);
 };
 
 const stubFailedUpload = function (server, code, error, delay = 0) {
-    server.post('/ghost/api/v2/admin/uploads/', function () {
+    server.post('/ghost/api/v2/admin/images/', function () {
         return [code, {'Content-Type': 'application/json'}, JSON.stringify({
             errors: [{
                 errorType: error,
@@ -41,7 +41,7 @@ describe('Integration: Component: gh-file-uploader', function () {
 
     beforeEach(function () {
         server = new Pretender();
-        this.set('uploadUrl', '/ghost/api/v2/admin/uploads/');
+        this.set('uploadUrl', '/ghost/api/v2/admin/images/');
 
         this.owner.register('service:notifications', notificationsStub);
     });
@@ -86,7 +86,7 @@ describe('Integration: Component: gh-file-uploader', function () {
         await fileUpload('input[type="file"]', ['test'], {name: 'test.csv'});
 
         expect(server.handledRequests.length).to.equal(1);
-        expect(server.handledRequests[0].url).to.equal('/ghost/api/v2/admin/uploads/');
+        expect(server.handledRequests[0].url).to.equal('/ghost/api/v2/admin/images/');
     });
 
     it('fires uploadSuccess action on successful upload', async function () {
@@ -185,7 +185,7 @@ describe('Integration: Component: gh-file-uploader', function () {
     });
 
     it('handles file too large error directly from the web server', async function () {
-        server.post('/ghost/api/v2/admin/uploads/', function () {
+        server.post('/ghost/api/v2/admin/images/', function () {
             return [413, {}, ''];
         });
         await render(hbs`{{gh-file-uploader url=uploadUrl}}`);
@@ -205,7 +205,7 @@ describe('Integration: Component: gh-file-uploader', function () {
     });
 
     it('handles unknown failure', async function () {
-        server.post('/ghost/api/v2/admin/uploads/', function () {
+        server.post('/ghost/api/v2/admin/images/', function () {
             return [500, {'Content-Type': 'application/json'}, ''];
         });
         await render(hbs`{{gh-file-uploader url=uploadUrl}}`);

--- a/tests/integration/components/gh-image-uploader-test.js
+++ b/tests/integration/components/gh-image-uploader-test.js
@@ -30,7 +30,7 @@ const sessionStub = Service.extend({
 
 const stubSuccessfulUpload = function (server, delay = 0) {
     server.post('/ghost/api/v2/admin/images/', function () {
-        return [200, {'Content-Type': 'application/json'}, '"/content/images/test.png"'];
+        return [200, {'Content-Type': 'application/json'}, '{"url":"/content/images/test.png"}'];
     }, delay);
 };
 

--- a/tests/integration/components/gh-image-uploader-test.js
+++ b/tests/integration/components/gh-image-uploader-test.js
@@ -29,13 +29,13 @@ const sessionStub = Service.extend({
 });
 
 const stubSuccessfulUpload = function (server, delay = 0) {
-    server.post('/ghost/api/v2/admin/uploads/', function () {
+    server.post('/ghost/api/v2/admin/images/', function () {
         return [200, {'Content-Type': 'application/json'}, '"/content/images/test.png"'];
     }, delay);
 };
 
 const stubFailedUpload = function (server, code, error, delay = 0) {
-    server.post('/ghost/api/v2/admin/uploads/', function () {
+    server.post('/ghost/api/v2/admin/images/', function () {
         return [code, {'Content-Type': 'application/json'}, JSON.stringify({
             errors: [{
                 errorType: error,
@@ -84,7 +84,7 @@ describe('Integration: Component: gh-image-uploader', function () {
         await fileUpload('input[type="file"]', ['test'], {name: 'test.png'});
 
         expect(server.handledRequests.length).to.equal(1);
-        expect(server.handledRequests[0].url).to.equal('/ghost/api/v2/admin/uploads/');
+        expect(server.handledRequests[0].url).to.equal('/ghost/api/v2/admin/images/');
         expect(server.handledRequests[0].requestHeaders.Authorization).to.be.undefined;
     });
 
@@ -183,7 +183,7 @@ describe('Integration: Component: gh-image-uploader', function () {
     });
 
     it('handles file too large error directly from the web server', async function () {
-        server.post('/ghost/api/v2/admin/uploads/', function () {
+        server.post('/ghost/api/v2/admin/images/', function () {
             return [413, {}, ''];
         });
         await render(hbs`{{gh-image-uploader image=image update=(action update)}}`);
@@ -203,7 +203,7 @@ describe('Integration: Component: gh-image-uploader', function () {
     });
 
     it('handles unknown failure', async function () {
-        server.post('/ghost/api/v2/admin/uploads/', function () {
+        server.post('/ghost/api/v2/admin/images/', function () {
             return [500, {'Content-Type': 'application/json'}, ''];
         });
         await render(hbs`{{gh-image-uploader image=image update=(action update)}}`);

--- a/tests/integration/components/gh-uploader-test.js
+++ b/tests/integration/components/gh-uploader-test.js
@@ -10,7 +10,7 @@ import {setupRenderingTest} from 'ember-mocha';
 
 const stubSuccessfulUpload = function (server, delay = 0) {
     server.post('/ghost/api/v2/admin/images/', function () {
-        return [200, {'Content-Type': 'application/json'}, '"/content/images/test.png"'];
+        return [200, {'Content-Type': 'application/json'}, '{"url": "/content/images/test.png"}'];
     }, delay);
 };
 

--- a/tests/integration/components/gh-uploader-test.js
+++ b/tests/integration/components/gh-uploader-test.js
@@ -9,13 +9,13 @@ import {run} from '@ember/runloop';
 import {setupRenderingTest} from 'ember-mocha';
 
 const stubSuccessfulUpload = function (server, delay = 0) {
-    server.post('/ghost/api/v2/admin/uploads/', function () {
+    server.post('/ghost/api/v2/admin/images/', function () {
         return [200, {'Content-Type': 'application/json'}, '"/content/images/test.png"'];
     }, delay);
 };
 
 const stubFailedUpload = function (server, code, error, delay = 0) {
-    server.post('/ghost/api/v2/admin/uploads/', function () {
+    server.post('/ghost/api/v2/admin/images/', function () {
         return [code, {'Content-Type': 'application/json'}, JSON.stringify({
             errors: [{
                 errorType: error,
@@ -51,7 +51,7 @@ describe('Integration: Component: gh-uploader', function () {
 
             let [lastRequest] = server.handledRequests;
             expect(server.handledRequests.length).to.equal(1);
-            expect(lastRequest.url).to.equal('/ghost/api/v2/admin/uploads/');
+            expect(lastRequest.url).to.equal('/ghost/api/v2/admin/images/');
             // requestBody is a FormData object
             // this will fail in anything other than Chrome and Firefox
             // https://developer.mozilla.org/en-US/docs/Web/API/FormData#Browser_compatibility
@@ -136,7 +136,7 @@ describe('Integration: Component: gh-uploader', function () {
 
         it('onComplete returns results in same order as selected', async function () {
             // first request has a delay to simulate larger file
-            server.post('/ghost/api/v2/admin/uploads/', function () {
+            server.post('/ghost/api/v2/admin/images/', function () {
                 // second request has no delay to simulate small file
                 stubSuccessfulUpload(server, 0);
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/10438

@kevinansfield changed `/uploads` endpoints to `/images` and updated response handling for those endpoints to use new structure (`{url: 'image_url'}`). Would love to receive feedback on possible other places that might be affected by the response structure change