### PR TITLE
Added `ember-exam` to Renovate ignore list

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,8 @@
   "ignoreDeps": [
     "ember-drag-drop",
     "normalize.css",
-    "validator"
+    "validator",
+    "ember-exam"
   ],
   "ignorePaths": ["lib/koenig-editor/package.json"],
   "travis": { "enabled": true },


### PR DESCRIPTION
no issue
- `ember-exam@3.x` is not compatible with the latest stable `ember-mocha` release