### PR TITLE
Add typographical expansions

### DIFF
--- a/app/utils/format-markdown.js
+++ b/app/utils/format-markdown.js
@@ -42,7 +42,8 @@ let markdownitNamedHeaders = function markdownitNamedHeaders(md) {
 let md = markdownit({
     html: true,
     breaks: true,
-    linkify: true
+    linkify: true,
+    typographer: true
 })
     .use(markdownitFootnote)
     .use(markdownitLazyHeaders)

--- a/lib/koenig-editor/addon/options/text-expansions.js
+++ b/lib/koenig-editor/addon/options/text-expansions.js
@@ -104,16 +104,93 @@ function registerInlineMarkdownTextExpansions(editor) {
             }
         }
     });
+    
+    // Convert straight quotes into curly quotes.
+    // This is a fairly naive algorithm, so there are times when it's wrong,
+    // but it's better than no replacement, which is wrong all the time.
+    editor.onTextInput({
+        name: 'smart_quotes',
+        match: /['"]$/,
+        run(editor) {
+            let {range} = editor;
+
+            let text = editor.range.head.section.textUntil(editor.range.head);
+
+            // do not match if we're in code formatting
+            if (editor.hasActiveMarkup('code') || text.match(/[^\s]?`[^\s]/)) {
+                return;
+            }
+            
+            let openSingleMatch = text.match(/\s'$/);
+            if (openSingleMatch) {
+                range = range.extend(-1);
+
+                if (editor.detectMarkupInRange(range, 'code')) {
+                    return;
+                }
+                
+                return editor.run((postEditor) => {
+                    let position = postEditor.deleteRange(range);
+                    postEditor.insertText(position, `‘`);
+                });
+            }
+
+            let openDoubleMatch = text.match(/\s"$/);
+            if (openDoubleMatch) {
+                range = range.extend(-1);
+
+                if (editor.detectMarkupInRange(range, 'code')) {
+                    return;
+                }
+                
+                return editor.run((postEditor) => {
+                    let position = postEditor.deleteRange(range);
+                    postEditor.insertText(position, `“`);
+                });
+            }
+
+            let singleMatch = text.match(/'$/);
+            if (singleMatch) {
+                range = range.extend(-1);
+
+                if (editor.detectMarkupInRange(range, 'code')) {
+                    return;
+                }
+                
+                let replacement = text.length === 1 ? `‘` : `’`;
+
+                return editor.run((postEditor) => {
+                    let position = postEditor.deleteRange(range);
+                    postEditor.insertText(position, replacement);
+                });
+            }
+            
+            let doubleMatch = text.match(/"$/);
+            if (doubleMatch) {
+                range = range.extend(-1);
+
+                if (editor.detectMarkupInRange(range, 'code')) {
+                    return;
+                }
+
+                let replacement = text.length === 1 ? `“` : `”`;
+
+                return editor.run((postEditor) => {
+                    let position = postEditor.deleteRange(range);
+                    postEditor.insertText(position, replacement);
+                });
+            }
+        }
+    });
 
     // We don't want to run all our content rules on every text entry event,
     // instead we check to see if this text entry event could match a content
     // rule, and only then run the rules. Right now we only want to match
-    // content ending with *, _, ), ~, and `. This could increase as we support
-    // more markdown.
-
+    // content ending with `*`, `_`, `)`, `~`, ```, `^`, `-`, `.`. This could
+    // increase as we support more markdown.
     editor.onTextInput({
         name: 'inline_markdown',
-        match: /[*_)~`^]$/,
+        match: /[*_)~`^\-.]$/,
         run(editor, matches) {
             let text = editor.range.head.section.textUntil(editor.range.head);
 
@@ -129,6 +206,7 @@ function registerInlineMarkdownTextExpansions(editor) {
             case ')':
                 matchLink(editor, text);
                 matchImage(editor, text);
+                matchScopedReplacements(editor, text);
                 break;
             case '~':
                 matchSub(editor, text);
@@ -139,6 +217,12 @@ function registerInlineMarkdownTextExpansions(editor) {
                 break;
             case '^':
                 matchSup(editor, text);
+                break;
+            case '-':
+                matchPlusOrMinus(editor, text);
+                break;
+            case '.':
+                matchEllipsis(editor, text);
                 break;
             }
         }
@@ -165,6 +249,27 @@ function registerInlineMarkdownTextExpansions(editor) {
         run.later(_this, function () {
             editor.toggleMarkup(markupStr);
         }, 10);
+    }
+
+    function _inlineMatchAndReplace(editor, text, matches, replacement) {
+        let {range} = editor;
+
+        // do not match if we're in code formatting
+        if (editor.hasActiveMarkup('code') || text.match(/[^\s]?`[^\s]/)) {
+            return;
+        }
+
+        let match = matches[0];
+        range = range.extend(-(match.length));
+
+        if (editor.detectMarkupInRange(range, 'code')) {
+            return;
+        }
+
+        return editor.run((postEditor) => {
+            let position = postEditor.deleteRange(range);
+            postEditor.insertText(position, replacement);
+        });
     }
 
     function matchStrongStar(editor, text) {
@@ -243,6 +348,42 @@ function registerInlineMarkdownTextExpansions(editor) {
         let matches = text.match(/\^([^\s^]+|[^\s^][^^]*[^\s^])\^$/);
         if (matches) {
             _addMarkdownMarkup(this, editor, matches, 'sup');
+        }
+    }
+
+    function matchPlusOrMinus(editor, text) {
+        let matches = text.match(/\+-$/);
+        if (matches) {
+            return _inlineMatchAndReplace(editor, text, matches, `±`);
+        }
+    }
+
+    function matchEllipsis(editor, text) {
+        let matches = text.match(/\.{3,}$/);
+        if (matches) {
+            return _inlineMatchAndReplace(editor, text, matches, `…`);
+        }
+    }
+
+    function matchScopedReplacements(editor, text) {
+        let copyrightMatches = text.match(/\((c)\)$/i);
+        if (copyrightMatches) {
+            return _inlineMatchAndReplace(editor, text, copyrightMatches, `©`);
+        }
+        
+        let trademarkMatches = text.match(/\((tm)\)$/i);
+        if (trademarkMatches) {
+            return _inlineMatchAndReplace(editor, text, trademarkMatches, `™`);
+        }
+        
+        let registeredMatches = text.match(/\((r)\)$/i);
+        if (registeredMatches) {
+            return _inlineMatchAndReplace(editor, text, registeredMatches, `®`);
+        }
+        
+        let paragraphMatches = text.match(/\((p)\)$/i);
+        if (paragraphMatches) {
+            return _inlineMatchAndReplace(editor, text, paragraphMatches, `§`);
         }
     }
 


### PR DESCRIPTION
This PR sets the Markdown-it option `typographer` for rendering markdown previews, which performs [certain symbol replacements](https://github.com/markdown-it/markdown-it/blob/master/lib/rules_core/replacements.js), along with converting straight quotes into curly quotes.

It also adds text expansions to the editor to mimic a subset of this functionality, including quote conversion. This PR does not implement the full set of conversions, because many of them may feel disruptive if performed in real-time, such as the removal of excessive punctuation. The following conversions are performed as the user types:
- `' → ‘` and `" → “` if after whitespace or at the beginning of a paragraph
- `' → ’` and `" → ”` elsewhere
- `(c), (C) → ©`
- `(tm), (TM) → ™`
- `(r), (R) → ®`
- `(p), (P) → §`

There's no current issue that this is addressing, but the problem of not having smart quotes specifically has been raised multiple times in the past, including back in [#1795](https://github.com/TryGhost/Ghost/issues/1795)