### PR TITLE
🔗 Update link to Marketplace

### DIFF
--- a/app/templates/settings/design.hbs
+++ b/app/templates/settings/design.hbs
@@ -95,7 +95,7 @@
             </div>
 
             <div class="td-cta">
-                <a class="td-cta-box td-cta-marketplace" href="https://marketplace.ghost.org" target="_blank" rel="noopener">
+                <a class="td-cta-box td-cta-marketplace" href="https://ghost.org/marketplace/" target="_blank" rel="noopener">
                     <div class="td-cta-icon">{{svg-jar "store"}}</div>
                     <div class="td-cta-content-wrapper">
                         <div class="td-cta-content">


### PR DESCRIPTION
no issue

- Marketplace moved to https://ghost.org/marketplace
