### PR TITLE
Fixed post/page labels in feature image and save components

### DIFF
--- a/app/templates/components/gh-post-settings-menu.hbs
+++ b/app/templates/components/gh-post-settings-menu.hbs
@@ -10,7 +10,7 @@
             <div class="settings-menu-content">
                 {{gh-image-uploader-with-preview
                     image=post.featureImage
-                    text="Upload post image"
+                    text=(concat "Upload " post.displayName " image")
                     allowUnsplash=true
                     update=(action "setCoverImage")
                     remove=(action "clearCoverImage")

--- a/app/templates/components/gh-publishmenu-draft.hbs
+++ b/app/templates/components/gh-publishmenu-draft.hbs
@@ -1,10 +1,10 @@
-<header class="gh-publishmenu-heading">Ready to publish your post?</header>
+<header class="gh-publishmenu-heading">Ready to publish your {{post.displayName}}?</header>
 <section class="gh-publishmenu-content">
     <div class="gh-publishmenu-radio {{if (eq saveType "publish") "active"}}" {{action "setSaveType" "publish" on="click"}}>
         <div class="gh-publishmenu-radio-button" data-test-publishmenu-published-option></div>
         <div class="gh-publishmenu-radio-content">
             <div class="gh-publishmenu-radio-label">Set it live now</div>
-            <div class="gh-publishmenu-radio-desc">Publish this post immediately</div>
+            <div class="gh-publishmenu-radio-desc">Publish this {{post.displayName}} immediately</div>
         </div>
     </div>
     <div class="gh-publishmenu-radio {{if (eq saveType "schedule") "active"}}" {{action "setSaveType" "schedule" on="click"}}>

--- a/app/templates/components/gh-publishmenu-published.hbs
+++ b/app/templates/components/gh-publishmenu-published.hbs
@@ -1,17 +1,17 @@
-<header class="gh-publishmenu-heading">Update post status</header>
+<header class="gh-publishmenu-heading">Update {{post.displayName}} status</header>
 <section class="gh-publishmenu-content">
     <div class="gh-publishmenu-radio {{if (eq saveType "draft") "active"}}" {{action setSaveType "draft" on="click"}}>
         <div class="gh-publishmenu-radio-button" data-test-publishmenu-unpublished-option></div>
         <div class="gh-publishmenu-radio-content">
             <div class="gh-publishmenu-radio-label">Unpublished</div>
-            <div class="gh-publishmenu-radio-desc">Revert this post to a private draft</div>
+            <div class="gh-publishmenu-radio-desc">Revert this {{post.displayName}} to a private draft</div>
         </div>
     </div>
     <div class="gh-publishmenu-radio {{if (eq saveType "publish") "active"}}" {{action setSaveType "publish" on="click"}}>
         <div class="gh-publishmenu-radio-button" data-test-publishmenu-published-option></div>
         <div class="gh-publishmenu-radio-content">
             <div class="gh-publishmenu-radio-label">Published</div>
-            <div class="gh-publishmenu-radio-desc">Display this post publicly</div>
+            <div class="gh-publishmenu-radio-desc">Display this {{post.displayName}} publicly</div>
         </div>
     </div>
 </section>

--- a/app/templates/components/gh-publishmenu.hbs
+++ b/app/templates/components/gh-publishmenu.hbs
@@ -6,6 +6,7 @@
     {{#dd.content class="gh-publishmenu-dropdown"}}
         {{#if (eq displayState "published")}}
         {{gh-publishmenu-published
+            post=post
             saveType=saveType
             setSaveType=(action "setSaveType")}}
 


### PR DESCRIPTION
Closes TryGhost/Ghost#10658

- Update publish menu states to use `{{post.displayName}}` instead of hard coded `post`
- Update settings menu image uploader to generate CTA using `post.displayName`