### PR TITLE
✨ Added global meta data and Twitter/Facebook card settings

### DIFF
--- a/app/models/setting.js
+++ b/app/models/setting.js
@@ -29,5 +29,13 @@ export default Model.extend(ValidationEngine, {
             return {isActive: true};
         }
     }),
-    membersSubscriptionSettings: attr('string')
+    membersSubscriptionSettings: attr('string'),
+    metaTitle: attr('string'),
+    metaDescription: attr('string'),
+    twitterTitle: attr('string'),
+    twitterDescription: attr('string'),
+    twitterImage: attr('string'),
+    ogTitle: attr('string'),
+    ogDescription: attr('string'),
+    ogImage: attr('string')
 });

--- a/app/styles/layouts/settings.css
+++ b/app/styles/layouts/settings.css
@@ -71,19 +71,22 @@
 }
 
 .gh-setting-content-extended label {
+    display: block;
     font-size: 1.25rem;
-    line-height: 1.15em;
     font-weight: 600;
     color: var(--darkgrey);
+    margin-bottom: 4px;
 }
 
 .gh-setting-content-extended textarea {
+    font-size: 1.5rem;
+    line-height: 1.4em;
     max-width: initial;
 }
 
 .gh-setting-content-extended .gh-image-uploader {
     margin: 0;
-    border: 1px solid color-mod(var(--lightgrey));
+    border: 1px solid var(--lightgrey);
 }
 
 

--- a/app/styles/layouts/settings.css
+++ b/app/styles/layouts/settings.css
@@ -70,6 +70,23 @@
     margin: 1px 0 0 0;
 }
 
+.gh-setting-content-extended label {
+    font-size: 1.25rem;
+    line-height: 1.15em;
+    font-weight: 600;
+    color: var(--darkgrey);
+}
+
+.gh-setting-content-extended textarea {
+    max-width: initial;
+}
+
+.gh-setting-content-extended .gh-image-uploader {
+    margin: 0;
+    border: 1px solid color-mod(var(--lightgrey));
+}
+
+
 /* Images */
 
 .gh-setting-action-smallimg {
@@ -693,7 +710,7 @@
     margin-left: -17px;
 }
 
-.theme-fatal-error .theme-validation-type-label::before, 
+.theme-fatal-error .theme-validation-type-label::before,
 .theme-error .theme-validation-type-label::before {
     background: color-mod(var(--red) alpha(0.85));
 }

--- a/app/styles/spirit/_flexbox.css
+++ b/app/styles/spirit/_flexbox.css
@@ -72,6 +72,10 @@
 .flex-shrink-0 { flex-shrink: 0; }
 .flex-shrink-1 { flex-shrink: 1; }
 
+.flex-basis-1-2 { flex-basis: 50%; }
+.flex-basis-2-3 { flex-basis: 67%; }
+.flex-basis-1-3 { flex-basis: 33%; }
+
 @media (--breakpoint-not-small) {
   .flex-ns { display: flex; }
   .inline-flex-ns { display: inline-flex; }
@@ -129,6 +133,10 @@
 
   .flex-shrink-0-ns { flex-shrink: 0; }
   .flex-shrink-1-ns { flex-shrink: 1; }
+
+  .flex-basis-1-2-ns { flex-basis: 50%; }
+  .flex-basis-2-3-ns { flex-basis: 67%; }
+  .flex-basis-1-3-ns { flex-basis: 33%; }
 }
 @media (--breakpoint-medium) {
   .flex-m { display: flex; }
@@ -187,6 +195,10 @@
 
   .flex-shrink-0-m { flex-shrink: 0; }
   .flex-shrink-1-m { flex-shrink: 1; }
+
+  .flex-basis-1-2-m { flex-basis: 50%; }
+  .flex-basis-2-3-m { flex-basis: 67%; }
+  .flex-basis-1-3-m { flex-basis: 33%; }
 }
 
 @media (--breakpoint-large) {
@@ -247,4 +259,8 @@
 
   .flex-shrink-0-l { flex-shrink: 0; }
   .flex-shrink-1-l { flex-shrink: 1; }
+
+  .flex-basis-1-2-l { flex-basis: 50%; }
+  .flex-basis-2-3-l { flex-basis: 67%; }
+  .flex-basis-1-3-l { flex-basis: 33%; }
 }

