### PR TITLE
🐛Changed date-time picker date format to 'YYYY-MM-DD'.

### DIFF
--- a/app/templates/components/gh-date-time-picker.hbs
+++ b/app/templates/components/gh-date-time-picker.hbs
@@ -8,7 +8,7 @@
     }}
         {{#dp.trigger tabindex="-1" data-test-date-time-picker-datepicker=true}}
             <div class="gh-date-time-picker-date {{if dateError "error"}}">
-                <input type="text" readonly value={{moment-format _date "MM/DD/YYYY"}} disabled={{disabled}} data-test-date-time-picker-date-input>
+                <input type="text" readonly value={{moment-format _date "YYYY-MM-DD"}} disabled={{disabled}} data-test-date-time-picker-date-input>
                 {{svg-jar "calendar"}}
             </div>
         {{/dp.trigger}}


### PR DESCRIPTION
refs #10767
In the absence of being able to determine full locale data (i.e. being able to differntiate between EN-US and EN-AU, EN-GB, etc.), using YYYY-MM-DD seems to be the most unambiguous date format. For those not in American English speaking locales, the American date format (MM/DD/YYYY) can be very confusing.