### PR TITLE
🐛 Post -> Page in Page PSM and delete modal

### DIFF
--- a/app/templates/components/gh-post-settings-menu.hbs
+++ b/app/templates/components/gh-post-settings-menu.hbs
@@ -357,7 +357,7 @@
                         <div class="settings-menu-content settings-menu-content-codeinjection">
                             <form {{action "discardEnter" on="submit"}}>
                                 {{#gh-form-group errors=post.errors hasValidated=post.hasValidated property="codeinjectionHead"}}
-                                    <label for="codeinjection-head">Post Header <code>\{{ghost_head}}</code></label>
+                                    <label for="codeinjection-head">{{capitalize post.displayName}} Header <code>\{{ghost_head}}</code></label>
                                     {{gh-cm-editor codeinjectionHeadScratch
                                         id="post-setting-codeinjection-head"
                                         class="post-setting-codeinjection"
@@ -370,7 +370,7 @@
                                 {{/gh-form-group}}
 
                                 {{#gh-form-group errors=post.errors hasValidated=post.hasValidated property="codeinjectionFoot"}}
-                                    <label for="codeinjection-foot">Post Footer <code>\{{ghost_foot}}</code></label>
+                                    <label for="codeinjection-foot">{{capitalize post.displayName}} Footer <code>\{{ghost_foot}}</code></label>
                                     {{gh-cm-editor codeinjectionFootScratch
                                         id="post-setting-codeinjection-foot"
                                         class="post-setting-codeinjection"

--- a/app/templates/components/gh-post-settings-menu.hbs
+++ b/app/templates/components/gh-post-settings-menu.hbs
@@ -145,7 +145,7 @@
                     onTemplateSelect=(action (mut post.customTemplate))}}
 
                 {{#unless post.isNew}}
-                    <button type="button" class="gh-btn gh-btn-link gh-btn-icon settings-menu-delete-button" {{action "deletePost"}}><span>{{svg-jar "trash"}} Delete Post</span></button>
+                    <button type="button" class="gh-btn gh-btn-link gh-btn-icon settings-menu-delete-button" {{action "deletePost"}}><span>{{svg-jar "trash"}} Delete {{capitalize post.displayName}}</span></button>
                 {{/unless}}
 
                 </form>

--- a/app/templates/components/modal-delete-post.hbs
+++ b/app/templates/components/modal-delete-post.hbs
@@ -1,5 +1,5 @@
 <header class="modal-header">
-    <h1>Are you sure you want to delete this post?</h1>
+    <h1>Are you sure you want to delete this {{post.displayName}}?</h1>
 </header>
 <a class="close" href="" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
 


### PR DESCRIPTION
Closes tryghost/ghost#10577

- Update templates to use `post.displayName` rather than hard-coded `Post`

Fixed three separate things:
 - Code injection
 - Delete ... action button
 - Delete ... modal