### PR TITLE
🔥 Removed publicAPI feature flag related code

### DIFF
--- a/app/services/feature.js
+++ b/app/services/feature.js
@@ -50,7 +50,6 @@ export default Service.extend({
     notifications: service(),
     lazyLoader: service(),
 
-    publicAPI: feature('publicAPI'),
     subscribers: feature('subscribers'),
     members: feature('members'),
     nightShift: feature('nightShift', {user: true, onChange: '_setAdminTheme'}),

--- a/app/templates/settings/labs.hbs
+++ b/app/templates/settings/labs.hbs
@@ -98,17 +98,6 @@
                     <div class="for-switch">{{gh-feature-flag "nightShift"}}</div>
                 </div>
             </div>
-            {{#if (not-eq feature.labs.publicAPI undefined)}}
-                <div class="gh-setting">
-                    <div class="gh-setting-content">
-                    <div class="gh-setting-title">Public API (deprecated)</div>
-                    <div class="gh-setting-desc">⚠️ Please use the Content API instead, more info in <a href="https://ghost.org/docs/api/content/">the docs</a></div>
-                    </div>
-                    <div class="gh-setting-action">
-                        <div class="for-switch">{{gh-feature-flag "publicAPI"}}</div>
-                    </div>
-                </div>
-            {{/if}}
             <div class="gh-setting {{if feature.members "gh-labs-disabled"}}" data-tooltip="{{if feature.members "Disabled when members is turned on"}}">
                 <div class="gh-setting-content">
                     <div class="gh-setting-title">Subscribers</div>

--- a/mirage/fixtures/configs.js
+++ b/mirage/fixtures/configs.js
@@ -3,7 +3,7 @@ export default [{
     database: 'mysql',
     enableDeveloperExperiments: true,
     environment: 'development',
-    labs: {publicAPI: true, subscribers: false},
+    labs: {subscribers: false},
     mail: 'SMTP',
     version: '2.15.0',
     useGravatar: 'true'


### PR DESCRIPTION
Changes are related to API v0.1 being completely gone and this flag won't be returned from anywhere anymore. 

I rarely get into Ember codebase (shame on you Naz! :grimacing:) Would appreciate a quick glance if there are any obvious things I missed. Checked the UI and tests but just in case :crossed_fingers: 