### PR TITLE
🎨 Changed post/page date picker format to 'YYYY-MM-DD'

### DIFF
--- a/app/templates/components/gh-date-time-picker.hbs
+++ b/app/templates/components/gh-date-time-picker.hbs
@@ -8,7 +8,7 @@
     }}
         {{#dp.trigger tabindex="-1" data-test-date-time-picker-datepicker=true}}
             <div class="gh-date-time-picker-date {{if dateError "error"}}">
-                <input type="text" readonly value={{moment-format _date "MM/DD/YYYY"}} disabled={{disabled}} data-test-date-time-picker-date-input>
+                <input type="text" readonly value={{moment-format _date "YYYY-MM-DD"}} disabled={{disabled}} data-test-date-time-picker-date-input>
                 {{svg-jar "calendar"}}
             </div>
         {{/dp.trigger}}

--- a/tests/acceptance/editor-test.js
+++ b/tests/acceptance/editor-test.js
@@ -158,7 +158,7 @@ describe('Acceptance: Editor', function () {
             expect(
                 find('[data-test-date-time-picker-date-input]').value,
                 'PSM date value after closing with invalid date'
-            ).to.equal(moment(post1.publishedAt).tz('Etc/UTC').format('MM/DD/YYYY'));
+            ).to.equal(moment(post1.publishedAt).tz('Etc/UTC').format('YYYY-MM-DD'));
 
             expect(
                 find('[data-test-date-time-picker-time-input]').value,
@@ -238,7 +238,7 @@ describe('Acceptance: Editor', function () {
             await visit('/editor/post/2');
 
             expect(currentURL(), 'currentURL').to.equal('/editor/post/2');
-            expect(find('[data-test-date-time-picker-date-input]').value).to.equal('12/19/2015');
+            expect(find('[data-test-date-time-picker-date-input]').value).to.equal('2015-12-19');
             expect(find('[data-test-date-time-picker-time-input]').value).to.equal('16:25');
 
             // saves the post with a new date
@@ -288,7 +288,7 @@ describe('Acceptance: Editor', function () {
             expect(
                 find('[data-test-date-time-picker-date-input]').value,
                 'date after timezone change'
-            ).to.equal('05/10/2016');
+            ).to.equal('2016-05-10');
 
             expect(
                 find('[data-test-date-time-picker-time-input]').value,
@@ -523,7 +523,7 @@ describe('Acceptance: Editor', function () {
         it('renders first countdown notification before scheduled time', async function () {
             let clock = sinon.useFakeTimers(moment().valueOf());
             let compareDate = moment().tz('Etc/UTC').add(4, 'minutes');
-            let compareDateString = compareDate.format('MM/DD/YYYY');
+            let compareDateString = compareDate.format('YYYY-MM-DD');
             let compareTimeString = compareDate.format('HH:mm');
             this.server.create('post', {publishedAt: moment.utc().add(4, 'minutes'), status: 'scheduled', authors: [author]});
             this.server.create('setting', {activeTimezone: 'Europe/Dublin'});


### PR DESCRIPTION
refs TryGhost/Ghost#10767

The use of the date format 'MM/DD/YYYY' is confusing to those not in American English locations. In the absence of being able to dynamically determine full locale data, using 'YYYY-MM-DD' seems to the least ambiguous date format which would be intuitive to most users.