### PR TITLE
🐛Fixed links to editor FAQ page

### DIFF
--- a/app/templates/components/modal-markdown-help.hbs
+++ b/app/templates/components/modal-markdown-help.hbs
@@ -81,6 +81,6 @@
             </tr>
             </tbody>
         </table>
-        For further Markdown syntax reference: <a href="https://docs.ghost.org/faq/using-the-editor/#using-markdown" target="_blank">Markdown Documentation</a>
+        For further Markdown syntax reference: <a href="https://ghost.org/faq/using-the-editor/#using-markdown" target="_blank">Markdown Documentation</a>
     </section>
 </div>

--- a/app/templates/editor.hbs
+++ b/app/templates/editor.hbs
@@ -90,7 +90,7 @@
             <div class="midgrey-l2 {{if editor.headerClass "f-supersmall pl2 pr2" "f8 pl4 pr3"}} fw4">
                 {{pluralize wordCount.wordCount "word"}}
             </div>
-            <a href="https://docs.ghost.org/faq/using-the-editor/" class="flex {{if editor.headerClass "pa2" "pa3"}}" target="_blank">{{svg-jar "help" class="w4 h4 stroke-midgrey-l2"}}</a>
+            <a href="https://ghost.org/faq/using-the-editor/" class="flex {{if editor.headerClass "pa2" "pa3"}}" target="_blank">{{svg-jar "help" class="w4 h4 stroke-midgrey-l2"}}</a>
         </div>
 
     {{/gh-editor}}


### PR DESCRIPTION
refs #10803
Corrected link to editor usage FAQ in both instances of use in admin client.