### PR TITLE
Fixed missing ghost-dark.css causing crash

### DIFF
--- a/app/services/feature.js
+++ b/app/services/feature.js
@@ -128,7 +128,8 @@ export default Service.extend({
         return this.lazyLoader.loadStyle('dark', 'assets/ghost-dark.css', true).then(() => {
             $('link[title=dark]').prop('disabled', !nightShift);
             $('link[title=light]').prop('disabled', nightShift);
-        }).catch((err) => {
+        }).catch(() => {
+            //TODO: Also disable toggle from settings and Labs hover
             $('link[title=dark]').prop('disabled', true);
             $('link[title=light]').prop('disabled', false);
         });

--- a/app/services/feature.js
+++ b/app/services/feature.js
@@ -128,6 +128,9 @@ export default Service.extend({
         return this.lazyLoader.loadStyle('dark', 'assets/ghost-dark.css', true).then(() => {
             $('link[title=dark]').prop('disabled', !nightShift);
             $('link[title=light]').prop('disabled', nightShift);
+        }).catch((err) => {
+            $('link[title=dark]').prop('disabled', true);
+            $('link[title=light]').prop('disabled', false);
         });
     }
 });


### PR DESCRIPTION
We currently set admin theme by dynamically loading `ghost-dark.css` and based on the value of `nightShift` feature. In extreme cases, when `ghost-dark.css` is unavailable, it causes the ember route to crash as we reject the promise from `lazyLoader` service which is currently not being handled in `setAdminTheme` method.

As a quick fix, `setAdminTheme` method is updated to catch the error from `lazyLoader` and enable light theme as graceful exit.

Known issue: Admin will crash in case user attempts to toggle theme again from UI :(