### PR TITLE
Update Renovate Configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,8 @@
     "group:jsTestMonMajor",
     "group:linters",
     ":maintainLockFilesWeekly",
-    "schedule:earlyMondays"
+    "schedule:earlyMondays",
+    ":autoMergePatch"
   ],
   "ignoreDeps": [
     "ember-drag-drop",
@@ -16,10 +17,6 @@
   "travis": { "enabled": true },
   "node": {
     "supportPolicy": ["lts_latest"]
-  },
-  "separateMinorPatch": true,
-  "patch": {
-    "automerge": true
   },
   "packageRules": [
     {


### PR DESCRIPTION
I believe this config preset is a slightly better version of the longform that was there, but feel free to ignore this if I'm wrong :)

- simplify automerge rules using `:automergePatch` config preset
- See: https://renovatebot.com/docs/presets-default/#automergepatch


