### PR TITLE
Updated renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,6 +32,10 @@
       "packageNames": ["ember-mocha", "ember-exam", "testem"]
     },
     {
+      "groupName": "ember-basic-dropdown addons",
+      "packagePatterns": ["^ember-basic", "^ember-power"]
+    },
+    {
       "groupName": "ember addons",
       "packagePatterns": ["^ember", "^@ember", "^broccoli", "^liquid"],
       "excludePackageNames": ["ember-source", "ember-cli", "ember-data", "ember-mocha", "ember-exam"]


### PR DESCRIPTION
no issue
- grouped `ember-basic-dropdown` and related `ember-power-*` addons together
- they share a common base and are going through a major breaking change so it's easier to upgrade them together