### PR TITLE
Used ember-exam to split tests and run in parallel on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   - yarn
 
 script:
-  - npm run lint:js && COVERAGE=true npm test
+  - npm run lint:js && COVERAGE=true npm run test
 
 after_success:
   - npm run coverage

--- a/config/coverage.js
+++ b/config/coverage.js
@@ -1,0 +1,4 @@
+/* eslint-env node */
+module.exports = {
+    parallel: true
+};

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   "scripts": {
     "start": "ember serve",
     "build": "ember build",
-    "test": "ember test",
+    "test": "ember exam --split 2 --parallel",
     "lint:js": "eslint .",
-    "coverage": "cat ./coverage/lcov.info | coveralls"
+    "coverage": "ember coverage-merge && cat ./coverage/lcov.info | coveralls"
   },
   "engines": {
     "node": ">= 6"
@@ -70,6 +70,7 @@
     "ember-concurrency": "0.9.0",
     "ember-data": "3.8.0",
     "ember-drag-drop": "0.4.8",
+    "ember-exam": "2.0.3",
     "ember-export-application-global": "2.0.0",
     "ember-fetch": "6.4.0",
     "ember-in-viewport": "~3.0.3",

--- a/testem.js
+++ b/testem.js
@@ -14,6 +14,7 @@ module.exports = {
     framework: 'mocha',
     test_page: 'tests/index.html?hidepassed',
     disable_watching: true,
+    parallel: process.env.EMBER_EXAM_SPLIT_COUNT || 1,
     launch_in_ci,
     launch_in_dev: [
         'Chrome',

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,7 +1,10 @@
 import Application from '../app';
 import config from '../config/environment';
+import loadEmberExam from 'ember-exam/test-support/load';
 import registerWaiter from 'ember-raf-scheduler/test-support/register-waiter';
 import {setApplication} from '@ember/test-helpers';
+
+loadEmberExam();
 
 setApplication(Application.create(config.APP));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3180,6 +3180,16 @@ cli-spinners@^2.0.0:
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.0.0.tgz#4b078756fc17a8f72043fdc9f1f14bf4fa87e2df"
   integrity sha512-yiEBmhaKPPeBj7wWm4GEdtPZK940p9pl3EANIrnJ3JnvWyrPjcFcsEq6qRUuQ7fzB0+Y82ld3p6B34xo95foWw==
 
+cli-table3@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.5.1.tgz#0252372d94dfc40dbd8df06005f48f31f656f202"
+  integrity sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==
+  dependencies:
+    object-assign "^4.1.0"
+    string-width "^2.1.1"
+  optionalDependencies:
+    colors "^1.1.2"
+
 cli-table@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cli-table/-/cli-table-0.3.1.tgz#f53b05266a8b1a0b934b3d0821e6e2dc5914ae23"
@@ -3290,6 +3300,11 @@ colors@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
   integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
+
+colors@^1.1.2:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.3.tgz#39e005d546afe01e01f9c4ca8fa50f686a01205d"
+  integrity sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==
 
 colors@~1.1.2:
   version "1.1.2"
@@ -4799,6 +4814,19 @@ ember-element-resize-detector@~0.4.0:
     ember-cli-babel "^6.6.0"
     ember-cli-htmlbars "^2.0.1"
 
+ember-exam@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/ember-exam/-/ember-exam-2.0.3.tgz#74ebcdbbb5658c7420e8960bd04d1e291f728c9f"
+  integrity sha512-FLuDRkpUXQqjd7A3siPbPcMmUmUZlm1lumWatC/3mxph3kV+c2FIfft83CJKjkhK5i7j7jRPa49LimreC6UmbQ==
+  dependencies:
+    chalk "^2.1.0"
+    cli-table3 "^0.5.1"
+    debug "^4.1.0"
+    ember-cli-babel "^7.4.0"
+    execa "^1.0.0"
+    fs-extra "^7.0.1"
+    rimraf "^2.6.2"
+
 ember-export-application-global@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ember-export-application-global/-/ember-export-application-global-2.0.0.tgz#8d6d7619ac8a1a3f8c43003549eb21ebed685bd2"
@@ -6072,7 +6100,7 @@ from2@^2.1.0, from2@^2.1.1:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
 
-fs-extra@7.0.1, fs-extra@^7.0.0:
+fs-extra@7.0.1, fs-extra@^7.0.0, fs-extra@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
   integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
@@ -11044,7 +11072,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-"string-width@^1.0.2 || 2", string-width@^2.1.0:
+"string-width@^1.0.2 || 2", string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==


### PR DESCRIPTION
no issue
- improves test run times by splitting the tests into multiple groups and running each in their own browser instance
  - settled on 2 browser instances as that seems to best fit within Travis' memory and CPU constraints
- updated ember-cli-code-coverage config to work with parallel builds