### PR TITLE
Improved alt text UI legibility

### DIFF
--- a/lib/koenig-editor/addon/templates/components/koenig-card-image.hbs
+++ b/lib/koenig-editor/addon/templates/components/koenig-card-image.hbs
@@ -80,7 +80,7 @@
         {{#if isSelected}}
             <button
                 title="Toggle between editing alt text and caption"
-                class="absolute right-0 bottom-0 ma2 pl1 pr1 ba br3 f7 sans-serif fw4 lh-title tracked-2 {{if this.isEditingAlt "bg-blue b--blue white" "b--midlightgrey midlightgrey"}}"
+                class="absolute right-0 bottom-0 ma2 pl1 pr1 ba br3 f8 sans-serif fw4 lh-title tracked-2 bg-white {{if this.isEditingAlt "bg-blue b--blue white" "b--midlightgrey midlightgrey"}}"
                 {{on "click" this.toggleAltEditing passive=true}}
             >
                 Alt


### PR DESCRIPTION
This kept bugging me so I made a tweak suggestion

Before:
![image](https://user-images.githubusercontent.com/120485/64915622-74221380-d795-11e9-99b3-2f5cc0c89dd3.png)

After:
![image](https://user-images.githubusercontent.com/120485/64915629-987df000-d795-11e9-9058-909976ccc65a.png)
