### PR TITLE
Updated .travis.yml swap renovate build to push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ env:
   global:
   - MOZ_HEADLESS=1
   - JOBS=1
-branches:
-  except:
-  - "/^renovate\\/.+$/"
+# Don't run builds for renovate PRs, only renovate pushes
+if: NOT branch =~ /^renovate\\/.+$/ AND type != pull_request
 addons:
   firefox: latest
   chrome: stable


### PR DESCRIPTION
Fundamental problem: cos renovate pushes branches to the main repo, when it opens a PR there are 2 checks, one for push and one for the pr.

Currently to fix that we exclude renovate branches, and only build renovate PRs
That means we can't use automerge branch, as we wouldn't run any checks!
This swaps to running only renovate pushes, which means the branch always gets checked

PR builds check the merge commit, but as renovate always rebases from latest master, this is effectively the same commit as the push.