### PR TITLE
Made date input manual editable

### DIFF
--- a/app/templates/components/gh-date-time-picker.hbs
+++ b/app/templates/components/gh-date-time-picker.hbs
@@ -8,7 +8,7 @@
     }}
         {{#dp.trigger tabindex="-1" data-test-date-time-picker-datepicker=true}}
             <div class="gh-date-time-picker-date {{if dateError "error"}}">
-                <input type="text" readonly value={{moment-format _date "MM/DD/YYYY"}} disabled={{disabled}} data-test-date-time-picker-date-input>
+                <input type="text" value={{moment-format _date "MM/DD/YYYY"}} disabled={{disabled}} data-test-date-time-picker-date-input>
                 {{svg-jar "calendar"}}
             </div>
         {{/dp.trigger}}


### PR DESCRIPTION
closes #9256

Remove the `readonly` attribute.