### PR TITLE
🐛 Fixed "unsaved changes" modal when leaving a new post with no content

### DIFF
--- a/app/controllers/editor.js
+++ b/app/controllers/editor.js
@@ -460,8 +460,13 @@ export default Controller.extend({
         // NOTE: `updateTags` changes `hasDirtyAttributes => true`.
         // For a saved post it would otherwise be false.
         post.updateTags();
-
         this._previousTagNames = this._tagNames;
+
+        // update the scratch property if it's `null` and we get a blank mobiledoc
+        // back from the API - prevents "unsaved changes" modal on new+blank posts
+        if (!post.scratch) {
+            post.set('scratch', JSON.parse(JSON.stringify(post.get('mobiledoc'))));
+        }
 
         // if the two "scratch" properties (title and content) match the post,
         // then it's ok to set hasDirtyAttributes to false


### PR DESCRIPTION
no issue

- if you created a post by setting a title but did not enter anything into the editor body before trying to leave the editor you'd see an "unsaved changes" modal because the "scratch" value for the post mobiledoc is `null` but the post's real mobiledoc value is now a blank document as returned from the API
- adds a conditional reset of the `post.scratch` value after a successful save if the scratch value is blank