### PR TITLE
🔥 Dropped Node v6 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint:js": "eslint ."
   },
   "engines": {
-    "node": ">= 6"
+    "node": "^8.9.0 || ^10.13.0"
   },
   "devDependencies": {
     "@ember/jquery": "0.6.0",


### PR DESCRIPTION
no issue

- Node v6 has come to EOL as of 2019-04-30 (ref. https://github.com/nodejs/Release#end-of-life-releases)
