### PR TITLE
✨ Added caption support to code cards

### DIFF
--- a/lib/koenig-editor/addon/components/kg-action-bar.js
+++ b/lib/koenig-editor/addon/components/kg-action-bar.js
@@ -1,0 +1,28 @@
+import Component from '@ember/component';
+import layout from '../templates/components/kg-action-bar';
+import {computed} from '@ember/object';
+
+export default Component.extend({
+    layout,
+
+    tagName: '',
+
+    instantClose: false,
+    isVisible: false,
+    style: null,
+
+    animationClasses: computed('isVisible', 'instantClose', function () {
+        let {instantClose, isVisible} = this;
+        let classes = [];
+
+        if (!instantClose || (instantClose && isVisible)) {
+            classes.push('anim-fast-bezier');
+        }
+
+        if (!isVisible) {
+            classes.push('o-0 pop-down');
+        }
+
+        return classes.join(' ');
+    })
+});

--- a/lib/koenig-editor/addon/components/koenig-caption-input.js
+++ b/lib/koenig-editor/addon/components/koenig-caption-input.js
@@ -4,8 +4,11 @@ import layout from '../templates/components/koenig-caption-input';
 import {computed} from '@ember/object';
 import {kgStyle} from '../helpers/kg-style';
 import {run} from '@ember/runloop';
