### PR TITLE
Dropped Node v6 support for 1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "coverage": "cat ./coverage/lcov.info | coveralls"
   },
   "engines": {
-    "node": ">= 6"
+    "node": "^8.9.0 || ^10.13.0"
   },
   "devDependencies": {
     "@ember/optional-features": "0.6.1",


### PR DESCRIPTION
no issue

- Node v6 has come to EOL as of 2019-04-30 (ref. nodejs/Release#end-of-life-releases)

Note: updating travis to run on Node v10 caused build to fail - https://travis-ci.org/gargol/Ghost-Admin/builds/549962391 . Left it on v8 for now as it wasn't a priority. @kevinansfield did see similar fails when upgrading Travis environment to Node v10 in current master?