### PR TITLE
Renamed "Preview site" to "View site"

### DIFF
--- a/app/templates/components/gh-nav-menu.hbs
+++ b/app/templates/components/gh-nav-menu.hbs
@@ -20,7 +20,7 @@
             <li class="relative">
                 <span {{action "transitionToOrRefreshSite" on="click"}}>
                     {{#link-to "site" data-test-nav="site" current-when=isOnSite preventDefault=false}}
-                        {{svg-jar "house"}} Preview site
+                        {{svg-jar "house"}} View site
                     {{/link-to}}
                 </span>
                 <a href="{{config.blogUrl}}/" class="gh-secondary-action" title="Open site in new tab" target="_blank">


### PR DESCRIPTION
no-issue

Preview implies something which is not-yet-live, but this feature only shows the live site.