+import {inject as service} from '@ember/service';
 
 export default Component.extend({
+    koenigUi: service(),
+
     tagName: 'figcaption',
     classNameBindings: ['figCaptionClass'],
     layout,
@@ -40,6 +43,7 @@ export default Component.extend({
 
     willDestroyElement() {
         this._super(...arguments);
+        this.koenigUi.captionLostFocus(this);
         this._detachHandlers();
     },
 
@@ -70,6 +74,18 @@ export default Component.extend({
             this.addParagraphAfterCard();
         }
     },
+
+    // events ------------------------------------------------------------------
+
+    focusIn() {
+        this.koenigUi.captionGainedFocus(this);
+    },
+
+    focusOut() {
+        this.koenigUi.captionLostFocus(this);
+    },
+
+    // private -----------------------------------------------------------------
 
     _attachHandlers() {
         if (!this._keypressHandler) {

--- a/lib/koenig-editor/addon/components/koenig-card-code.js
+++ b/lib/koenig-editor/addon/components/koenig-card-code.js
@@ -35,6 +35,9 @@ export default Component.extend({
     deselectCard() {},
     deleteCard() {},
     registerComponent() {},
+    moveCursorToNextSection() {},
+    moveCursorToPrevSection() {},
+    addParagraphAfterCard() {},
 
     counts: computed('payload.code', function () {
         return {wordCount: countWords(this.payload.code)};
@@ -96,6 +99,10 @@ export default Component.extend({
         updateCode(code) {
             this._hideLanguageInput();
             this._updatePayloadAttr('code', code);
+        },
+
+        updateCaption(caption) {
+            this._updatePayloadAttr('caption', caption);
         },
 
         enterEditMode() {

--- a/lib/koenig-editor/addon/components/koenig-card.js
+++ b/lib/koenig-editor/addon/components/koenig-card.js
@@ -9,7 +9,7 @@ import {inject as service} from '@ember/service';
 const TICK_HEIGHT = 8;
 
 export default Component.extend({
-    koenigDragDropHandler: service(),
+    koenigUi: service(),
 
     layout,
     attributeBindings: ['_style:style'],
@@ -44,8 +44,8 @@ export default Component.extend({
     onEnterEdit() {},
     onLeaveEdit() {},
 
-    shouldShowToolbar: computed('showToolbar', 'koenigDragDropHandler.isDragging', function () {
-        return this.showToolbar && !this.koenigDragDropHandler.isDragging;
+    shouldShowToolbar: computed('showToolbar', 'koenigUi.{captionHasFocus,isDragging}', function () {
+        return this.showToolbar && !this.koenigUi.captionHasFocus && !this.koenigUi.isDragging;
     }),
 
     toolbarStyle: computed('shouldShowToolbar', 'toolbarWidth', 'toolbarHeight', function () {
@@ -166,10 +166,11 @@ export default Component.extend({
             this._skipMouseUp = true;
         }
 
-        // don't trigger select->edit transition for clicks in the caption
+        // don't trigger select->edit transition for clicks in the caption or
+        // when clicking out of the caption
         if (isSelected && hasEditMode) {
             let allowClickthrough = !!event.target.closest('[data-kg-allow-clickthrough]');
-            if (allowClickthrough) {
+            if (allowClickthrough || this.koenigUi.captionHasFocus) {
                 this._skipMouseUp = true;
             }
         }
@@ -179,7 +180,7 @@ export default Component.extend({
     mouseUp(event) {
         let {isSelected, isEditing, hasEditMode, _skipMouseUp} = this;
 
-        if (!_skipMouseUp && hasEditMode && isSelected && !isEditing && !this.koenigDragDropHandler.isDragging) {
+        if (!_skipMouseUp && hasEditMode && isSelected && !isEditing && !this.koenigUi.isDragging) {
             this.editCard();
             this.set('showToolbar', true);
             event.preventDefault();

--- a/lib/koenig-editor/addon/components/koenig-card.js
+++ b/lib/koenig-editor/addon/components/koenig-card.js
@@ -239,7 +239,9 @@ export default Component.extend({
 
     _setToolbarProperties() {
         if (this.toolbar) {
-            let toolbar = this.element.querySelector('[data-toolbar="true"]');
+            // select the last toolbar in the element because card contents/captions
+            // may have their own toolbar elements
+            let toolbar = this.element.querySelector(':scope > [data-kg-toolbar="true"]');
             let {width, height} = toolbar.getBoundingClientRect();
 
             this.setProperties({

--- a/lib/koenig-editor/addon/components/koenig-card.js
+++ b/lib/koenig-editor/addon/components/koenig-card.js
@@ -141,7 +141,7 @@ export default Component.extend({
     },
 
     mouseDown(event) {
-        let {isSelected, isEditing} = this;
+        let {isSelected, isEditing, hasEditMode} = this;
 
         // if we perform an action we want to prevent the mousedown from
         // triggering a cursor position change which can result in multiple
@@ -165,6 +165,14 @@ export default Component.extend({
             // don't trigger edit mode immediately
             this._skipMouseUp = true;
         }
+
+        // don't trigger select->edit transition for clicks in the caption
+        if (isSelected && hasEditMode) {
+            let allowClickthrough = !!event.target.closest('[data-kg-allow-clickthrough]');
+            if (allowClickthrough) {
+                this._skipMouseUp = true;
+            }
+        }
     },
 
     // lazy-click to enter edit mode
@@ -181,7 +189,8 @@ export default Component.extend({
     },
 
     doubleClick() {
-        if (this.hasEditMode && !this.isEditing) {
+        let allowClickthrough = !!event.target.closest('[data-kg-allow-clickthrough]');
+        if (this.hasEditMode && !this.isEditing && !allowClickthrough) {
             this.editCard();
             this.set('showToolbar', true);
         }

--- a/lib/koenig-editor/addon/options/parser-plugins.js
+++ b/lib/koenig-editor/addon/options/parser-plugins.js
@@ -77,6 +77,38 @@ export function hrToCard(node, builder, {addSection, nodeFinished}) {
     nodeFinished();
 }
 
+export function figureToCodeCard(node, builder, {addSection, nodeFinished}) {
+    if (node.nodeType !== 1 || node.tagName !== 'FIGURE') {
+        return;
+    }
+
+    let pre = node.querySelector('pre');
+    let code = pre.querySelector('code');
+    let figcaption = node.querySelector('figcaption');
+
+    // if there's no caption the preCodeToCard plugin will pick it up instead
+    if (!code || !figcaption) {
+        return;
+    }
+
+    let payload = {
+        code: code.textContent,
+        caption: cleanBasicHtml(figcaption.innerHTML)
+    };
+
+    let preClass = code.getAttribute('class');
+    let codeClass = code.getAttribute('class');
+    let langRegex = /lang(?:uage)?-(.*?)(?:\s|$)/i;
+    let languageMatches = preClass.match(langRegex) || codeClass.match(langRegex);
+    if (languageMatches) {
+        payload.language = languageMatches[1].toLowerCase();
+    }
+
+    let cardSection = builder.createCardSection('code', payload);
+    addSection(cardSection);
+    nodeFinished();
+}
+
 export function preCodeToCard(node, builder, {addSection, nodeFinished}) {
     if (node.nodeType !== 1 || node.tagName !== 'PRE') {
         return;
@@ -86,6 +118,15 @@ export function preCodeToCard(node, builder, {addSection, nodeFinished}) {
 
     if (codeElement && codeElement.tagName === 'CODE') {
         let payload = {code: codeElement.textContent};
+
+        let preClass = node.getAttribute('class');
+        let codeClass = codeElement.getAttribute('class');
+        let langRegex = /lang(?:uage)?-(.*?)(?:\s|$)/i;
+        let languageMatches = preClass.match(langRegex) || codeClass.match(langRegex);
+        if (languageMatches) {
+            payload.language = languageMatches[1].toLowerCase();
+        }
+
         let cardSection = builder.createCardSection('code', payload);
         addSection(cardSection);
         nodeFinished();
@@ -98,5 +139,6 @@ export default [
     figureToImageCard,
     imgToCard,
     hrToCard,
+    figureToCodeCard,
     preCodeToCard
 ];

--- a/lib/koenig-editor/addon/services/koenig-drag-drop-handler.js
+++ b/lib/koenig-editor/addon/services/koenig-drag-drop-handler.js
@@ -4,8 +4,10 @@ import Container from '../lib/dnd/container';
 import ScrollHandler from '../lib/dnd/scroll-handler';
 import Service from '@ember/service';
 import {A} from '@ember/array';
+import {alias} from '@ember/object/computed';
 import {didCancel, task, waitForProperty} from 'ember-concurrency';
 import {run} from '@ember/runloop';
+import {inject as service} from '@ember/service';
 
 // this service allows registration of "containers"
 // containers can have both draggables and droppables
@@ -15,12 +17,14 @@ import {run} from '@ember/runloop';
 // this service keeps track of all containers and has centralized event handling for mouse events
 
 export default Service.extend({
+    koenigUi: service(),
 
     containers: null,
     ghostInfo: null,
     grabbedElement: null, // TODO: standardise on draggableInfo.element
-    isDragging: false,
     sourceContainer: null,
+
+    isDragging: alias('koenigUi.isDragging'),
 
     _eventHandlers: null,
 

--- a/lib/koenig-editor/addon/services/koenig-ui.js
+++ b/lib/koenig-editor/addon/services/koenig-ui.js
@@ -1,0 +1,18 @@
+import Service from '@ember/service';
+
+export default Service.extend({
+    captionHasFocus: false,
+    isDragging: false,
+
+    captionGainedFocus(caption) {
+        this._focusedCaption = caption;
+        this.set('captionHasFocus', true);
+    },
+
+    captionLostFocus(caption) {
+        if (this._focusedCaption === caption) {
+            this._focusedCaption = null;
+            this.set('captionHasFocus', false);
+        }
+    }
+});

--- a/lib/koenig-editor/addon/templates/components/kg-action-bar.hbs
+++ b/lib/koenig-editor/addon/templates/components/kg-action-bar.hbs
@@ -1,0 +1,3 @@
+<ul class="kg-action-bar inline-flex items-center pa0 ma0 pl1 pr1 nl1 list br3 shadow-2 bg-darkgrey-d1 white sans-serif f8 fw6 tracked-2 z-999 {{this.class}} {{this.animationClasses}}" style={{this.style}} data-kg-toolbar="true" data-kg-allow-clickthrough="true">
+    {{yield}}
+</ul>

--- a/lib/koenig-editor/addon/templates/components/koenig-card-code.hbs
+++ b/lib/koenig-editor/addon/templates/components/koenig-card-code.hbs
@@ -52,7 +52,7 @@
             class="z-999"
             caption=payload.caption
             update=(action "updateCaption")
-            placeholder="Type caption for image (optional)"
+            placeholder="Type caption for code block (optional)"
         }}
     {{/if}}
 {{/koenig-card}}

--- a/lib/koenig-editor/addon/templates/components/koenig-card-code.hbs
+++ b/lib/koenig-editor/addon/templates/components/koenig-card-code.hbs
@@ -12,7 +12,11 @@
     saveCard=(action saveCard)
     onEnterEdit=(action "enterEditMode")
     onLeaveEdit=(action "leaveEditMode")
+    addParagraphAfterCard=addParagraphAfterCard
+    moveCursorToPrevSection=moveCursorToPrevSection
+    moveCursorToNextSection=moveCursorToNextSection
     editor=editor
+    as |card|
 }}
     {{#if isEditing}}
         {{gh-cm-editor payload.code
@@ -41,5 +45,14 @@
             </div>
         {{/if}}
         <div class="koenig-card-click-overlay"></div>
+    {{/if}}
+
+    {{#if (and (not isEditing) (or isSelected (clean-basic-html payload.caption)))}}
+        {{card.captionInput
+            class="z-999"
+            caption=payload.caption
+            update=(action "updateCaption")
+            placeholder="Type caption for image (optional)"
+        }}
     {{/if}}
 {{/koenig-card}}

--- a/lib/koenig-editor/addon/templates/components/koenig-card.hbs
+++ b/lib/koenig-editor/addon/templates/components/koenig-card.hbs
@@ -12,7 +12,7 @@
 ))}}
 
 {{#if toolbar}}
-    <ul data-toolbar="true" class="kg-action-bar bg-darkgrey-d1 inline-flex pa0 ma0 pl1 pr1 nl1 list br3 shadow-2 items-center absolute white sans-serif f8 fw6 tracked-2 anim-fast-bezier z-999 {{if shouldShowToolbar "" "o-0 pop-down"}}" style={{toolbarStyle}}>
+    {{#kg-action-bar class="absolute" style=toolbarStyle isVisible=shouldShowToolbar}}
         {{#each toolbar.items as |item|}}
             {{#if item.divider}}
                 <li class="ma0 kg-action-bar-divider bg-darkgrey-d2 h5"></li>
@@ -29,5 +29,5 @@
                 </li>
             {{/if}}
         {{/each}}
-    </ul>
+    {{/kg-action-bar}}
 {{/if}}

--- a/lib/koenig-editor/addon/templates/components/koenig-toolbar.hbs
+++ b/lib/koenig-editor/addon/templates/components/koenig-toolbar.hbs
@@ -1,4 +1,4 @@
-<ul class="kg-action-bar bg-darkgrey-d1 inline-flex pa0 ma0 pl1 pr1 nl1 list br3 shadow-2 items-center relative white f8 fw6 tracked-2 {{if showToolbar "anim-fast-bezier" "o-0 pop-down"}}">
+<ul class="kg-action-bar bg-darkgrey-d1 inline-flex pa0 ma0 pl1 pr1 nl1 list br3 shadow-2 items-center relative white f8 fw6 tracked-2 {{if showToolbar "anim-fast-bezier" "o-0 pop-down"}}" data-kg-allow-clickthrough="true">
     <li class="ma0 lh-solid">
         <button
             type="button"

--- a/lib/koenig-editor/addon/templates/components/koenig-toolbar.hbs
+++ b/lib/koenig-editor/addon/templates/components/koenig-toolbar.hbs
@@ -1,4 +1,4 @@
-<ul class="kg-action-bar bg-darkgrey-d1 inline-flex pa0 ma0 pl1 pr1 nl1 list br3 shadow-2 items-center relative white f8 fw6 tracked-2 {{if showToolbar "anim-fast-bezier" "o-0 pop-down"}}" data-kg-allow-clickthrough="true">
+{{#kg-action-bar class="relative" instantClose=true isVisible=showToolbar}}
     <li class="ma0 lh-solid">
         <button
             type="button"
@@ -66,4 +66,4 @@
             {{svg-jar "koenig/kg-link" class=(concat (if activeMarkupTagNames.isA "fill-blue-l2" "fill-white") " w4 h4")}}
         </button>
     </li>
-</ul>
+{{/kg-action-bar}}

--- a/lib/koenig-editor/app/components/kg-action-bar.js
+++ b/lib/koenig-editor/app/components/kg-action-bar.js
@@ -1,0 +1,1 @@
+export {default} from 'koenig-editor/components/kg-action-bar';

--- a/lib/koenig-editor/app/services/koenig-ui.js
+++ b/lib/koenig-editor/app/services/koenig-ui.js
@@ -1,0 +1,1 @@
+export {default} from 'koenig-editor/services/koenig-ui';


### PR DESCRIPTION
requires https://github.com/TryGhost/Ghost/pull/10719

- added caption component to the code card
- updated the click-to-edit behaviour for cards with edit mode to allow clicks through to the caption element so that caption clicks, selects, etc don't trigger edit mode
- added allow-clickthrough data attribute to the toolbar element so clicks on the caption's formatting toolbar don't trigger edit mode
- added parser plugin to transform `<figure><pre /><code /><figcaption /></figure>` into a code card with a caption
- improved code card parser plugins so that they can set the code card's language if a `lang-x` or `language-x` CSS class is detected
- added `koenig-ui` service for tracking when a caption has focus so that we can disable card toolbars when a caption has focus
  - aliased the `koenigUi.isDragging` property to the `koenigDragDropHandler.isDragging` property so that `koenigUi` can become the central store of general UI state within the editor

TODO:
- [x] hide card toolbar when caption toolbar is displayed
- [x] add parser plugin for parsing figures to code cards with captions