### PR TITLE
Reconfigure Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,7 +32,8 @@
     },
     {
       "groupName": "ember addons",
-      "packagePatterns": ["^ember", "^@ember", "^broccoli", "^liquid"]
+      "packagePatterns": ["^ember", "^@ember", "^broccoli", "^liquid"],
+      "excludePackageNames": ["ember-source", "ember-cli", "ember-data", "ember-mocha", "ember-exam"]
     },
     {
       "groupName": "css processors",


### PR DESCRIPTION
no issue
- explicitly exclude packages from the "ember addons" group that should be matched by other groups