### PR TITLE
Hidden post visibility select from PSM for non editors

### DIFF
--- a/app/components/gh-post-settings-menu.js
+++ b/app/components/gh-post-settings-menu.js
@@ -46,6 +46,8 @@ export default Component.extend(SettingsMenuMixin, {
     twitterImage: or('post.twitterImage', 'post.featureImage'),
     twitterTitle: or('twitterTitleScratch', 'seoTitle'),
 
+    showVisibilityInput: or('session.user.isOwner', 'session.user.isAdmin', 'session.user.isEditor'),
+
     seoTitle: computed('metaTitleScratch', 'post.titleScratch', function () {
         return this.metaTitleScratch || this.post.titleScratch || '(Untitled)';
     }),

--- a/app/templates/components/gh-post-settings-menu.hbs
+++ b/app/templates/components/gh-post-settings-menu.hbs
@@ -77,12 +77,12 @@
 
 
                 {{#if feature.members}}
-                    {{#unless session.user.isContributor}}
+                    {{#if showVisibilityInput}}
                         <div class="form-group">
                             <label for="visibility-input">Who can see this post</label>
                             {{gh-psm-visibility-input post=post triggerId="visibility-input"}}
                         </div>
-                    {{/unless}}
+                    {{/if}}
                 {{/if}}
 
 


### PR DESCRIPTION
no issue

- Limited visiblity to only those users who have the rights to edit post's visibility
