### PR TITLE
🔥 Removed unnecessary '?status=all' query parameter

### DIFF
--- a/app/components/gh-search-input.js
+++ b/app/components/gh-search-input.js
@@ -161,7 +161,7 @@ export default Component.extend({
     _loadPosts() {
         let store = this.store;
         let postsUrl = `${store.adapterFor('post').urlForQuery({}, 'post')}/`;
-        let postsQuery = {fields: 'id,title,page', limit: 'all', status: 'all'};
+        let postsQuery = {fields: 'id,title,page', limit: 'all'};
         let content = this.content;
 
         return this.ajax.request(postsUrl, {data: postsQuery}).then((posts) => {
@@ -178,7 +178,7 @@ export default Component.extend({
     _loadPages() {
         let store = this.store;
         let pagesUrl = `${store.adapterFor('page').urlForQuery({}, 'page')}/`;
-        let pagesQuery = {fields: 'id,title,page', limit: 'all', status: 'all'};
+        let pagesQuery = {fields: 'id,title,page', limit: 'all'};
         let content = this.content;
 
         return this.ajax.request(pagesUrl, {data: pagesQuery}).then((pages) => {

--- a/app/routes/editor/edit.js
+++ b/app/routes/editor/edit.js
@@ -24,8 +24,7 @@ export default AuthenticatedRoute.extend({
         }
 
         let query = {
-            id: post_id,
-            status: 'all'
+            id: post_id
         };
 
         return this.store.query(modelName, query)


### PR DESCRIPTION
no issue

- The default post/user filter gets expanded to the same values default values as `status=all` used to: https://github.com/TryGhost/Ghost/blob/e57e19e/core/server/api/canary/utils/serializers/input/posts.js#L97

@kevinansfield didn't find any more references to this filter seems like quite a small change :smiley: 