### PR TITLE
Gscan styles

### DIFF
--- a/app/styles/layouts/settings.css
+++ b/app/styles/layouts/settings.css
@@ -598,7 +598,7 @@
 
 /*Errors */
 .theme-validation-container {
-    max-height: calc(100vh - 12vw - 140px);
+    max-height: calc(100vh - 12vw - 110px);
     overflow-y: scroll;
     margin: -40px -40px 0;
     padding: 40px 40px 0;

--- a/app/styles/layouts/settings.css
+++ b/app/styles/layouts/settings.css
@@ -616,6 +616,7 @@
 
 .theme-validation-errortype {
     font-size: 1.8rem;
+    margin-top: 32px;
 }
 
 .theme-validation-errortype.fatal {
@@ -623,8 +624,8 @@
 }
 
 .theme-validation-item {
-    margin: 0 0 15px;
-    padding: 15px 20px;
+    margin: 12px 0 0;
+    padding: 12px 16px;
     border: 1px solid #e5eff5;
     border-radius: 5px;
     display: flex;
@@ -633,13 +634,33 @@
 
 .theme-validation-item h4 {
     margin: 0;
-    font-size: 1.5rem;
-    font-weight: 500;
+    font-size: 1.4rem;
+    font-weight: 400;
+    line-height: 1.5em;
+}
+
+.theme-validation-item.theme-error {
+    background: color-mod(var(--red) alpha(5%));
+    border-color: color-mod(var(--red) alpha(25%));
+}
+
+.theme-validation-item.theme-warning {
+    background: color-mod(var(--yellow) alpha(10%));
+    border-color: color-mod(var(--yellow) alpha(45%));
+}
+
+.theme-validation-list code,
+.theme-validation-rule-text code {
+    font-size: 0.9em;
 }
 
 .theme-validation-item h6 {
-    font-size: 1.4rem;
+    font-size: 1.3rem;
     font-weight: 500;
+}
+
+.theme-validation-item {
+    background: var(--whitegrey-l2);
 }
 
 .theme-validation-toggle-details {
@@ -650,6 +671,7 @@
     padding: 0;
     color: var(--darkgrey);
     text-decoration: none!important;
+    font-size: 1.3rem;
 }
 
 .theme-validation-rule-icon {
@@ -665,7 +687,13 @@
 }
 
 .theme-validation-details {
-    margin-top: 15px;
+    margin-top: 12px;
+    font-size: 1.3rem;
+    font-weight: 300;
+}
+
+p.theme-validation-details {
+    font-size: 1.3rem;
 }
 
 .theme-validation-list {

--- a/app/styles/layouts/settings.css
+++ b/app/styles/layouts/settings.css
@@ -596,6 +596,10 @@
     margin-top: 25px;
 }
 
+.theme-validation-summary {
+    
+}
+
 /*Errors */
 .theme-validation-errors {
     padding-left: 0;

--- a/app/styles/layouts/settings.css
+++ b/app/styles/layouts/settings.css
@@ -695,7 +695,7 @@
     display: flex;
     justify-content: space-between;
     flex-grow: 1;
-    align-items: start;
+    align-items: flex-start;
     padding: 0;
     color: var(--darkgrey);
     text-decoration: none!important;

--- a/app/styles/layouts/settings.css
+++ b/app/styles/layouts/settings.css
@@ -596,37 +596,7 @@
     margin-top: 25px;
 }
 
-.theme-validation-summary {
-    
-}
-
 /*Errors */
-.theme-validation-errors {
-    padding-left: 0;
-}
-
-.theme-validation-errors p {
-    margin-bottom: 0;
-}
-
-.theme-validation-errordescription {
-    margin-top: 1em;
-    margin-bottom: 0.5em;
-}
-
-.theme-validation-errordescription span {
-    font-weight: 600;
-}
-
-.theme-validation-errortype {
-    font-size: 1.8rem;
-    margin-top: 32px;
-}
-
-.theme-validation-errortype.fatal {
-    color: var(--red);
-}
-
 .theme-validation-item {
     margin: 12px 0 0;
     padding: 12px 16px;
@@ -643,6 +613,7 @@
     line-height: 1.5em;
 }
 
+.theme-validation-item.theme-fatal-error,
 .theme-validation-item.theme-error {
     background: color-mod(var(--red) alpha(5%));
     border-color: color-mod(var(--red) alpha(25%));
@@ -651,6 +622,39 @@
 .theme-validation-item.theme-warning {
     background: color-mod(var(--yellow) alpha(10%));
     border-color: color-mod(var(--yellow) alpha(45%));
+}
+
+.theme-validation-item.theme-fatal-error .theme-validation-rule-text::before,
+.theme-validation-item.theme-error .theme-validation-rule-text::before,
+.theme-validation-item.theme-warning .theme-validation-rule-text::before
+ {
+    display: inline-block;
+    text-transform: uppercase;
+    font-size: 1.3rem;
+    font-weight: 600;
+    margin-right: 2px;
+}
+
+.theme-validation-item.theme-fatal-error .theme-validation-rule-text::before {
+    content: "Fatal error:";
+}
+
+.theme-validation-item.theme-error .theme-validation-rule-text::before {
+    content: "Error:";
+}
+
+.theme-validation-item.theme-fatal-error .theme-validation-rule-text::before,
+.theme-validation-item.theme-error .theme-validation-rule-text::before {
+    color: var(--red);
+}
+
+.theme-validation-item.theme-warning .theme-validation-rule-text::before {
+    content: "Warning:";
+    color: color-mod(var(--yellow) l(-12%) s(+5%));
+}
+
+.theme-validation-list ul {
+    list-style: disc;
 }
 
 .theme-validation-list code,
@@ -686,20 +690,20 @@
     transition: all 0.1s ease-out;
 }
 
+.theme-validation-rule-icon svg {
+    margin-top: 3px;
+}
+
 .theme-validation-rule-icon svg path {
     fill: var(--midgrey);
 }
 
 .theme-validation-details {
-    margin-top: 12px;
+    margin-top: 20px;
     font-size: 1.3rem;
     font-weight: 300;
 }
 
 p.theme-validation-details {
     font-size: 1.3rem;
-}
-
-.theme-validation-list {
-    margin-top: 1em;
 }

--- a/app/styles/layouts/settings.css
+++ b/app/styles/layouts/settings.css
@@ -611,6 +611,8 @@
     border-radius: 5px;
     display: flex;
     flex-direction: column;
+    background: var(--whitegrey);
+    border: 1px solid var(--lightgrey);
 }
 
 .theme-validation-item h4 {
@@ -620,44 +622,55 @@
     line-height: 1.5em;
 }
 
-.theme-validation-item.theme-fatal-error,
-.theme-validation-item.theme-error {
-    background: color-mod(var(--red) alpha(5%));
-    border-color: color-mod(var(--red) alpha(25%));
+.theme-validation-rule-text {
+    flex-grow: 1;
 }
 
-.theme-validation-item.theme-warning {
-    background: color-mod(var(--yellow) alpha(10%));
-    border-color: color-mod(var(--yellow) alpha(45%));
+.theme-validation-item.theme-fatal-error {
+    background: color-mod(var(--red) alpha(0.04));
+    border: 1px solid color-mod(var(--red) alpha(0.4));
 }
 
 .theme-validation-item.theme-fatal-error .theme-validation-rule-text::before,
 .theme-validation-item.theme-error .theme-validation-rule-text::before,
 .theme-validation-item.theme-warning .theme-validation-rule-text::before
- {
-    display: inline-block;
-    text-transform: uppercase;
-    font-size: 1.3rem;
+{
     font-weight: 600;
-    margin-right: 2px;
 }
 
 .theme-validation-item.theme-fatal-error .theme-validation-rule-text::before {
     content: "Fatal error:";
+    color: var(--red);
 }
 
 .theme-validation-item.theme-error .theme-validation-rule-text::before {
     content: "Error:";
 }
 
-.theme-validation-item.theme-fatal-error .theme-validation-rule-text::before,
-.theme-validation-item.theme-error .theme-validation-rule-text::before {
-    color: var(--red);
-}
-
 .theme-validation-item.theme-warning .theme-validation-rule-text::before {
     content: "Warning:";
-    color: color-mod(var(--yellow) l(-12%) s(+5%));
+}
+
+.theme-fatal-error .theme-validation-type-label::before,
+.theme-error .theme-validation-type-label::before,
+.theme-warning .theme-validation-type-label::before {
+    content: "";
+    display: block;
+    border-top-right-radius: 2px;
+    border-bottom-right-radius: 2px;
+    width: 8px;
+    height: 16px;
+    margin-top: 3px;
+    margin-left: -17px;
+}
+
+.theme-fatal-error .theme-validation-type-label::before, 
+.theme-error .theme-validation-type-label::before {
+    background: color-mod(var(--red) alpha(0.85));
+}
+
+.theme-warning .theme-validation-type-label::before {
+    background: color-mod(var(--yellow));
 }
 
 .theme-validation-list ul {
@@ -682,7 +695,7 @@
     display: flex;
     justify-content: space-between;
     flex-grow: 1;
-    align-items: center;
+    align-items: start;
     padding: 0;
     color: var(--darkgrey);
     text-decoration: none!important;
@@ -706,9 +719,11 @@
 }
 
 .theme-validation-details {
-    margin-top: 20px;
+    margin-top: 12px;
+    padding-top: 12px;
     font-size: 1.3rem;
     font-weight: 300;
+    border-top: 1px solid var(--lightgrey);
 }
 
 p.theme-validation-details {

--- a/app/styles/layouts/settings.css
+++ b/app/styles/layouts/settings.css
@@ -597,6 +597,13 @@
 }
 
 /*Errors */
+.theme-validation-container {
+    max-height: calc(100vh - 12vw - 140px);
+    overflow-y: scroll;
+    margin: -40px -40px 0;
+    padding: 40px 40px 0;
+}
+
 .theme-validation-item {
     margin: 12px 0 0;
     padding: 12px 16px;

--- a/app/templates/components/gh-theme-error-li.hbs
+++ b/app/templates/components/gh-theme-error-li.hbs
@@ -1,13 +1,16 @@
 <a href="" class="theme-validation-toggle-details" {{action "toggleDetails"}} data-test-toggle-details>
-    <h4 class="theme-validation-rule-text">
-        {{{error.rule}}}
-    </h4>
-    <div class="theme-validation-rule-icon">
-        {{#if showDetails}}
-            {{svg-jar "arrow-down"}}
-        {{else}}
-            {{svg-jar "arrow-right"}}
-        {{/if}}
+    <div class="theme-validation-type-label"></div>
+    <div class="flex items-center flex-auto">
+        <h4 class="theme-validation-rule-text">
+            {{{error.rule}}}
+        </h4>
+        <div class="theme-validation-rule-icon">
+            {{#if showDetails}}
+                {{svg-jar "arrow-down"}}
+            {{else}}
+                {{svg-jar "arrow-right"}}
+            {{/if}}
+        </div>
     </div>
 </a>
 

--- a/app/templates/components/modal-theme-warnings.hbs
+++ b/app/templates/components/modal-theme-warnings.hbs
@@ -14,7 +14,7 @@
         {{#if this.fatalErrors}}
             <div class="theme-validation-errordescription">
                 <h2 class="theme-validation-errortype fatal">Fatal Errors</h2>
-                <p><em>(Must-fix to activate theme)</em></p>
+                <p>Must-fix to activate theme</p>
             </div>
         {{/if}}
         {{#each this.fatalErrors as |error|}}
@@ -26,11 +26,11 @@
         {{#if this.errors}}
             <div class="theme-validation-errordescription">
                 <h2 class="theme-validation-errortype">Errors</h2>
-                <p><em>(Very recommended to fix, functionality <span>could</span> be restricted)</em></p>
+                <p>Very recommended to fix, functionality <span>could</span> be restricted</p>
             </div>
         {{/if}}
         {{#each this.errors as |error|}}
-            <li class="theme-validation-item">
+            <li class="theme-validation-item theme-error">
                 {{gh-theme-error-li error=error}}
             </li>
         {{/each}}
@@ -41,7 +41,7 @@
             </div>
         {{/if}}
         {{#each this.warnings as |error|}}
-            <li class="theme-validation-item">
+            <li class="theme-validation-item theme-warning">
                 {{gh-theme-error-li error=error}}
             </li>
         {{/each}}

--- a/app/templates/components/modal-theme-warnings.hbs
+++ b/app/templates/components/modal-theme-warnings.hbs
@@ -13,7 +13,7 @@
     <div class="modal-body">
         {{#if this.fatalErrors}}
             <div>
-                <h2 class="mb0 mt2 f5 fw6 red">Fatal Errors</h2>
+                <h2 class="mb0 mt4 f5 fw6 red">Fatal Errors</h2>
                 <p class="mb2 red">Must-fix to activate theme</p>
             </div>
             <ul class="pa0" data-test-theme-warnings>
@@ -27,7 +27,7 @@
 
         {{#if this.errors}}
             <div>
-                <h2 class="mb0 mt2 f5 fw6">Errors</h2>
+                <h2 class="mb0 mt4 f5 fw6">Errors</h2>
                 <p class="mb2">Very recommended to fix, functionality <span>could</span> be restricted</p>
             </div>
         
@@ -42,7 +42,7 @@
 
         {{#if (and this.warnings (or this.fatalErrors this.errors))}}
             <div>
-                <h2 class="mb0 mt2 f5 fw6">Warnings</h2>
+                <h2 class="mb0 mt4 f5 fw6">Warnings</h2>
             </div>
             <ul class="pa0" data-test-theme-warnings>
             {{#each this.warnings as |error|}}

--- a/app/templates/components/modal-theme-warnings.hbs
+++ b/app/templates/components/modal-theme-warnings.hbs
@@ -1,16 +1,16 @@
-<header class="modal-header">
-    <h1 data-test-theme-warnings-title>
-        {{#unless this.canActivate}}
-            {{this.title}}
-        {{else}}
-            {{this.title}} with {{#if this.errors}}errors{{else}}warnings{{/if}}
-        {{/unless}}
-    </h1>
-</header>
-<a class="close" href="#" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
+<div class="theme-validation-container">
+    <header class="modal-header">
+        <h1 data-test-theme-warnings-title>
+            {{#unless this.canActivate}}
+                {{this.title}}
+            {{else}}
+                {{this.title}} with {{#if this.errors}}errors{{else}}warnings{{/if}}
+            {{/unless}}
+        </h1>
+    </header>
+    <a class="close" href="#" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
 
-<div class="modal-body">
-    
+    <div class="modal-body">
         {{#if this.fatalErrors}}
             <div>
                 <h2 class="mb0 mt2 f5 fw6 red">Fatal Errors</h2>
@@ -52,7 +52,7 @@
             {{/each}}
             </ul>
         {{/if}}
-
+    </div>
 </div>
 
 <div class="modal-footer">

--- a/app/templates/components/modal-theme-warnings.hbs
+++ b/app/templates/components/modal-theme-warnings.hbs
@@ -30,7 +30,7 @@
                 <h2 class="mb0 mt4 f5 fw6">Errors</h2>
                 <p class="mb2">Highly recommended to fix, functionality <span>could</span> be restricted</p>
             </div>
-        
+
             <ul class="pa0" data-test-theme-warnings>
             {{#each this.errors as |error|}}
                 <li class="theme-validation-item theme-error">
@@ -44,6 +44,8 @@
             <div>
                 <h2 class="mb0 mt4 f5 fw6">Warnings</h2>
             </div>
+        {{/if}}
+        {{#if this.warnings}}
             <ul class="pa0" data-test-theme-warnings>
             {{#each this.warnings as |error|}}
                 <li class="theme-validation-item theme-warning">

--- a/app/templates/components/modal-theme-warnings.hbs
+++ b/app/templates/components/modal-theme-warnings.hbs
@@ -10,43 +10,49 @@
 <a class="close" href="#" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
 
 <div class="modal-body">
-    <ul class="theme-validation-errors" data-test-theme-warnings>
+    
         {{#if this.fatalErrors}}
-            <div class="theme-validation-errordescription">
-                <h2 class="theme-validation-errortype fatal">Fatal Errors</h2>
-                <p>Must-fix to activate theme</p>
+            <div>
+                <h2 class="mb0 mt2 f5 fw6 red">Fatal Errors</h2>
+                <p class="mb2 red">Must-fix to activate theme</p>
             </div>
+            <ul class="pa0" data-test-theme-warnings>
+            {{#each this.fatalErrors as |error|}}
+                <li class="theme-validation-item theme-fatal-error">
+                    {{gh-theme-error-li error=error}}
+                </li>
+            {{/each}}
+            </ul>
         {{/if}}
-        {{#each this.fatalErrors as |error|}}
-            <li class="theme-validation-item">
-                {{gh-theme-error-li error=error}}
-            </li>
-        {{/each}}
 
         {{#if this.errors}}
-            <div class="theme-validation-errordescription">
-                <h2 class="theme-validation-errortype">Errors</h2>
-                <p>Very recommended to fix, functionality <span>could</span> be restricted</p>
+            <div>
+                <h2 class="mb0 mt2 f5 fw6">Errors</h2>
+                <p class="mb2">Very recommended to fix, functionality <span>could</span> be restricted</p>
             </div>
+        
+            <ul class="pa0" data-test-theme-warnings>
+            {{#each this.errors as |error|}}
+                <li class="theme-validation-item theme-error">
+                    {{gh-theme-error-li error=error}}
+                </li>
+            {{/each}}
+            </ul>
         {{/if}}
-        {{#each this.errors as |error|}}
-            <li class="theme-validation-item theme-error">
-                {{gh-theme-error-li error=error}}
-            </li>
-        {{/each}}
 
         {{#if (and this.warnings (or this.fatalErrors this.errors))}}
-            <div class="theme-validation-errordescription">
-                <h2 class="theme-validation-errortype">Warnings</h2>
+            <div>
+                <h2 class="mb0 mt2 f5 fw6">Warnings</h2>
             </div>
+            <ul class="pa0" data-test-theme-warnings>
+            {{#each this.warnings as |error|}}
+                <li class="theme-validation-item theme-warning">
+                    {{gh-theme-error-li error=error}}
+                </li>
+            {{/each}}
+            </ul>
         {{/if}}
-        {{#each this.warnings as |error|}}
-            <li class="theme-validation-item theme-warning">
-                {{gh-theme-error-li error=error}}
-            </li>
-        {{/each}}
 
-    </ul>
 </div>
 
 <div class="modal-footer">

--- a/app/templates/components/modal-theme-warnings.hbs
+++ b/app/templates/components/modal-theme-warnings.hbs
@@ -28,7 +28,7 @@
         {{#if this.errors}}
             <div>
                 <h2 class="mb0 mt4 f5 fw6">Errors</h2>
-                <p class="mb2">Very recommended to fix, functionality <span>could</span> be restricted</p>
+                <p class="mb2">Highly recommended to fix, functionality <span>could</span> be restricted</p>
             </div>
         
             <ul class="pa0" data-test-theme-warnings>

--- a/app/templates/components/modal-upload-theme.hbs
+++ b/app/templates/components/modal-upload-theme.hbs
@@ -20,13 +20,18 @@
         {{#if theme}}
             {{#if hasWarningsOrErrors}}
                 <p>
-                    The theme <strong>"{{themeName}}"</strong> was uploaded successfully but some {{#if validationErrors}}errors{{else}}warnings{{/if}} were detected. You are still able to activate and use the theme but it is recommended to fix these {{#if validationErrors}}errors{{else}}warnings{{/if}} before you do so.
+                    {{#if canActivateTheme}}
+                        The theme <strong>"{{themeName}}"</strong> was uploaded successfully but we detected some {{#if validationErrors}}errors{{else}}warnings{{/if}}. You are still able to activate and use the theme but it is recommended to fix these {{#if validationErrors}}errors{{else}}warnings{{/if}} before you do so.
+                    {{else}}
+                        The theme <strong>"{{themeName}}"</strong> was uploaded successfully but we detected some
+                        {{#if validationErrors}}errors{{else}}warnings{{/if}}.
+                    {{/if}}
                 </p>
 
                 {{#if validationErrors}}
                     <div>
                         <h2 class="mb0 mt4 f5 fw6">Errors</h2>
-                        <p class="mb2">Very recommended to fix, functionality <strong>could</strong> be restricted</p>
+                        <p class="mb2">Highly recommended to fix, functionality <strong>could</strong> be restricted</p>
                     </div>
                     <ul class="pa0">
                     {{#each validationErrors as |error|}}
@@ -83,7 +88,7 @@
             {{#if validationErrors}}
                 <div>
                     <h2 class="mb0 mt4 f5 fw6">Errors</h2>
-                    <p class="mb2">Very recommended to fix, functionality <span>could</span> be restricted</p>
+                    <p class="mb2">Highly recommended to fix, functionality <strong>could</strong> be restricted</p>
                 </div>
                 <ul class="pa0">
                 {{#each validationErrors as |error|}}

--- a/app/templates/components/modal-upload-theme.hbs
+++ b/app/templates/components/modal-upload-theme.hbs
@@ -18,34 +18,36 @@
 <div class="modal-body">
     {{#if theme}}
         {{#if hasWarningsOrErrors}}
-             <ul class="theme-validation-errors">
-                <p class="theme-validation-summary">
-                    The theme <strong>"{{themeName}}"</strong> was uploaded successfully but some {{#if validationErrors}}errors{{else}}warnings{{/if}} were detected. You are still able to activate and use the theme but it is recommended to fix these {{#if validationErrors}}errors{{else}}warnings{{/if}} before you do so.
-                </p>
+            <p>
+                The theme <strong>"{{themeName}}"</strong> was uploaded successfully but some {{#if validationErrors}}errors{{else}}warnings{{/if}} were detected. You are still able to activate and use the theme but it is recommended to fix these {{#if validationErrors}}errors{{else}}warnings{{/if}} before you do so.
+            </p>
 
-                {{#if validationErrors}}
-                    <div class="theme-validation-errordescription">
-                        <h2 class="theme-validation-errortype">Errors</h2>
-                        <p>Very recommended to fix, functionality <span>could</span> be restricted</p>
-                    </div>
-                {{/if}}
+            {{#if validationErrors}}
+                <div>
+                    <h2 class="mb0 mt2 f5 fw6">Errors</h2>
+                    <p class="mb2">Very recommended to fix, functionality <strong>could</strong> be restricted</p>
+                </div>
+                <ul class="pa0">
                 {{#each validationErrors as |error|}}
                     <li class="theme-validation-item theme-error">
                         {{gh-theme-error-li error=error}}
                     </li>
                 {{/each}}
+                </ul>
+            {{/if}}
 
-                {{#if validationWarnings}}
-                    <div class="theme-validation-errordescription">
-                        <h2 class="theme-validation-errortype">Warnings</h2>
-                    </div>
-                {{/if}}
+            {{#if validationWarnings}}
+                <div>
+                    <h2 class="mb0 mt2 f5 fw6">Warnings</h2>
+                </div>
+                <ul class="pa0">
                 {{#each validationWarnings as |error|}}
                     <li class="theme-validation-item theme-warning">
                         {{gh-theme-error-li error=error}}
                     </li>
                 {{/each}}
-            </ul>
+                </ul>
+            {{/if}}
         {{else}}
             <p>
                 "{{themeName}}" uploaded successfully.
@@ -54,37 +56,42 @@
         {{/if}}
     {{else if displayOverwriteWarning}}
         <p>
-            "{{fileThemeName}}" will overwrite an existing theme of the same name. Are you sure?
+            The theme folder <strong>"{{fileThemeName}}"</strong> already exists. Do you want to overwrite it?
         </p>
     {{else if (or validationErrors fatalValidationErrors)}}
-        <ul class="theme-validation-errors">
-            <p class="theme-validation-summary">
-                This theme is invalid and cannot be activated. Fix the following errors and re-upload the theme.
-            </p>
-            {{#if fatalValidationErrors}}
-                <div class="theme-validation-errordescription">
-                    <h2 class="theme-validation-errortype fatal">Fatal Errors</h2>
-                    <p>Must-fix to activate theme</p>
-                </div>
-            {{/if}}
+        
+        <p>
+            This theme is invalid and cannot be activated. Fix the following errors and re-upload the theme.
+        </p>
+
+        {{#if fatalValidationErrors}}
+            <div>
+                <h2 class="mb0 mt2 f5 fw6 red">Fatal Errors</h2>
+                <p class="mb2 red">Must-fix to activate theme</p>
+            </div>
+        
+            <ul class="pa0">
             {{#each fatalValidationErrors as |error|}}
-                <li class="theme-validation-item theme-error">
+                <li class="theme-validation-item theme-fatal-error">
                     {{gh-theme-error-li error=error}}
                 </li>
             {{/each}}
+            </ul>
+        {{/if}}
 
-            {{#if validationErrors}}
-                <div class="theme-validation-errordescription">
-                    <h2 class="theme-validation-errortype theme-error">Errors</h2>
-                    <p>Very recommended to fix, functionality <span>could</span> be restricted</p>
-                </div>
-            {{/if}}
+        {{#if validationErrors}}
+            <div>
+                <h2 class="mb0 mt2 f5 fw6">Errors</h2>
+                <p class="mb2">Very recommended to fix, functionality <span>could</span> be restricted</p>
+            </div>
+            <ul class="pa0">
             {{#each validationErrors as |error|}}
                 <li class="theme-validation-item theme-error">
                     {{gh-theme-error-li error=error}}
                 </li>
             {{/each}}
-        </ul>
+            </ul>
+        {{/if}}
     {{else}}
         {{gh-file-uploader
             url=uploadUrl
@@ -109,14 +116,14 @@
             <span>Overwrite</span>
         </button>
     {{/if}}
-    {{#if validationErrors}}
-        <button {{action "reset"}} class="gh-btn gh-btn-green" data-test-try-again-button>
-            <span>Try Again</span>
-        </button>
-    {{/if}}
     {{#if canActivateTheme}}
-        <button {{action "activate"}} class="gh-btn gh-btn-green" data-test-activate-now-button>
-            <span>Activate Now</span>
+    <button {{action "activate"}} class="gh-btn" data-test-activate-now-button>
+        <span>Activate with errors</span>
+    </button>
+    {{/if}}
+    {{#if validationErrors}}
+        <button {{action "reset"}} class="gh-btn gh-btn-blue" data-test-try-again-button>
+            <span>Retry</span>
         </button>
     {{/if}}
 </div>

--- a/app/templates/components/modal-upload-theme.hbs
+++ b/app/templates/components/modal-upload-theme.hbs
@@ -110,22 +110,26 @@
 </div>
 
 <div class="modal-footer">
-    <button {{action "closeModal"}} disabled={{closeDisabled}} class="gh-btn" data-test-close-button>
-        <span>{{#if theme}}Close{{else}}Cancel{{/if}}</span>
-    </button>
-    {{#if displayOverwriteWarning}}
-        <button {{action "confirmOverwrite"}} class="gh-btn gh-btn-red" data-test-overwrite-button>
-            <span>Overwrite</span>
+    <div class="flex items-center justify-between {{if (or displayOverwriteWarning canActivateTheme validationErrors) "flex-auto"}}">
+        <button {{action "closeModal"}} disabled={{closeDisabled}} class="gh-btn" data-test-close-button>
+            <span>{{#if theme}}Close{{else}}Cancel{{/if}}</span>
         </button>
-    {{/if}}
-    {{#if canActivateTheme}}
-    <button {{action "activate"}} class="gh-btn" data-test-activate-now-button>
-        <span>Activate with errors</span>
-    </button>
-    {{/if}}
-    {{#if validationErrors}}
-        <button {{action "reset"}} class="gh-btn gh-btn-blue" data-test-try-again-button>
-            <span>Retry</span>
-        </button>
-    {{/if}}
+        <div class="flex items-center ml2">
+            {{#if displayOverwriteWarning}}
+                <button {{action "confirmOverwrite"}} class="gh-btn gh-btn-red" data-test-overwrite-button>
+                    <span>Overwrite</span>
+                </button>
+            {{/if}}
+            {{#if canActivateTheme}}
+            <button {{action "activate"}} class="gh-btn" data-test-activate-now-button>
+                <span>Activate with errors</span>
+            </button>
+            {{/if}}
+            {{#if validationErrors}}
+                <button {{action "reset"}} class="gh-btn gh-btn-blue ml2" data-test-try-again-button>
+                    <span>Retry</span>
+                </button>
+            {{/if}}
+        </div>
+    </div>
 </div>

--- a/app/templates/components/modal-upload-theme.hbs
+++ b/app/templates/components/modal-upload-theme.hbs
@@ -25,7 +25,7 @@
 
                 {{#if validationErrors}}
                     <div>
-                        <h2 class="mb0 mt2 f5 fw6">Errors</h2>
+                        <h2 class="mb0 mt4 f5 fw6">Errors</h2>
                         <p class="mb2">Very recommended to fix, functionality <strong>could</strong> be restricted</p>
                     </div>
                     <ul class="pa0">
@@ -39,7 +39,7 @@
 
                 {{#if validationWarnings}}
                     <div>
-                        <h2 class="mb0 mt2 f5 fw6">Warnings</h2>
+                        <h2 class="mb0 mt4 f5 fw6">Warnings</h2>
                     </div>
                     <ul class="pa0">
                     {{#each validationWarnings as |error|}}
@@ -67,8 +67,8 @@
 
             {{#if fatalValidationErrors}}
                 <div>
-                    <h2 class="mb0 mt2 f5 fw6 red">Fatal Errors</h2>
-                    <p class="mb2 red">Must-fix to activate theme</p>
+                    <h2 class="mb0 mt4 f5 fw6">Fatal Errors</h2>
+                    <p class="mb2">Must-fix to activate theme</p>
                 </div>
             
                 <ul class="pa0">
@@ -82,7 +82,7 @@
 
             {{#if validationErrors}}
                 <div>
-                    <h2 class="mb0 mt2 f5 fw6">Errors</h2>
+                    <h2 class="mb0 mt4 f5 fw6">Errors</h2>
                     <p class="mb2">Very recommended to fix, functionality <span>could</span> be restricted</p>
                 </div>
                 <ul class="pa0">
@@ -114,7 +114,7 @@
         <button {{action "closeModal"}} disabled={{closeDisabled}} class="gh-btn" data-test-close-button>
             <span>{{#if theme}}Close{{else}}Cancel{{/if}}</span>
         </button>
-        <div class="flex items-center ml2">
+        <div class="flex items-center">
             {{#if displayOverwriteWarning}}
                 <button {{action "confirmOverwrite"}} class="gh-btn gh-btn-red" data-test-overwrite-button>
                     <span>Overwrite</span>

--- a/app/templates/components/modal-upload-theme.hbs
+++ b/app/templates/components/modal-upload-theme.hbs
@@ -19,21 +19,18 @@
     {{#if theme}}
         {{#if hasWarningsOrErrors}}
              <ul class="theme-validation-errors">
-                <li>
-                    <p>
-                        "{{themeName}}" uploaded successfully but some {{#if validationErrors}}errors{{else}}warnings{{/if}} were detected.
-                        You are still able to use and activate the theme. Here's your report...
-                    </p>
-                </li>
+                <p class="theme-validation-summary">
+                    The theme <strong>"{{themeName}}"</strong> was uploaded successfully but some {{#if validationErrors}}errors{{else}}warnings{{/if}} were detected. You are still able to activate and use the theme but it is recommended to fix these {{#if validationErrors}}errors{{else}}warnings{{/if}} before you do so.
+                </p>
 
                 {{#if validationErrors}}
                     <div class="theme-validation-errordescription">
                         <h2 class="theme-validation-errortype">Errors</h2>
-                        <p><em>(Very recommended to fix, functionality <span>could</span> be restricted)</em></p>
+                        <p>Very recommended to fix, functionality <span>could</span> be restricted</p>
                     </div>
                 {{/if}}
                 {{#each validationErrors as |error|}}
-                    <li class="theme-validation-item">
+                    <li class="theme-validation-item theme-error">
                         {{gh-theme-error-li error=error}}
                     </li>
                 {{/each}}
@@ -44,7 +41,7 @@
                     </div>
                 {{/if}}
                 {{#each validationWarnings as |error|}}
-                    <li class="theme-validation-item">
+                    <li class="theme-validation-item theme-warning">
                         {{gh-theme-error-li error=error}}
                     </li>
                 {{/each}}
@@ -61,26 +58,29 @@
         </p>
     {{else if (or validationErrors fatalValidationErrors)}}
         <ul class="theme-validation-errors">
+            <p class="theme-validation-summary">
+                This theme is invalid and cannot be activated. Fix the following errors and re-upload the theme.
+            </p>
             {{#if fatalValidationErrors}}
                 <div class="theme-validation-errordescription">
                     <h2 class="theme-validation-errortype fatal">Fatal Errors</h2>
-                    <p><em>(Must-fix to activate theme)</em></p>
+                    <p>Must-fix to activate theme</p>
                 </div>
             {{/if}}
             {{#each fatalValidationErrors as |error|}}
-                <li class="theme-validation-item">
+                <li class="theme-validation-item theme-error">
                     {{gh-theme-error-li error=error}}
                 </li>
             {{/each}}
 
             {{#if validationErrors}}
                 <div class="theme-validation-errordescription">
-                    <h2 class="theme-validation-errortype">Errors</h2>
-                    <p><em>(Very recommended to fix, functionality <span>could</span> be restricted)</em></p>
+                    <h2 class="theme-validation-errortype theme-error">Errors</h2>
+                    <p>Very recommended to fix, functionality <span>could</span> be restricted</p>
                 </div>
             {{/if}}
             {{#each validationErrors as |error|}}
-                <li class="theme-validation-item">
+                <li class="theme-validation-item theme-error">
                     {{gh-theme-error-li error=error}}
                 </li>
             {{/each}}

--- a/app/templates/components/modal-upload-theme.hbs
+++ b/app/templates/components/modal-upload-theme.hbs
@@ -1,31 +1,89 @@
-<header class="modal-header" data-test-modal="upload-theme">
-    <h1>
+<div class="theme-validation-container">
+    <header class="modal-header" data-test-modal="upload-theme">
+        <h1>
+            {{#if theme}}
+                {{#if hasWarningsOrErrors}}
+                    Upload successful with {{#if validationErrors}}errors{{else}}warnings{{/if}}
+                {{else}}
+                    Upload successful!
+                {{/if}}
+            {{else if (or validationErrors fatalValidationErrors)}}
+                Invalid theme
+            {{else}}
+                Upload a theme
+            {{/if}}
+        </h1>
+    </header>
+    <a class="close" href="#" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
+
+    <div class="modal-body">
         {{#if theme}}
             {{#if hasWarningsOrErrors}}
-                Upload successful with {{#if validationErrors}}errors{{else}}warnings{{/if}}
-            {{else}}
-                Upload successful!
-            {{/if}}
-        {{else if (or validationErrors fatalValidationErrors)}}
-            Invalid theme
-        {{else}}
-            Upload a theme
-        {{/if}}
-    </h1>
-</header>
-<a class="close" href="#" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
+                <p>
+                    The theme <strong>"{{themeName}}"</strong> was uploaded successfully but some {{#if validationErrors}}errors{{else}}warnings{{/if}} were detected. You are still able to activate and use the theme but it is recommended to fix these {{#if validationErrors}}errors{{else}}warnings{{/if}} before you do so.
+                </p>
 
-<div class="modal-body">
-    {{#if theme}}
-        {{#if hasWarningsOrErrors}}
+                {{#if validationErrors}}
+                    <div>
+                        <h2 class="mb0 mt2 f5 fw6">Errors</h2>
+                        <p class="mb2">Very recommended to fix, functionality <strong>could</strong> be restricted</p>
+                    </div>
+                    <ul class="pa0">
+                    {{#each validationErrors as |error|}}
+                        <li class="theme-validation-item theme-error">
+                            {{gh-theme-error-li error=error}}
+                        </li>
+                    {{/each}}
+                    </ul>
+                {{/if}}
+
+                {{#if validationWarnings}}
+                    <div>
+                        <h2 class="mb0 mt2 f5 fw6">Warnings</h2>
+                    </div>
+                    <ul class="pa0">
+                    {{#each validationWarnings as |error|}}
+                        <li class="theme-validation-item theme-warning">
+                            {{gh-theme-error-li error=error}}
+                        </li>
+                    {{/each}}
+                    </ul>
+                {{/if}}
+            {{else}}
+                <p>
+                    "{{themeName}}" uploaded successfully.
+                    {{#if canActivateTheme}}Do you want to activate it now?{{/if}}
+                </p>
+            {{/if}}
+        {{else if displayOverwriteWarning}}
             <p>
-                The theme <strong>"{{themeName}}"</strong> was uploaded successfully but some {{#if validationErrors}}errors{{else}}warnings{{/if}} were detected. You are still able to activate and use the theme but it is recommended to fix these {{#if validationErrors}}errors{{else}}warnings{{/if}} before you do so.
+                The theme folder <strong>"{{fileThemeName}}"</strong> already exists. Do you want to overwrite it?
             </p>
+        {{else if (or validationErrors fatalValidationErrors)}}
+            
+            <p>
+                This theme is invalid and cannot be activated. Fix the following errors and re-upload the theme.
+            </p>
+
+            {{#if fatalValidationErrors}}
+                <div>
+                    <h2 class="mb0 mt2 f5 fw6 red">Fatal Errors</h2>
+                    <p class="mb2 red">Must-fix to activate theme</p>
+                </div>
+            
+                <ul class="pa0">
+                {{#each fatalValidationErrors as |error|}}
+                    <li class="theme-validation-item theme-fatal-error">
+                        {{gh-theme-error-li error=error}}
+                    </li>
+                {{/each}}
+                </ul>
+            {{/if}}
 
             {{#if validationErrors}}
                 <div>
                     <h2 class="mb0 mt2 f5 fw6">Errors</h2>
-                    <p class="mb2">Very recommended to fix, functionality <strong>could</strong> be restricted</p>
+                    <p class="mb2">Very recommended to fix, functionality <span>could</span> be restricted</p>
                 </div>
                 <ul class="pa0">
                 {{#each validationErrors as |error|}}
@@ -35,76 +93,20 @@
                 {{/each}}
                 </ul>
             {{/if}}
-
-            {{#if validationWarnings}}
-                <div>
-                    <h2 class="mb0 mt2 f5 fw6">Warnings</h2>
-                </div>
-                <ul class="pa0">
-                {{#each validationWarnings as |error|}}
-                    <li class="theme-validation-item theme-warning">
-                        {{gh-theme-error-li error=error}}
-                    </li>
-                {{/each}}
-                </ul>
-            {{/if}}
         {{else}}
-            <p>
-                "{{themeName}}" uploaded successfully.
-                {{#if canActivateTheme}}Do you want to activate it now?{{/if}}
-            </p>
+            {{gh-file-uploader
+                url=uploadUrl
+                paramName="file"
+                accept=accept
+                labelText="Click to select or drag-and-drop your theme zip file here."
+                validate=(action "validateTheme")
+                uploadStarted=(action "uploadStarted")
+                uploadFinished=(action "uploadFinished")
+                uploadSuccess=(action "uploadSuccess")
+                uploadFailed=(action "uploadFailed")
+                listenTo="themeUploader"}}
         {{/if}}
-    {{else if displayOverwriteWarning}}
-        <p>
-            The theme folder <strong>"{{fileThemeName}}"</strong> already exists. Do you want to overwrite it?
-        </p>
-    {{else if (or validationErrors fatalValidationErrors)}}
-        
-        <p>
-            This theme is invalid and cannot be activated. Fix the following errors and re-upload the theme.
-        </p>
-
-        {{#if fatalValidationErrors}}
-            <div>
-                <h2 class="mb0 mt2 f5 fw6 red">Fatal Errors</h2>
-                <p class="mb2 red">Must-fix to activate theme</p>
-            </div>
-        
-            <ul class="pa0">
-            {{#each fatalValidationErrors as |error|}}
-                <li class="theme-validation-item theme-fatal-error">
-                    {{gh-theme-error-li error=error}}
-                </li>
-            {{/each}}
-            </ul>
-        {{/if}}
-
-        {{#if validationErrors}}
-            <div>
-                <h2 class="mb0 mt2 f5 fw6">Errors</h2>
-                <p class="mb2">Very recommended to fix, functionality <span>could</span> be restricted</p>
-            </div>
-            <ul class="pa0">
-            {{#each validationErrors as |error|}}
-                <li class="theme-validation-item theme-error">
-                    {{gh-theme-error-li error=error}}
-                </li>
-            {{/each}}
-            </ul>
-        {{/if}}
-    {{else}}
-        {{gh-file-uploader
-            url=uploadUrl
-            paramName="file"
-            accept=accept
-            labelText="Click to select or drag-and-drop your theme zip file here."
-            validate=(action "validateTheme")
-            uploadStarted=(action "uploadStarted")
-            uploadFinished=(action "uploadFinished")
-            uploadSuccess=(action "uploadSuccess")
-            uploadFailed=(action "uploadFailed")
-            listenTo="themeUploader"}}
-    {{/if}}
+    </div>
 </div>
 
 <div class="modal-footer">

--- a/mirage/config/themes.js
+++ b/mirage/config/themes.js
@@ -26,7 +26,7 @@ export default function mockThemes(server) {
     server.del('/themes/:theme/', function ({themes}, {params}) {
         themes.findBy({name: params.theme}).destroy();
 
-        return new Response(204, {}, null);
+        return new Response(204);
     });
 
     server.put('/themes/:theme/activate/', function ({themes}, {params}) {


### PR DESCRIPTION
refs. https://github.com/TryGhost/Team/issues/206

Improvements for theme upload and activation dialogs:
- updated copy for buttons and static descriptions
- updated style for better readability of gscan errors
- fixed modal scrolling when gscan output is too long to fit on screen