### PR TITLE
Updated Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,8 @@
   "ignoreDeps": [
     "ember-drag-drop",
     "normalize.css",
-    "validator"
+    "validator",
+    "ember-exam"
   ],
   "ignorePaths": ["lib/koenig-editor/package.json"],
   "travis": { "enabled": true },
@@ -24,6 +25,10 @@
     {
       "groupName": "ember core",
       "packageNames": ["ember-source", "ember-cli", "ember-data"]
+    },
+    {
+      "groupName": "ember testing",
+      "packageNames": ["ember-mocha", "ember-exam", "testem"]
     },
     {
       "groupName": "ember addons",


### PR DESCRIPTION
no issue
- ignore `ember-exam` until it's compatible with latest stable of `ember-mocha`
  - see https://github.com/ember-cli/ember-exam/issues/238
- moved `ember-exam`, `ember-mocha`, and `testem` into their own group so changes to test env don't cause addon upgrade PRs to fail