--- a/app/templates/settings/general.hbs
+++ b/app/templates/settings/general.hbs
@@ -98,7 +98,6 @@
         </div>
 
         <div class="gh-setting-header">Publication identity</div>
-
         <div class="flex flex-column br3 shadow-1 bg-grouped-table pa5">
             <div class="gh-setting-first" data-test-setting="icon">
                 {{#gh-uploader
@@ -196,6 +195,198 @@
                     </div>
                 </div>
                 {{/gh-uploader}}
+            </div>
+        </div>
+
+        <div class="gh-setting-header">Site SEO</div>
+        <div class="flex flex-column br3 shadow-1 bg-grouped-table pa5">
+            <div class="gh-setting-first flex-column">
+                <div class="flex flex-row justify-between w-100">
+                    <div class="gh-setting-content">
+                        <div class="gh-setting-title">Meta data</div>
+                        <div class="gh-setting-desc">Extra home page content for search engines</div>
+                    </div>
+                    <div class="gh-setting-action">
+                        <button type="button" class="gh-btn" {{action (toggle "metaDataOpen" this)}} data-test-toggle-social><span>{{if metaDataOpen "Close" "Expand"}}</span></button>
+                    </div>
+                </div>
+                {{#liquid-if metaDataOpen}}
+                    <div class="gh-setting-content-extended">
+                        <div class="flex flex-row">
+                            <div class="w-100">
+                                {{#gh-form-group errors=this.settings.errors hasValidated=this.settings.hasValidated property="metaTitle"}}
+                                    <label for="metaTitle">Home SEO title</label>
+                                    {{gh-text-input
+                                        id="metaTitle"
+                                        type="text"
+                                        value=(readonly this.settings.metaTitle)
+                                        input=(action (mut this.settings.metaTitle) value="target.value")
+                                        data-test-input="metaTitle"
+                                    }}
+                                    {{gh-error-message errors=this.settings.errors property="metaTitle" data-test-error="metaTitle"}}
+                                    <p>The title appears browser tabs and search engine results for your home page.</p>
+                                {{/gh-form-group}}
+                                {{#gh-form-group errors=this.settings.errors hasValidated=this.settings.hasValidated property="metaDescription"}}
+                                    <label for="metaDescription">Home SEO description</label>
+                                    {{gh-textarea
+                                        id="metaDescription"
+                                        type="text"
+                                        value=(readonly this.settings.metaDescription)
+                                        input=(action (mut this.settings.metaDescription) value="target.value")
+                                        data-test-input="metaDescription"
+                                    }}
+                                    {{gh-error-message errors=this.settings.errors property="metaDescription" data-test-error="metaDescription"}}
+                                    <p>A short description of your home page, it should be between 50 and 300 characters.</p>
+                                {{/gh-form-group}}
+                            </div>
+                            <div style="margin-left: 20px; width: 300px">
+                                <label>Preview</label>
+                                <div class="seo-preview">
+                                    <div class="seo-preview-title">{{truncate (or this.settings.metaTitle this.settings.title) 70}}</div>
+                                    <div class="seo-preview-link">{{truncate this.config.blogUrl 70}}</div>
+                                    <div class="seo-preview-description">{{truncate (or this.settings.metaDescription this.settings.description) 300}}</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                {{/liquid-if}}
+            </div>
+            <div class="gh-setting flex-column">
+                <div class="flex flex-row justify-between w-100">
+                    <div class="gh-setting-content">
+                        <div class="gh-setting-title">Twitter card</div>
+                        <div class="gh-setting-desc">Customise structured data of your home page for Twitter</div>
+                    </div>
+                    <div class="gh-setting-action">
+                        <button type="button" class="gh-btn" {{action (toggle "twitterCardOpen" this)}} data-test-toggle-social><span>{{if twitterCardOpen "Close" "Expand"}}</span></button>
+                    </div>
+                </div>
+                {{#liquid-if twitterCardOpen}}
+                    <div class="gh-setting-content-extended">
+                        <div class="flex flex-row">
+                            <div class="w-100">
+                                {{#gh-form-group}}
+                                    <label>Twitter thumbnail image</label>
+                                    {{gh-image-uploader-with-preview
+                                        image=this.settings.twitterImage
+                                        text="Add Twitter image"
+                                        allowUnsplash=true
+                                        update=(action (mut this.settings.twitterImage))
+                                        remove=(action (mut this.settings.twitterImage ""))
+                                    }}
+                                {{/gh-form-group}}
+                                {{#gh-form-group errors=this.settings.errors hasValidated=this.settings.hasValidated property="twitterTitle"}}
+                                    <label for="twitterTitle">Twitter title</label>
+                                    {{gh-text-input
+                                        id="twitterTitle"
+                                        type="text"
+                                        value=(readonly this.settings.twitterTitle)
+                                        input=(action (mut this.settings.twitterTitle) value="target.value")
+                                        data-test-input="metaData"
+                                    }}
+                                    {{gh-error-message errors=this.settings.errors property="twitterTitle" data-test-error="twitterTitle"}}
+                                {{/gh-form-group}}
+                                {{#gh-form-group errors=this.settings.errors hasValidated=this.settings.hasValidated property="twitterDescription"}}
+                                    <label for="twitterDescription">Twitter description</label>
+                                    {{gh-textarea
+                                        id="twitterDescription"
+                                        value=(readonly this.settings.twitterDescription)
+                                        input=(action (mut this.settings.twitterDescription) value="target.value")
+                                        data-test-input="twitterDescription"
+                                    }}
+                                    {{gh-error-message errors=this.settings.errors property="twitterDescription" data-test-error="twitterDescription"}}
+                                {{/gh-form-group}}
+                            </div>
+                            <div style="margin-left: 20px; width: 300px">
+                                <label>Preview</label>
+                                <div class="gh-twitter-preview">
+                                    {{#if this.settings.twitterImage}}
+                                    <div class="gh-twitter-preview-image" style={{background-image-style this.settings.twitterImage}}></div>
+                                    {{/if}}
+                                    <div class="gh-twitter-preview-content">
+                                        <div class="gh-twitter-preview-title">{{or this.settings.twitterTitle this.settings.title}}</div>
+                                        <div class="gh-twitter-preview-description">{{truncate (or this.settings.twitterDescription this.settings.description) 155}}</div>
+                                        <div class="gh-twitter-preview-footer">
+                                            <div class="gh-twitter-preview-footer-left">
+                                                {{this.config.blogDomain}}
+                                            </div>
+                                            <div class="gh-twitter-preview-footer-right">
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    {{/liquid-if}}
+            </div>
+            <div class="gh-setting-last flex-column">
+                <div class="flex flex-row justify-between w-100">
+                    <div class="gh-setting-content">
+                        <div class="gh-setting-title">Facebook card</div>
+                        <div class="gh-setting-desc">Customise structured data of your home page</div>
+                    </div>
+                    <div class="gh-setting-action">
+                        <button type="button" class="gh-btn" {{action (toggle "facebookCardOpen" this)}} data-test-toggle-social><span>{{if facebookCardOpen "Close" "Expand"}}</span></button>
+                    </div>
+                </div>
+                {{#liquid-if facebookCardOpen}}
+                    <div class="gh-setting-content-extended">
+                        <div class="flex flex-row">
+                            <div class="w-100">
+                                {{#gh-form-group}}
+                                    <label>Facebook thumbnail image</label>
+                                    {{gh-image-uploader-with-preview
+                                        image=this.settings.ogImage
+                                        text="Add Facebook image"
+                                        allowUnsplash=true
+                                        update=(action (mut this.settings.ogImage))
+                                        remove=(action (mut this.settings.ogImage ""))
+                                    }}
+                                {{/gh-form-group}}
+                                {{#gh-form-group errors=this.settings.errors hasValidated=this.settings.hasValidated property="ogTitle"}}
+                                    <label for="ogTitle">Facebook title</label>
+                                    {{gh-text-input
+                                        id="ogTitle"
+                                        type="text"
+                                        value=(readonly this.settings.ogTitle)
+                                        input=(action (mut this.settings.ogTitle) value="target.value")
+                                        data-test-input="metaData"
+                                    }}
+                                    {{gh-error-message errors=this.settings.errors property="ogTitle" data-test-error="ogTitle"}}
+                                {{/gh-form-group}}
+                                {{#gh-form-group errors=this.settings.errors hasValidated=this.settings.hasValidated property="ogDescription"}}
+                                    <label for="ogDescription">Facebook description</label>
+                                    {{gh-textarea
+                                        id="ogDescription"
+                                        value=(readonly this.settings.ogDescription)
+                                        input=(action (mut this.settings.ogDescription) value="target.value")
+                                        data-test-input="ogDescription"
+                                    }}
+                                    {{gh-error-message errors=this.settings.errors property="ogDescription" data-test-error="ogDescription"}}
+                                {{/gh-form-group}}
+                            </div>
+                            <div style="margin-left: 20px; width: 300px">
+                                <label>Preview</label>
+                                <div class="gh-og-preview">
+                                    {{#if this.settings.ogImage}}
+                                    <div class="gh-og-preview-image" style={{background-image-style this.settings.ogImage}}></div>
+                                    {{/if}}
+                                    <div class="gh-og-preview-content">
+                                        <div class="gh-og-preview-title">{{truncate (or this.settings.ogTitle this.settings.title) 88}}</div>
+                                        <div class="gh-og-preview-description">{{truncate (or this.settings.ogDescription this.settings.description) 300}}</div>
+                                        <div class="gh-og-preview-footer">
+                                            <div class="gh-og-preview-footer-left">
+                                                {{this.config.blogDomain}}
+                                            </div>
+                                            <div class="gh-og-preview-footer-right"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    {{/liquid-if}}
             </div>
         </div>
 

--- a/app/templates/settings/general.hbs
+++ b/app/templates/settings/general.hbs
@@ -198,13 +198,13 @@
             </div>
         </div>
 
-        <div class="gh-setting-header">Site SEO</div>
+        <div class="gh-setting-header">Site meta settings</div>
         <div class="flex flex-column br3 shadow-1 bg-grouped-table pa5">
             <div class="gh-setting-first flex-column">
                 <div class="flex flex-row justify-between w-100">
                     <div class="gh-setting-content">
                         <div class="gh-setting-title">Meta data</div>
-                        <div class="gh-setting-desc">Extra home page content for search engines</div>
+                        <div class="gh-setting-desc">Extra content for search engines</div>
                     </div>
                     <div class="gh-setting-action">
                         <button type="button" class="gh-btn" {{action (toggle "metaDataOpen" this)}} data-test-toggle-social><span>{{if metaDataOpen "Close" "Expand"}}</span></button>
@@ -212,10 +212,10 @@
                 </div>
                 {{#liquid-if metaDataOpen}}
                     <div class="gh-setting-content-extended">
-                        <div class="flex flex-row">
-                            <div class="w-100">
+                        <div class="flex flex-column flex-row-ns">
+                            <div class="flex-basis-1-2-m flex-basis-2-3-l mr5">
                                 {{#gh-form-group errors=this.settings.errors hasValidated=this.settings.hasValidated property="metaTitle"}}
-                                    <label for="metaTitle">Home SEO title</label>
+                                    <label for="metaTitle">Meta title</label>
                                     {{gh-text-input
                                         id="metaTitle"
                                         type="text"
@@ -224,10 +224,10 @@
                                         data-test-input="metaTitle"
                                     }}
                                     {{gh-error-message errors=this.settings.errors property="metaTitle" data-test-error="metaTitle"}}
-                                    <p>The title appears browser tabs and search engine results for your home page.</p>
+                                    <p>The title appears browser tabs and search engine results for your site.</p>
                                 {{/gh-form-group}}
                                 {{#gh-form-group errors=this.settings.errors hasValidated=this.settings.hasValidated property="metaDescription"}}
-                                    <label for="metaDescription">Home SEO description</label>
+                                    <label for="metaDescription">Meta description</label>
                                     {{gh-textarea
                                         id="metaDescription"
                                         type="text"
@@ -236,11 +236,11 @@
                                         data-test-input="metaDescription"
                                     }}
                                     {{gh-error-message errors=this.settings.errors property="metaDescription" data-test-error="metaDescription"}}
-                                    <p>A short description of your home page, it should be between 50 and 300 characters.</p>
+                                    <p>A short description of your site, it should be between 50 and 300 characters.</p>
                                 {{/gh-form-group}}
                             </div>
-                            <div style="margin-left: 20px; width: 300px">
-                                <label>Preview</label>
+                            <div class="flex-basis-1-2-m flex-basis-1-3-l">
+                                <label>Search engine result preview</label>
                                 <div class="seo-preview">
                                     <div class="seo-preview-title">{{truncate (or this.settings.metaTitle this.settings.title) 70}}</div>
                                     <div class="seo-preview-link">{{truncate this.config.blogUrl 70}}</div>
@@ -255,7 +255,7 @@
                 <div class="flex flex-row justify-between w-100">
                     <div class="gh-setting-content">
                         <div class="gh-setting-title">Twitter card</div>
-                        <div class="gh-setting-desc">Customise structured data of your home page for Twitter</div>
+                        <div class="gh-setting-desc">Customise structured data of your site for Twitter</div>
                     </div>
                     <div class="gh-setting-action">
                         <button type="button" class="gh-btn" {{action (toggle "twitterCardOpen" this)}} data-test-toggle-social><span>{{if twitterCardOpen "Close" "Expand"}}</span></button>
@@ -263,10 +263,9 @@
                 </div>
                 {{#liquid-if twitterCardOpen}}
                     <div class="gh-setting-content-extended">
-                        <div class="flex flex-row">
-                            <div class="w-100">
+                        <div class="flex flex-column flex-row-ns">
+                            <div class="flex-basis-1-2-m flex-basis-2-3-l mr5 nudge-top--7">
                                 {{#gh-form-group}}
-                                    <label>Twitter thumbnail image</label>
                                     {{gh-image-uploader-with-preview
                                         image=this.settings.twitterImage
                                         text="Add Twitter image"
@@ -297,7 +296,7 @@
                                     {{gh-error-message errors=this.settings.errors property="twitterDescription" data-test-error="twitterDescription"}}
                                 {{/gh-form-group}}
                             </div>
-                            <div style="margin-left: 20px; width: 300px">
+                            <div class="flex-basis-1-2-m flex-basis-1-3-l nt4-ns">
                                 <label>Preview</label>
                                 <div class="gh-twitter-preview">
                                     {{#if this.settings.twitterImage}}
@@ -324,7 +323,7 @@
                 <div class="flex flex-row justify-between w-100">
                     <div class="gh-setting-content">
                         <div class="gh-setting-title">Facebook card</div>
-                        <div class="gh-setting-desc">Customise structured data of your home page</div>
+                        <div class="gh-setting-desc">Customise structured data of your site</div>
                     </div>
                     <div class="gh-setting-action">
                         <button type="button" class="gh-btn" {{action (toggle "facebookCardOpen" this)}} data-test-toggle-social><span>{{if facebookCardOpen "Close" "Expand"}}</span></button>
@@ -332,10 +331,9 @@
                 </div>
                 {{#liquid-if facebookCardOpen}}
                     <div class="gh-setting-content-extended">
-                        <div class="flex flex-row">
-                            <div class="w-100">
+                        <div class="flex flex-column flex-row-ns">
+                            <div class="flex-basis-1-2-m flex-basis-2-3-l mr5 nudge-top--7">
                                 {{#gh-form-group}}
-                                    <label>Facebook thumbnail image</label>
                                     {{gh-image-uploader-with-preview
                                         image=this.settings.ogImage
                                         text="Add Facebook image"
@@ -366,7 +364,7 @@
                                     {{gh-error-message errors=this.settings.errors property="ogDescription" data-test-error="ogDescription"}}
                                 {{/gh-form-group}}
                             </div>
-                            <div style="margin-left: 20px; width: 300px">
+                            <div class="flex-basis-1-2-m flex-basis-1-3-l nt4-ns">
                                 <label>Preview</label>
                                 <div class="gh-og-preview">
                                     {{#if this.settings.ogImage}}

--- a/app/templates/settings/general.hbs
+++ b/app/templates/settings/general.hbs
@@ -219,18 +219,20 @@
                                     {{gh-text-input
                                         id="metaTitle"
                                         type="text"
+                                        placeholder=(truncate this.settings.title 70)
                                         value=(readonly this.settings.metaTitle)
                                         input=(action (mut this.settings.metaTitle) value="target.value")
                                         data-test-input="metaTitle"
                                     }}
                                     {{gh-error-message errors=this.settings.errors property="metaTitle" data-test-error="metaTitle"}}
-                                    <p>The title appears browser tabs and search engine results for your site.</p>
+                                    <p>The title appears on browser tabs and search engine results for your site.</p>
                                 {{/gh-form-group}}
                                 {{#gh-form-group errors=this.settings.errors hasValidated=this.settings.hasValidated property="metaDescription"}}
                                     <label for="metaDescription">Meta description</label>
                                     {{gh-textarea
                                         id="metaDescription"
                                         type="text"
+                                        placeholder=(truncate this.settings.description 300)
                                         value=(readonly this.settings.metaDescription)
                                         input=(action (mut this.settings.metaDescription) value="target.value")
                                         data-test-input="metaDescription"
@@ -279,6 +281,7 @@
                                     {{gh-text-input
                                         id="twitterTitle"
                                         type="text"
+                                        placeholder=(truncate this.settings.title 70)
                                         value=(readonly this.settings.twitterTitle)
                                         input=(action (mut this.settings.twitterTitle) value="target.value")
                                         data-test-input="metaData"
@@ -289,6 +292,7 @@
                                     <label for="twitterDescription">Twitter description</label>
                                     {{gh-textarea
                                         id="twitterDescription"
+                                        placeholder=(truncate this.settings.description 300)
                                         value=(readonly this.settings.twitterDescription)
                                         input=(action (mut this.settings.twitterDescription) value="target.value")
                                         data-test-input="twitterDescription"
@@ -347,6 +351,7 @@
                                     {{gh-text-input
                                         id="ogTitle"
                                         type="text"
+                                        placeholder=(truncate this.settings.title 70)
                                         value=(readonly this.settings.ogTitle)
                                         input=(action (mut this.settings.ogTitle) value="target.value")
                                         data-test-input="metaData"
@@ -357,6 +362,7 @@
                                     <label for="ogDescription">Facebook description</label>
                                     {{gh-textarea
                                         id="ogDescription"
+                                        placeholder=(truncate this.settings.description 300)
                                         value=(readonly this.settings.ogDescription)
                                         input=(action (mut this.settings.ogDescription) value="target.value")
                                         data-test-input="ogDescription"

--- a/app/templates/settings/general.hbs
+++ b/app/templates/settings/general.hbs
@@ -225,7 +225,7 @@
                                         data-test-input="metaTitle"
                                     }}
                                     {{gh-error-message errors=this.settings.errors property="metaTitle" data-test-error="metaTitle"}}
-                                    <p>The title appears on browser tabs and search engine results for your site.</p>
+                                    <p>Appears on browser tabs and search engine results for your site. Recommended: <b>70</b> characters.</p>
                                 {{/gh-form-group}}
                                 {{#gh-form-group errors=this.settings.errors hasValidated=this.settings.hasValidated property="metaDescription"}}
                                     <label for="metaDescription">Meta description</label>
@@ -238,7 +238,7 @@
                                         data-test-input="metaDescription"
                                     }}
                                     {{gh-error-message errors=this.settings.errors property="metaDescription" data-test-error="metaDescription"}}
-                                    <p>A short description of your site, it should be between 50 and 300 characters.</p>
+                                    <p>A short description of your site. Recommended: <b>156</b> characters.</p>
                                 {{/gh-form-group}}
                             </div>
                             <div class="flex-basis-1-2-m flex-basis-1-3-l">

--- a/app/templates/settings/general.hbs
+++ b/app/templates/settings/general.hbs
@@ -207,7 +207,7 @@
                         <div class="gh-setting-desc">Extra content for search engines</div>
                     </div>
                     <div class="gh-setting-action">
-                        <button type="button" class="gh-btn" {{action (toggle "metaDataOpen" this)}} data-test-toggle-social><span>{{if metaDataOpen "Close" "Expand"}}</span></button>
+                        <button type="button" class="gh-btn" {{action (toggle "metaDataOpen" this)}} data-test-toggle-meta><span>{{if metaDataOpen "Close" "Expand"}}</span></button>
                     </div>
                 </div>
                 {{#liquid-if metaDataOpen}}
@@ -260,7 +260,7 @@
                         <div class="gh-setting-desc">Customise structured data of your site for Twitter</div>
                     </div>
                     <div class="gh-setting-action">
-                        <button type="button" class="gh-btn" {{action (toggle "twitterCardOpen" this)}} data-test-toggle-social><span>{{if twitterCardOpen "Close" "Expand"}}</span></button>
+                        <button type="button" class="gh-btn" {{action (toggle "twitterCardOpen" this)}} data-test-toggle-twitter><span>{{if twitterCardOpen "Close" "Expand"}}</span></button>
                     </div>
                 </div>
                 {{#liquid-if twitterCardOpen}}
@@ -284,7 +284,7 @@
                                         placeholder=(truncate this.settings.title 70)
                                         value=(readonly this.settings.twitterTitle)
                                         input=(action (mut this.settings.twitterTitle) value="target.value")
-                                        data-test-input="metaData"
+                                        data-test-input="twitterTitle"
                                     }}
                                     {{gh-error-message errors=this.settings.errors property="twitterTitle" data-test-error="twitterTitle"}}
                                 {{/gh-form-group}}
@@ -330,7 +330,7 @@
                         <div class="gh-setting-desc">Customise structured data of your site</div>
                     </div>
                     <div class="gh-setting-action">
-                        <button type="button" class="gh-btn" {{action (toggle "facebookCardOpen" this)}} data-test-toggle-social><span>{{if facebookCardOpen "Close" "Expand"}}</span></button>
+                        <button type="button" class="gh-btn" {{action (toggle "facebookCardOpen" this)}} data-test-toggle-facebook><span>{{if facebookCardOpen "Close" "Expand"}}</span></button>
                     </div>
                 </div>
                 {{#liquid-if facebookCardOpen}}
@@ -354,7 +354,7 @@
                                         placeholder=(truncate this.settings.title 70)
                                         value=(readonly this.settings.ogTitle)
                                         input=(action (mut this.settings.ogTitle) value="target.value")
-                                        data-test-input="metaData"
+                                        data-test-input="ogTitle"
                                     }}
                                     {{gh-error-message errors=this.settings.errors property="ogTitle" data-test-error="ogTitle"}}
                                 {{/gh-form-group}}

--- a/app/templates/settings/general.hbs
+++ b/app/templates/settings/general.hbs
@@ -225,7 +225,7 @@
                                         data-test-input="metaTitle"
                                     }}
                                     {{gh-error-message errors=this.settings.errors property="metaTitle" data-test-error="metaTitle"}}
-                                    <p>Appears on browser tabs and search engine results for your site. Recommended: <b>70</b> characters.</p>
+                                    <p>Recommended: <b>70</b> characters. You’ve used <b>{{gh-count-down-characters this.settings.metaTitle 70}}</b></p>
                                 {{/gh-form-group}}
                                 {{#gh-form-group errors=this.settings.errors hasValidated=this.settings.hasValidated property="metaDescription"}}
                                     <label for="metaDescription">Meta description</label>
@@ -238,7 +238,7 @@
                                         data-test-input="metaDescription"
                                     }}
                                     {{gh-error-message errors=this.settings.errors property="metaDescription" data-test-error="metaDescription"}}
-                                    <p>A short description of your site. Recommended: <b>156</b> characters.</p>
+                                    <p>Recommended: <b>156</b> characters. You’ve used <b>{{gh-count-down-characters this.settings.metaDescription 156}}</b></p>
                                 {{/gh-form-group}}
                             </div>
                             <div class="flex-basis-1-2-m flex-basis-1-3-l">


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/10921

- added new fields to settings model
- added "Site SEO" section to general settings

@peterzimon ready for you to work your design magic when you're back 😄 

@JohnONolan a wording review would be good, so far it's only been copied across from a rough sketch so it could do with some tweaking - do we want to mention the fallback behaviour anywhere?

<img width="321" alt="Screenshot 2019-08-08 at 16 24 58" src="https://user-images.githubusercontent.com/415/62716106-93d95580-b9f9-11e9-8067-0ec7f53ac68c.png">
