### PR TITLE
Removed "ember-exam" from list of ignored packages in Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,8 +9,7 @@
   "ignoreDeps": [
     "ember-drag-drop",
     "normalize.css",
-    "validator",
-    "ember-exam"
+    "validator"
   ],
   "ignorePaths": ["lib/koenig-editor/package.json"],
   "travis": { "enabled": true },


### PR DESCRIPTION
no issue
- latest `ember-exam` is now compatible with latest stable `ember-mocha` release