### PR TITLE
Update Renovate Configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,8 @@
     "@tryghost:base",
     "@tryghost:groupTestLint",
     "@tryghost:groupCSS",
-    "@tryghost:groupBuildTools"  
+    "@tryghost:groupBuildTools",
+    "@tryghost:automergeSilentTestLintNonMajor"
   ],
   "ignoreDeps": [
     "ember-drag-drop",

--- a/renovate.json
+++ b/renovate.json
@@ -1,17 +1,16 @@
 {
   "extends": [
-    "config:base",
-    "group:jsTestMonMajor",
-    "group:linters",
-    ":maintainLockFilesWeekly",
-    "schedule:earlyMondays"
+    "@tryghost:base",
+    "@tryghost:groupTestLint",
+    "@tryghost:groupCSS",
+    "@tryghost:groupBuildTools"  
   ],
   "ignoreDeps": [
     "ember-drag-drop",
     "normalize.css",
     "validator"
   ],
-  "prHourlyLimit": 0,
+
   "ignorePaths": ["lib/koenig-editor/package.json"],
   "travis": { "enabled": true },
   "node": {
@@ -34,10 +33,6 @@
       "groupName": "ember addons",
       "packagePatterns": ["^ember", "^@ember", "^broccoli", "^liquid"],
       "excludePackageNames": ["ember-source", "ember-cli", "ember-data", "ember-mocha", "ember-exam"]
-    },
-    {
-      "groupName": "css processors",
-      "packagePatterns": ["^postcss", "^css", "autoprefixer"]
     }
   ]
 }


### PR DESCRIPTION
Shared configs are here: https://github.com/TryGhost/slimer/blob/master/packages/renovate-config/package.json#L10

 Testem isn't included in groupTestLint atm. If that's desirable it can be added here: https://github.com/TryGhost/slimer/blob/master/packages/renovate-config/package.json#L36 

The main functional change this includes is swapping lockfile maintenance to be monthly. If that's undesirable `maintainLockFilesWeekly` can be added back.

Need to consider if there are any dependency groups that can be automerged silently and safely.

- swap main config for @tryghost:base
- don't need `"prHourlyLimit": 0,` as the base config now includes `:disableRateLimiting`
- `@tryghost:groupCSS` replaces the css preprocessor group
- groupTestLint doesn't apply so much here, but it will group together common test and linting packages.
- groupBuildTools groups grunt etc
