### PR TITLE
Switched Admin API version from v2 to canary

### DIFF
--- a/app/utils/ghost-paths.js
+++ b/app/utils/ghost-paths.js
@@ -18,7 +18,7 @@ export default function () {
     let subdir = path.substr(0, path.search('/ghost/'));
     let adminRoot = `${subdir}/ghost/`;
     let assetRoot = `${subdir}/ghost/assets/`;
-    let apiRoot = `${subdir}/ghost/api/v2/admin`;
+    let apiRoot = `${subdir}/ghost/api/canary/admin`;
 
     function assetUrl(src) {
         return subdir + src;

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -25,7 +25,7 @@ export default function () {
     this.passthrough('/ghost/assets/**');
 
     // this.urlPrefix = '';    // make this `http://localhost:8080`, for example, if your API is on a different server
-    this.namespace = '/ghost/api/v2/admin'; // make this `api`, for example, if your API is namespaced
+    this.namespace = '/ghost/api/canary/admin'; // make this `api`, for example, if your API is namespaced
     this.timing = 1000; // delay for each request, automatically set to 0 during testing
     this.logging = true;
 
@@ -48,7 +48,7 @@ export default function () {
 // Mock all endpoints here as there is no real API during testing
 export function testConfig() {
     // this.urlPrefix = '';    // make this `http://localhost:8080`, for example, if your API is on a different server
-    this.namespace = '/ghost/api/v2/admin'; // make this `api`, for example, if your API is namespaced
+    this.namespace = '/ghost/api/canary/admin'; // make this `api`, for example, if your API is namespaced
     // this.timing = 400;      // delay for each request, automatically set to 0 during testing
     this.logging = false;
 

--- a/tests/integration/adapters/tag-test.js
+++ b/tests/integration/adapters/tag-test.js
@@ -18,7 +18,7 @@ describe('Integration: Adapter: tag', function () {
     });
 
     it('loads tags from regular endpoint when all are fetched', function (done) {
-        server.get('/ghost/api/v2/admin/tags/', function () {
+        server.get('/ghost/api/canary/admin/tags/', function () {
             return [200, {'Content-Type': 'application/json'}, JSON.stringify({tags: [
                 {
                     id: 1,
@@ -40,7 +40,7 @@ describe('Integration: Adapter: tag', function () {
     });
 
     it('loads tag from slug endpoint when single tag is queried and slug is passed in', function (done) {
-        server.get('/ghost/api/v2/admin/tags/slug/tag-1/', function () {
+        server.get('/ghost/api/canary/admin/tags/slug/tag-1/', function () {
             return [200, {'Content-Type': 'application/json'}, JSON.stringify({tags: [
                 {
                     id: 1,

--- a/tests/integration/adapters/user-test.js
+++ b/tests/integration/adapters/user-test.js
@@ -18,7 +18,7 @@ describe('Integration: Adapter: user', function () {
     });
 
     it('loads users from regular endpoint when all are fetched', function (done) {
-        server.get('/ghost/api/v2/admin/users/', function () {
+        server.get('/ghost/api/canary/admin/users/', function () {
             return [200, {'Content-Type': 'application/json'}, JSON.stringify({users: [
                 {
                     id: 1,
@@ -40,7 +40,7 @@ describe('Integration: Adapter: user', function () {
     });
 
     it('loads user from slug endpoint when single user is queried and slug is passed in', function (done) {
-        server.get('/ghost/api/v2/admin/users/slug/user-1/', function () {
+        server.get('/ghost/api/canary/admin/users/slug/user-1/', function () {
             return [200, {'Content-Type': 'application/json'}, JSON.stringify({users: [
                 {
                     id: 1,
@@ -58,7 +58,7 @@ describe('Integration: Adapter: user', function () {
     });
 
     it('handles "include" parameter when querying single user via slug', function (done) {
-        server.get('/ghost/api/v2/admin/users/slug/user-1/', (request) => {
+        server.get('/ghost/api/canary/admin/users/slug/user-1/', (request) => {
             let params = request.queryParams;
             expect(params.include, 'include query').to.equal('roles,count.posts');
 

--- a/tests/integration/components/gh-file-uploader-test.js
+++ b/tests/integration/components/gh-file-uploader-test.js
@@ -18,13 +18,13 @@ const notificationsStub = Service.extend({
 });
 
 const stubSuccessfulUpload = function (server, delay = 0) {
-    server.post('/ghost/api/v2/admin/images/', function () {
+    server.post('/ghost/api/canary/admin/images/', function () {
         return [200, {'Content-Type': 'application/json'}, '{"url":"/content/images/test.png"}'];
     }, delay);
 };
 
 const stubFailedUpload = function (server, code, error, delay = 0) {
-    server.post('/ghost/api/v2/admin/images/', function () {
+    server.post('/ghost/api/canary/admin/images/', function () {
         return [code, {'Content-Type': 'application/json'}, JSON.stringify({
             errors: [{
                 type: error,
@@ -41,7 +41,7 @@ describe('Integration: Component: gh-file-uploader', function () {
 
     beforeEach(function () {
         server = new Pretender();
-        this.set('uploadUrl', '/ghost/api/v2/admin/images/');
+        this.set('uploadUrl', '/ghost/api/canary/admin/images/');
 
         this.owner.register('service:notifications', notificationsStub);
     });
@@ -86,7 +86,7 @@ describe('Integration: Component: gh-file-uploader', function () {
         await fileUpload('input[type="file"]', ['test'], {name: 'test.csv'});
 
         expect(server.handledRequests.length).to.equal(1);
-        expect(server.handledRequests[0].url).to.equal('/ghost/api/v2/admin/images/');
+        expect(server.handledRequests[0].url).to.equal('/ghost/api/canary/admin/images/');
     });
 
     it('fires uploadSuccess action on successful upload', async function () {
@@ -185,7 +185,7 @@ describe('Integration: Component: gh-file-uploader', function () {
     });
 
     it('handles file too large error directly from the web server', async function () {
-        server.post('/ghost/api/v2/admin/images/', function () {
+        server.post('/ghost/api/canary/admin/images/', function () {
             return [413, {}, ''];
         });
         await render(hbs`{{gh-file-uploader url=uploadUrl}}`);
@@ -205,7 +205,7 @@ describe('Integration: Component: gh-file-uploader', function () {
     });
 
     it('handles unknown failure', async function () {
-        server.post('/ghost/api/v2/admin/images/', function () {
+        server.post('/ghost/api/canary/admin/images/', function () {
             return [500, {'Content-Type': 'application/json'}, ''];
         });
         await render(hbs`{{gh-file-uploader url=uploadUrl}}`);

--- a/tests/integration/components/gh-image-uploader-test.js
+++ b/tests/integration/components/gh-image-uploader-test.js
@@ -29,13 +29,13 @@ const sessionStub = Service.extend({
 });
 
 const stubSuccessfulUpload = function (server, delay = 0) {
-    server.post('/ghost/api/v2/admin/images/upload/', function () {
+    server.post('/ghost/api/canary/admin/images/upload/', function () {
         return [200, {'Content-Type': 'application/json'}, '{"images": [{"url":"/content/images/test.png"}]}'];
     }, delay);
 };
 
 const stubFailedUpload = function (server, code, error, delay = 0) {
-    server.post('/ghost/api/v2/admin/images/upload/', function () {
+    server.post('/ghost/api/canary/admin/images/upload/', function () {
         return [code, {'Content-Type': 'application/json'}, JSON.stringify({
             errors: [{
                 type: error,
@@ -78,7 +78,7 @@ describe('Integration: Component: gh-image-uploader', function () {
         await fileUpload('input[type="file"]', ['test'], {name: 'test.png'});
 
         expect(server.handledRequests.length).to.equal(1);
-        expect(server.handledRequests[0].url).to.equal('/ghost/api/v2/admin/images/upload/');
+        expect(server.handledRequests[0].url).to.equal('/ghost/api/canary/admin/images/upload/');
         expect(server.handledRequests[0].requestHeaders.Authorization).to.be.undefined;
     });
 
@@ -177,7 +177,7 @@ describe('Integration: Component: gh-image-uploader', function () {
     });
 
     it('handles file too large error directly from the web server', async function () {
-        server.post('/ghost/api/v2/admin/images/upload/', function () {
+        server.post('/ghost/api/canary/admin/images/upload/', function () {
             return [413, {}, ''];
         });
         await render(hbs`{{gh-image-uploader image=image update=(action update)}}`);
@@ -197,7 +197,7 @@ describe('Integration: Component: gh-image-uploader', function () {
     });
 
     it('handles unknown failure', async function () {
-        server.post('/ghost/api/v2/admin/images/upload/', function () {
+        server.post('/ghost/api/canary/admin/images/upload/', function () {
             return [500, {'Content-Type': 'application/json'}, ''];
         });
         await render(hbs`{{gh-image-uploader image=image update=(action update)}}`);

--- a/tests/integration/components/gh-uploader-test.js
+++ b/tests/integration/components/gh-uploader-test.js
@@ -8,13 +8,13 @@ import {expect} from 'chai';
 import {setupRenderingTest} from 'ember-mocha';
 
 const stubSuccessfulUpload = function (server, delay = 0) {
-    server.post('/ghost/api/v2/admin/images/upload/', function () {
+    server.post('/ghost/api/canary/admin/images/upload/', function () {
         return [200, {'Content-Type': 'application/json'}, '{"images": [{"url": "/content/images/test.png"}]}'];
     }, delay);
 };
 
 const stubFailedUpload = function (server, code, error, delay = 0) {
-    server.post('/ghost/api/v2/admin/images/upload/', function () {
+    server.post('/ghost/api/canary/admin/images/upload/', function () {
         return [code, {'Content-Type': 'application/json'}, JSON.stringify({
             errors: [{
                 type: error,
@@ -50,7 +50,7 @@ describe('Integration: Component: gh-uploader', function () {
 
             let [lastRequest] = server.handledRequests;
             expect(server.handledRequests.length).to.equal(1);
-            expect(lastRequest.url).to.equal('/ghost/api/v2/admin/images/upload/');
+            expect(lastRequest.url).to.equal('/ghost/api/canary/admin/images/upload/');
             // requestBody is a FormData object
             // this will fail in anything other than Chrome and Firefox
             // https://developer.mozilla.org/en-US/docs/Web/API/FormData#Browser_compatibility
@@ -135,7 +135,7 @@ describe('Integration: Component: gh-uploader', function () {
 
         it('onComplete returns results in same order as selected', async function () {
             // first request has a delay to simulate larger file
-            server.post('/ghost/api/v2/admin/images/upload/', function () {
+            server.post('/ghost/api/canary/admin/images/upload/', function () {
                 // second request has no delay to simulate small file
                 stubSuccessfulUpload(server, 0);
 
@@ -257,7 +257,7 @@ describe('Integration: Component: gh-uploader', function () {
         });
 
         it('uploads to supplied `uploadUrl`', async function () {
-            server.post('/ghost/api/v2/admin/images/', function () {
+            server.post('/ghost/api/canary/admin/images/', function () {
                 return [200, {'Content-Type': 'application/json'}, '{"images": [{"url": "/content/images/test.png"}]'];
             });
 
@@ -266,7 +266,7 @@ describe('Integration: Component: gh-uploader', function () {
             await settled();
 
             let [lastRequest] = server.handledRequests;
-            expect(lastRequest.url).to.equal('/ghost/api/v2/admin/images/');
+            expect(lastRequest.url).to.equal('/ghost/api/canary/admin/images/');
         });
 
         it('passes supplied paramName in request', async function () {

--- a/tests/integration/services/config-test.js
+++ b/tests/integration/services/config-test.js
@@ -32,7 +32,7 @@ describe('Integration: Service: config', function () {
 
     it('normalizes blogUrl to non-trailing-slash', function (done) {
         let stubBlogUrl = function stubBlogUrl(url) {
-            server.get('/ghost/api/v2/admin/config/', function () {
+            server.get('/ghost/api/canary/admin/config/', function () {
                 return [
                     200,
                     {'Content-Type': 'application/json'},
@@ -40,7 +40,7 @@ describe('Integration: Service: config', function () {
                 ];
             });
 
-            server.get('/ghost/api/v2/admin/site/', function () {
+            server.get('/ghost/api/canary/admin/site/', function () {
                 return [
                     200,
                     {'Content-Type': 'application/json'},

--- a/tests/integration/services/feature-test.js
+++ b/tests/integration/services/feature-test.js
@@ -17,11 +17,11 @@ function stubSettings(server, labs, validSave = true) {
         }
     ];
 
-    server.get('/ghost/api/v2/admin/settings/', function () {
+    server.get('/ghost/api/canary/admin/settings/', function () {
         return [200, {'Content-Type': 'application/json'}, JSON.stringify({settings})];
     });
 
-    server.put('/ghost/api/v2/admin/settings/', function (request) {
+    server.put('/ghost/api/canary/admin/settings/', function (request) {
         let statusCode = (validSave) ? 200 : 400;
         let response = (validSave) ? request.requestBody : JSON.stringify({
             errors: [{
@@ -47,11 +47,11 @@ function stubUser(server, accessibility, validSave = true) {
         }]
     }];
 
-    server.get('/ghost/api/v2/admin/users/me/', function () {
+    server.get('/ghost/api/canary/admin/users/me/', function () {
         return [200, {'Content-Type': 'application/json'}, JSON.stringify({users})];
     });
 
-    server.put('/ghost/api/v2/admin/users/1/', function (request) {
+    server.put('/ghost/api/canary/admin/users/1/', function (request) {
         let statusCode = (validSave) ? 200 : 400;
         let response = (validSave) ? request.requestBody : JSON.stringify({
             errors: [{

--- a/tests/integration/services/slug-generator-test.js
+++ b/tests/integration/services/slug-generator-test.js
@@ -5,7 +5,7 @@ import {expect} from 'chai';
 import {setupTest} from 'ember-mocha';
 
 function stubSlugEndpoint(server, type, slug) {
-    server.get('/ghost/api/v2/admin/slugs/:type/:slug/', function (request) {
+    server.get('/ghost/api/canary/admin/slugs/:type/:slug/', function (request) {
         expect(request.params.type).to.equal(type);
         expect(request.params.slug).to.equal(slug);
 

--- a/tests/integration/services/store-test.js
+++ b/tests/integration/services/store-test.js
@@ -21,7 +21,7 @@ describe('Integration: Service: store', function () {
         let {version} = config.APP;
         let store = this.owner.lookup('service:store');
 
-        server.get('/ghost/api/v2/admin/posts/1/', function () {
+        server.get('/ghost/api/canary/admin/posts/1/', function () {
             return [
                 404,
                 {'Content-Type': 'application/json'},

--- a/tests/unit/authenticators/cookie-test.js
+++ b/tests/unit/authenticators/cookie-test.js
@@ -42,7 +42,7 @@ const mockTour = Service.extend({
 });
 
 const mockGhostPaths = Service.extend({
-    apiRoot: '/ghost/api/v2/admin'
+    apiRoot: '/ghost/api/canary/admin'
 });
 
 describe('Unit: Authenticator: cookie', () => {
@@ -74,7 +74,7 @@ describe('Unit: Authenticator: cookie', () => {
             let tour = this.owner.lookup('service:tour');
 
             return authenticator.authenticate('AzureDiamond', 'hunter2').then(() => {
-                expect(post.args[0][0]).to.equal('/ghost/api/v2/admin/session');
+                expect(post.args[0][0]).to.equal('/ghost/api/canary/admin/session');
                 expect(post.args[0][1]).to.deep.include({
                     data: {
                         username: 'AzureDiamond',
@@ -103,7 +103,7 @@ describe('Unit: Authenticator: cookie', () => {
             let del = authenticator.ajax.del;
 
             return authenticator.invalidate().then(() => {
-                expect(del.args[0][0]).to.equal('/ghost/api/v2/admin/session');
+                expect(del.args[0][0]).to.equal('/ghost/api/canary/admin/session');
             });
         });
     });

--- a/tests/unit/models/invite-test.js
+++ b/tests/unit/models/invite-test.js
@@ -23,7 +23,7 @@ describe('Unit: Model: invite', function () {
             let model = store.createRecord('invite');
             let role;
 
-            server.post('/ghost/api/v2/admin/invites/', function () {
+            server.post('/ghost/api/canary/admin/invites/', function () {
                 return [200, {}, '{}'];
             });
 

--- a/tests/unit/serializers/notification-test.js
+++ b/tests/unit/serializers/notification-test.js
@@ -17,7 +17,7 @@ describe('Unit: Serializer: notification', function () {
     });
 
     it('converts location->key when deserializing', function () {
-        server.get('/ghost/api/v2/admin/notifications', function () {
+        server.get('/ghost/api/canary/admin/notifications', function () {
             let response = {
                 notifications: [{
                     id: 1,


### PR DESCRIPTION
no issue

- Ghost-Admin is our primary API client, we should keep it in sync with the canary API branch to dog food our API changes