### PR TITLE
✨ Added language selection to code cards

### DIFF
--- a/app/components/gh-cm-editor.js
+++ b/app/components/gh-cm-editor.js
@@ -11,6 +11,7 @@ const CmEditorComponent = Component.extend({
 
     classNameBindings: ['isFocused:focus'],
 
+    textareaClass: '',
     isFocused: false,
 
     // options for the editor

--- a/app/components/gh-cm-editor.js
+++ b/app/components/gh-cm-editor.js
@@ -35,6 +35,7 @@ const CmEditorComponent = Component.extend({
         }
 
         if (this.mode !== this._lastMode && this._editor) {
+            console.log('changing mode', this.mode);
             this._editor.setOption('mode', this.mode);
         }
         this._lastMode = this.mode;

--- a/app/components/gh-cm-editor.js
+++ b/app/components/gh-cm-editor.js
@@ -35,7 +35,6 @@ const CmEditorComponent = Component.extend({
         }
 
         if (this.mode !== this._lastMode && this._editor) {
-            console.log('changing mode', this.mode);
             this._editor.setOption('mode', this.mode);
         }
         this._lastMode = this.mode;

--- a/app/components/gh-cm-editor.js
+++ b/app/components/gh-cm-editor.js
@@ -33,6 +33,11 @@ const CmEditorComponent = Component.extend({
         if (this._value === null || undefined) {
             this.set('_value', '');
         }
+
+        if (this.mode !== this._lastMode && this._editor) {
+            this._editor.setOption('mode', this.mode);
+        }
+        this._lastMode = this.mode;
     },
 
     didInsertElement() {

--- a/app/styles/spirit/_font-weight.css
+++ b/app/styles/spirit/_font-weight.css
@@ -13,6 +13,7 @@
 .fw1     { font-weight: 100; }
 .fw3    { font-weight: 300; }
 .fw4    { font-weight: 400; }
+.fw5    { font-weight: 500; }
 .fw6      { font-weight: 600; }
 .fw7      { font-weight: 700; }
 
@@ -21,6 +22,7 @@
     .fw1-ns     { font-weight: 100; }
     .fw3-ns    { font-weight: 300; }
     .fw4-ns    { font-weight: 400; }
+    .fw5-ns    { font-weight: 500; }
     .fw6-ns      { font-weight: 600; }
     .fw7-ns      { font-weight: 700; }
 }
@@ -29,6 +31,7 @@
     .fw1-m     { font-weight: 100; }
     .fw3-m    { font-weight: 300; }
     .fw4-m    { font-weight: 400; }
+    .fw5-m    { font-weight: 500; }
     .fw6-m      { font-weight: 600; }
     .fw7-m      { font-weight: 700; }
 }
@@ -37,6 +40,7 @@
     .fw1-l     { font-weight: 100; }
     .fw3-l    { font-weight: 300; }
     .fw4-l    { font-weight: 400; }
+    .fw5-l    { font-weight: 500; }
     .fw6-l      { font-weight: 600; }
     .fw7-l      { font-weight: 700; }
 }

--- a/app/styles/spirit/_koenig.css
+++ b/app/styles/spirit/_koenig.css
@@ -816,6 +816,7 @@
 /* Codemirror overrides
 /* --------------------------------------------------------------- */
 .koenig-editor .CodeMirror pre {
+    font-size: 1.6rem;
     white-space: pre;
 }
 
@@ -828,6 +829,10 @@
     padding: 0;
     overflow: auto;
     background-color: #ffffff;
+}
+
+.koenig-card-code--editor .CodeMirror {
+    background-color: #f5f7f8;
 }
 
 .koenig-card-html--editor .CodeMirror:hover {

--- a/app/styles/spirit/_koenig.css
+++ b/app/styles/spirit/_koenig.css
@@ -832,7 +832,7 @@
 }
 
 .koenig-card-code--editor .CodeMirror {
-    background-color: #f5f7f8;
+    background: color-mod(var(--lightgrey) lightness(+4%));
 }
 
 .koenig-card-html--editor .CodeMirror:hover {

--- a/app/templates/components/gh-cm-editor.hbs
+++ b/app/templates/components/gh-cm-editor.hbs
@@ -1,5 +1,5 @@
 {{!-- display a standard textarea whilst waiting for CodeMirror to load/initialize --}}
 {{gh-textarea
-    class="gh-cm-editor-textarea"
+    class=(concat "gh-cm-editor-textarea " textareaClass)
     value=(readonly _value)
     input=(action "updateFromTextarea" value="target.value")}}

--- a/lib/koenig-editor/addon/components/koenig-card-code.js
+++ b/lib/koenig-editor/addon/components/koenig-card-code.js
@@ -66,12 +66,12 @@ export default Component.extend({
     }),
 
     cardStyle: computed('isEditing', function () {
-        let style = this.isEditing ? 'background-color: #f5f7f8; border-color: #f5f7f8' : '';
+        let style = this.isEditing ? 'background-color: #f4f8fb; border-color: #f4f8fb' : '';
         return htmlSafe(style);
     }),
 
     languageInputStyle: computed('showLanguageInput', function () {
-        let styles = ['caret-color: initial'];
+        let styles = ['caret-color: initial', 'top: 6px', 'right: 6px'];
         if (!this.showLanguageInput) {
             styles.push('opacity: 0');
         }

--- a/lib/koenig-editor/addon/components/koenig-card-code.js
+++ b/lib/koenig-editor/addon/components/koenig-card-code.js
@@ -26,6 +26,7 @@ export default Component.extend({
     isSelected: false,
     isEditing: false,
     headerOffset: 0,
+    showLanguageInput: true,
 
     // closure actions
     editCard() {},
@@ -64,6 +65,19 @@ export default Component.extend({
         return CM_MODE_MAP[language] || language;
     }),
 
+    cardStyle: computed('isEditing', function () {
+        let style = this.isEditing ? 'background-color: #f5f7f8; border-color: #f5f7f8' : '';
+        return htmlSafe(style);
+    }),
+
+    languageInputStyle: computed('showLanguageInput', function () {
+        let styles = ['caret-color: initial'];
+        if (!this.showLanguageInput) {
+            styles.push('opacity: 0');
+        }
+        return htmlSafe(styles.join('; '));
+    }),
+
     init() {
         this._super(...arguments);
         let payload = this.payload || {};
@@ -80,10 +94,17 @@ export default Component.extend({
 
     actions: {
         updateCode(code) {
+            this._hideLanguageInput();
             this._updatePayloadAttr('code', code);
         },
 
+        enterEditMode() {
+            this._addMousemoveHandler();
+        },
+
         leaveEditMode() {
+            this._removeMousemoveHandler();
+
             if (isBlank(this.payload.code)) {
                 // afterRender is required to avoid double modification of `isSelected`
                 // TODO: see if there's a way to avoid afterRender
@@ -102,5 +123,22 @@ export default Component.extend({
 
         // update the mobiledoc and stay in edit mode
         save(payload, false);
+    },
+
+    _hideLanguageInput() {
+        this.set('showLanguageInput', false);
+    },
+
+    _showLanguageInput() {
+        this.set('showLanguageInput', true);
+    },
+
+    _addMousemoveHandler() {
+        this._mousemoveHandler = run.bind(this, this._showLanguageInput);
+        window.addEventListener('mousemove', this._mousemoveHandler);
+    },
+
+    _removeMousemoveHandler() {
+        window.removeEventListener('mousemove', this._mousemoveHandler);
     }
 });

--- a/lib/koenig-editor/addon/components/koenig-card-code.js
+++ b/lib/koenig-editor/addon/components/koenig-card-code.js
@@ -11,6 +11,13 @@ import {set} from '@ember/object';
 const {Handlebars} = Ember;
 const {countWords} = ghostHelperUtils;
 
+const CM_MODE_MAP = {
+    html: 'htmlmixed',
+    xhtml: 'htmlmixed',
+    hbs: 'handlebars',
+    js: 'javascript'
+};
+
 export default Component.extend({
     layout,
 
@@ -50,6 +57,11 @@ export default Component.extend({
     escapedCode: computed('payload.code', function () {
         let escapedCode = Handlebars.Utils.escapeExpression(this.payload.code);
         return htmlSafe(escapedCode);
+    }),
+
+    cmMode: computed('payload.language', function () {
+        let {language} = this.payload;
+        return CM_MODE_MAP[language] || language;
     }),
 
     init() {

--- a/lib/koenig-editor/addon/components/koenig-card-code.js
+++ b/lib/koenig-editor/addon/components/koenig-card-code.js
@@ -71,7 +71,7 @@ export default Component.extend({
     }),
 
     languageInputStyle: computed('showLanguageInput', function () {
-        let styles = ['caret-color: initial', 'top: 6px', 'right: 6px'];
+        let styles = ['top: 6px', 'right: 6px'];
         if (!this.showLanguageInput) {
             styles.push('opacity: 0');
         }

--- a/lib/koenig-editor/addon/components/koenig-card.js
+++ b/lib/koenig-editor/addon/components/koenig-card.js
@@ -12,7 +12,7 @@ export default Component.extend({
     koenigDragDropHandler: service(),
 
     layout,
-    attributeBindings: ['style'],
+    attributeBindings: ['_style:style'],
     classNameBindings: ['selectedClass'],
 
     // attrs
@@ -43,13 +43,6 @@ export default Component.extend({
     onDeselect() {},
     onEnterEdit() {},
     onLeaveEdit() {},
-
-    // TODO: replace with Spirit classes
-    style: computed(function () {
-        let baseStyles = 'cursor: default; caret-color: auto;';
-
-        return htmlSafe(baseStyles);
-    }),
 
     shouldShowToolbar: computed('showToolbar', 'koenigDragDropHandler.isDragging', function () {
         return this.showToolbar && !this.koenigDragDropHandler.isDragging;
@@ -87,6 +80,13 @@ export default Component.extend({
         let isSelected = this.isSelected;
         let isEditing = this.isEditing;
         let hasEditMode = this.hasEditMode;
+
+        if (this.style !== this._lastSstyle) {
+            // TODO: replace with Spirit classes
+            let baseStyles = 'cursor: default; caret-color: auto;';
+            this.set('_style', htmlSafe(`${baseStyles} ${this.style}`));
+        }
+        this._lastStyle = this.style;
 
         if (isSelected !== this._lastIsSelected) {
             if (isSelected) {

--- a/lib/koenig-editor/addon/components/koenig-editor.js
+++ b/lib/koenig-editor/addon/components/koenig-editor.js
@@ -415,6 +415,12 @@ export default Component.extend({
             });
         });
 
+        editor.willHandleNewline((event) => {
+            run.join(() => {
+                this.willHandleNewline(event);
+            });
+        });
+
         if (this.isEditingDisabled) {
             editor.disableEditing();
         }
@@ -636,6 +642,10 @@ export default Component.extend({
     /* public interface ----------------------------------------------------- */
     // TODO: find a better way to expose the public interface?
 
+    skipNewline() {
+        this._skipNextNewline = true;
+    },
+
     // HACK: this scheduled cleanup is a bit hacky. We call .cleanup when
     // initializing Koenig in our editor controller but we have to wait for
     // rendering to finish so that componentCards is populated, even then
@@ -776,6 +786,13 @@ export default Component.extend({
         } else {
             this.set('activeMarkupTagNames', markupTags);
             this.set('activeSectionTagNames', sectionTags);
+        }
+    },
+
+    willHandleNewline(event) {
+        if (this._skipNextNewline) {
+            event.preventDefault();
+            this._skipNextNewline = false;
         }
     },
 

--- a/lib/koenig-editor/addon/options/text-expansions.js
+++ b/lib/koenig-editor/addon/options/text-expansions.js
@@ -395,7 +395,7 @@ export default function (editor, koenig) {
 
     editor.onTextInput({
         name: 'md_code',
-        match: /^```([a-zA-Z0-9]*)\n$/,
+        match: /^```([a-zA-Z0-9]*)[\n\s]$/,
         run(editor, matches) {
             let {range: {head, head: {section}}} = editor;
             let payload = {};

--- a/lib/koenig-editor/addon/options/text-expansions.js
+++ b/lib/koenig-editor/addon/options/text-expansions.js
@@ -395,9 +395,10 @@ export default function (editor, koenig) {
 
     editor.onTextInput({
         name: 'md_code',
-        match: /^```$/,
-        run(editor) {
+        match: /^```([a-zA-Z0-9]*)\n$/,
+        run(editor, matches) {
             let {range: {head, head: {section}}} = editor;
+            let payload = {};
 
             // Skip if cursor is not at end of section
             if (!head.isTail()) {
@@ -409,7 +410,11 @@ export default function (editor, koenig) {
                 return;
             }
 
-            koenig.send('replaceWithCardSection', 'code', section.toRange());
+            if (matches[1]) {
+                payload.language = matches[1];
+            }
+
+            koenig.send('replaceWithCardSection', 'code', section.toRange(), payload);
         }
     });
 

--- a/lib/koenig-editor/addon/options/text-expansions.js
+++ b/lib/koenig-editor/addon/options/text-expansions.js
@@ -395,7 +395,7 @@ export default function (editor, koenig) {
 
     editor.onTextInput({
         name: 'md_code',
-        match: /^```([a-zA-Z0-9]*)[\n\s]$/,
+        match: /^```([a-zA-Z0-9]*)(\s)$/,
         run(editor, matches) {
             let {range: {head, head: {section}}} = editor;
             let payload = {};
@@ -412,6 +412,10 @@ export default function (editor, koenig) {
 
             if (matches[1]) {
                 payload.language = matches[1];
+            }
+
+            if (matches[2] === '\n') {
+                koenig.skipNewline();
             }
 
             koenig.send('replaceWithCardSection', 'code', section.toRange(), payload);

--- a/lib/koenig-editor/addon/templates/components/koenig-card-code.hbs
+++ b/lib/koenig-editor/addon/templates/components/koenig-card-code.hbs
@@ -18,6 +18,7 @@
             autofocus=true
             lineWrapping=true
             update=(action "updateCode")
+            mode=cmMode
         }}
     {{else}}
         <div class="koenig-card-html-rendered">

--- a/lib/koenig-editor/addon/templates/components/koenig-card-code.hbs
+++ b/lib/koenig-editor/addon/templates/components/koenig-card-code.hbs
@@ -1,6 +1,6 @@
 {{#koenig-card
     class=(concat "ba b--white relative kg-card-hover miw-100 relative" (if isEditing " bw2 pt1 pb1 pl2 nl6 pr6 nr6"))
-    style=(if isEditing "background-color: #f5f7f8; border-color: #f5f7f8")
+    style=cardStyle
     headerOffset=headerOffset
     toolbar=toolbar
     payload=payload
@@ -10,6 +10,7 @@
     deselectCard=(action deselectCard)
     editCard=(action editCard)
     saveCard=(action saveCard)
+    onEnterEdit=(action "enterEditMode")
     onLeaveEdit=(action "leaveEditMode")
     editor=editor
 }}
@@ -26,7 +27,8 @@
             value={{readonly payload.language}}
             onblur={{action (mut payload.language) value="target.value"}}
             placeholder="Language..."
-            class="absolute top-1 right-1 w-20 pa1 ba b--lightgrey fs-base z-999"
+            class="absolute top-1 right-1 w-20 pa1 ba b--lightgrey fs-base z-999 outline-0 anim-normal"
+            style={{languageInputStyle}}
         />
     {{else}}
         <div class="koenig-card-html-rendered">

--- a/lib/koenig-editor/addon/templates/components/koenig-card-code.hbs
+++ b/lib/koenig-editor/addon/templates/components/koenig-card-code.hbs
@@ -20,10 +20,22 @@
             update=(action "updateCode")
             mode=cmMode
         }}
+        <input
+            type="text"
+            value={{readonly payload.language}}
+            onblur={{action (mut payload.language) value="target.value"}}
+            placeholder="Language..."
+            class="absolute top-1 right-1 w-20 pa1 ba b--lightgrey fs-base z-999"
+        />
     {{else}}
         <div class="koenig-card-html-rendered">
             <pre><code class="line-numbers {{if payload.language (concat "language-" payload.language)}}">{{escapedCode}}</code></pre>
         </div>
+        {{#if payload.language}}
+            <div class="absolute top-2 right-2 flex justify-center items-center pa2 br2 bg-white-90">
+                <span class="db fs-base ttu">{{payload.language}}</span>
+            </div>
+        {{/if}}
         <div class="koenig-card-click-overlay"></div>
     {{/if}}
 {{/koenig-card}}

--- a/lib/koenig-editor/addon/templates/components/koenig-card-code.hbs
+++ b/lib/koenig-editor/addon/templates/components/koenig-card-code.hbs
@@ -1,5 +1,6 @@
 {{#koenig-card
-    class=(concat "ba b--white relative kg-card-hover miw-100 relative" (if isEditing "pt1 pb1 pl6 nl6 pr6 nr6"))
+    class=(concat "ba b--white relative kg-card-hover miw-100 relative" (if isEditing " bw2 pt1 pb1 pl2 nl6 pr6 nr6"))
+    style=(if isEditing "background-color: #f5f7f8; border-color: #f5f7f8")
     headerOffset=headerOffset
     toolbar=toolbar
     payload=payload
@@ -14,7 +15,7 @@
 }}
     {{#if isEditing}}
         {{gh-cm-editor payload.code
-            class="koenig-card-html--editor"
+            class="koenig-card-code--editor koenig-card-html--editor"
             autofocus=true
             lineWrapping=true
             update=(action "updateCode")
@@ -32,8 +33,8 @@
             <pre><code class="line-numbers {{if payload.language (concat "language-" payload.language)}}">{{escapedCode}}</code></pre>
         </div>
         {{#if payload.language}}
-            <div class="absolute top-2 right-2 flex justify-center items-center pa2 br2 bg-white-90">
-                <span class="db fs-base ttu">{{payload.language}}</span>
+            <div class="absolute top-2 right-2 flex justify-center items-center pa2">
+                <span class="db fs-base">{{payload.language}}</span>
             </div>
         {{/if}}
         <div class="koenig-card-click-overlay"></div>

--- a/lib/koenig-editor/addon/templates/components/koenig-card-code.hbs
+++ b/lib/koenig-editor/addon/templates/components/koenig-card-code.hbs
@@ -27,7 +27,7 @@
             value={{readonly payload.language}}
             onblur={{action (mut payload.language) value="target.value"}}
             placeholder="Language..."
-            class="absolute top-1 right-1 w-20 pa1 ba b--lightgrey fs-base z-999 outline-0 anim-normal"
+            class="absolute w-20 pa1 ba b--lightgrey br2 f-small tracked-2 fw4 z-999 outline-0 anim-normal"
             style={{languageInputStyle}}
         />
     {{else}}
@@ -36,7 +36,7 @@
         </div>
         {{#if payload.language}}
             <div class="absolute top-2 right-2 flex justify-center items-center pa2">
-                <span class="db fs-base">{{payload.language}}</span>
+                <span class="db nudge-top--2 fw5 f-small midlightgrey">{{payload.language}}</span>
             </div>
         {{/if}}
         <div class="koenig-card-click-overlay"></div>

--- a/lib/koenig-editor/addon/templates/components/koenig-card-code.hbs
+++ b/lib/koenig-editor/addon/templates/components/koenig-card-code.hbs
@@ -17,6 +17,7 @@
     {{#if isEditing}}
         {{gh-cm-editor payload.code
             class="koenig-card-code--editor koenig-card-html--editor"
+            textareaClass="o-0"
             autofocus=true
             lineWrapping=true
             update=(action "updateCode")


### PR DESCRIPTION
no issue

- Added a language indicator when in rendered mode and a language input when in edit mode
- Allow code card language to be set with <code>```lang</code>+<kbd>Space/Enter</kbd> expansion 
    - previously <code>\`\`\`</code> would immediately create a code card, the <kbd>Space/Enter</kbd> is now necessary for the insertion to occur
    - lang is optional <code>\`\`\`</code>+<kbd>Space/Enter</kbd> will insert a code card with no language selected
    - requires <kbd>Enter</kbd> to be pressed to finalise the expansion and insert the card
- Set the code card editor's language mode based on selected language
    - set the CodeMirror mode based on the code card payload language
        - add a basic map of language short codes to their respective CodeMirror modes
    - observe `mode` property in `{{gh-cm-editor}}` so that the mode is properly set when it's changed after initial render

TODO:
- [x] fix issue with carriage returns being inserted when text expansions are triggered with <kbd>Enter</kbd>
- [x] finalise language input design
