### PR TITLE
Bumped minimum node v8.x version to v8.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint:js": "eslint ."
   },
   "engines": {
-    "node": "^8.9.0 || ^10.13.0"
+    "node": "^8.10.0 || ^10.13.0"
   },
   "devDependencies": {
     "@ember/jquery": "0.6.1",


### PR DESCRIPTION
no-issue

This is to keep it in sync with Ghost (https://github.com/TryGhost/Ghost/pull/10914) 
