### PR TITLE
✨ Added ability to drag images in and out of galleries

### DIFF
--- a/lib/koenig-editor/addon/components/koenig-card-gallery.js
+++ b/lib/koenig-editor/addon/components/koenig-card-gallery.js
@@ -406,26 +406,21 @@ export default Component.extend({
         return {};
     },
 
-    _onDrop(draggableInfo, droppableElem, position) {
+    _onDrop(draggableInfo/*, droppableElem, position*/) {
         // do not allow dropping of non-images
         if (draggableInfo.type !== 'image' && draggableInfo.cardName !== 'image') {
             return false;
         }
 
+        let {insertIndex} = draggableInfo;
         let droppables = Array.from(this.element.querySelectorAll('[data-image]'));
         let draggableIndex = droppables.indexOf(draggableInfo.element);
 
-        if (this._isDropAllowed(draggableIndex, draggableInfo.insertIndex)) {
+        if (this._isDropAllowed(draggableIndex, insertIndex)) {
             if (draggableIndex === -1) {
                 // external image being added
                 let {payload} = draggableInfo;
                 let img = draggableInfo.element.querySelector(`img[src="${payload.src}"]`);
-                let insertIndex = draggableInfo.insertIndex;
-
-                // insert index needs adjusting because we're not shuffling
-                if (position && position.match(/right/)) {
-                    insertIndex += 1;
-                }
 
                 // image card payloads may not have all of the details we need but we can fill them in
                 payload.width = payload.width || img.naturalWidth;
@@ -440,8 +435,9 @@ export default Component.extend({
             } else {
                 // internal image being re-ordered
                 let draggedImage = this.images.findBy('src', draggableInfo.payload.src);
+                let accountForRemoval = draggableIndex < insertIndex && insertIndex ? -1 : 0;
                 this.images.removeObject(draggedImage);
-                this.images.insertAt(draggableInfo.insertIndex, draggedImage);
+                this.images.insertAt(insertIndex + accountForRemoval, draggedImage);
             }
 
             this._recalculateImageRows();
@@ -514,12 +510,8 @@ export default Component.extend({
                 }
             });
 
-            if (position.match(/right/) && draggableIndex > insertIndex) {
+            if (position.match(/right/)) {
                 insertIndex += 1;
-            }
-
-            if (insertIndex >= this.images.length - 1) {
-                insertIndex = this.images.length - 1;
             }
 
             return {

--- a/lib/koenig-editor/addon/services/koenig-drag-drop-handler.js
+++ b/lib/koenig-editor/addon/services/koenig-drag-drop-handler.js
@@ -149,15 +149,21 @@ export default Service.extend({
 
     _onMouseUp(/*event*/) {
         if (this.draggableInfo) {
+            let success = false;
+
             // TODO: accept object rather than positioned args? OR, should the
             // droppable data be stored on draggableInfo?
             if (this._currentOverContainer) {
-                this._currentOverContainer.onDrop(
+                success = this._currentOverContainer.onDrop(
                     this.draggableInfo,
                     this._currentOverDroppableElem,
                     this._currentOverDroppablePosition
                 );
             }
+
+            this.containers.forEach((container) => {
+                container.onDropEnd(this.draggableInfo, success);
+            });
         }
 
         // remove drag info and any ghost element

--- a/lib/koenig-editor/addon/services/koenig-drag-drop-handler.js
+++ b/lib/koenig-editor/addon/services/koenig-drag-drop-handler.js
@@ -353,7 +353,6 @@ export default Service.extend({
                 this._currentOverContainer.onDragLeaveDroppable(overDroppableElem);
             }
             this._currentOverDroppableElem = null;
-            this._currentOverDroppablePosition = null;
         }
 
         if (isOverDroppable) {


### PR DESCRIPTION
no issue

- adjust drag handlers in the editor and gallery card to handle drag/drop of image cards as well as straight images
- adjust drag handlers in the gallery card to handle image inserts as well as re-orders
- add `onDragEnd` event/action to the Koenig drag-n-drop handler so that containers can perform cleanup if one of their draggables was successfully dropped into a different container
- change ghost element when dragging an image card to be an image rather than a card icon
  - allow `createGhostElement` function passed in when registering a drag-n-drop container to fall back to the default behaviour by returning a falsy value
- fixed position bugs in the gallery re-ordering when dropping images

TODO:
- [x] fix positioning bug in galleries
- [x] adjust image card drag to show image preview as per gallery re-ordering
- [ ] improve scroll jumping when moving images into/out of cards (this is more of an issue when devtools is open so leaving for now)