### PR TITLE
Remove 2-per-hour PR limit for Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
     "normalize.css",
     "validator"
   ],
+  "prHourlyLimit": 0,
   "ignorePaths": ["lib/koenig-editor/package.json"],
   "travis": { "enabled": true },
   "node": {


### PR DESCRIPTION
no issue
- the `config:base` preset sets a maximum of 2 PRs per hour
- we have specific timings for Renovate in this repo so the max limit is more hindrance than help