### PR TITLE
Re-configured Renovate to ignore ember-in-viewport

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,8 @@
   "ignoreDeps": [
     "ember-drag-drop",
     "normalize.css",
-    "validator"
+    "validator",
+    "ember-in-viewport"
   ],
   "prHourlyLimit": 0,
   "ignorePaths": ["lib/koenig-editor/package.json"],


### PR DESCRIPTION
no issue
- `ember-in-viewport` has introduced a change in 3.5.0 that is incompatible with `ember-light-table` so adding it to the ignore list temporarily