### PR TITLE
Fixed Post Editor Help Icon Pointing to URL

### DIFF
--- a/app/templates/editor.hbs
+++ b/app/templates/editor.hbs
@@ -90,7 +90,7 @@
             <div class="midgrey-l2 {{if editor.headerClass "f-supersmall pl2 pr2" "f8 pl4 pr3"}} fw4">
                 {{pluralize wordCount.wordCount "word"}}
             </div>
-            <a href="https://docs.ghost.org/faq/using-the-editor/" class="flex {{if editor.headerClass "pa2" "pa3"}}" target="_blank">{{svg-jar "help" class="w4 h4 stroke-midgrey-l2"}}</a>
+            <a href="https://ghost.org/faq/using-the-editor/" class="flex {{if editor.headerClass "pa2" "pa3"}}" target="_blank">{{svg-jar "help" class="w4 h4 stroke-midgrey-l2"}}</a>
         </div>
 
     {{/gh-editor}}


### PR DESCRIPTION
The small help icon (far bottom right of the screen) in editor (post page) was pointing to the URL which no longer exists.

Resolves issue #10803
