### PR TITLE
Add event to trigger set property when keydown on enter or cmd s in tag

### DIFF
--- a/app/components/gh-tag-settings-form.js
+++ b/app/components/gh-tag-settings-form.js
@@ -55,7 +55,7 @@ export default Component.extend({
     seoURL: computed('scratchSlug', function () {
         let blogUrl = this.get('config.blogUrl');
         let seoSlug = this.scratchSlug || '';
-
+        
         let seoURL = `${blogUrl}/tag/${seoSlug}`;
 
         // only append a slash to the URL if the slug exists
@@ -122,6 +122,12 @@ export default Component.extend({
 
         deleteTag() {
             this.showDeleteTagModal();
+        },
+
+        onKeydown(property, event) {
+            if (event.key === 'Enter' || (event.keyCode === 83 && event.metaKey)) {
+                this.setProperty(property, event.target.value);
+            }
         }
     },
 
@@ -131,11 +137,9 @@ export default Component.extend({
             this.$('.settings-menu-pane').scrollTop(0);
         }
     },
-
     focusIn() {
         key.setScope('tag-settings-form');
     },
-
     focusOut() {
         key.setScope('default');
     }

--- a/app/templates/components/gh-tag-settings-form.hbs
+++ b/app/templates/components/gh-tag-settings-form.hbs
@@ -8,6 +8,7 @@
                     name="name"
                     value=(readonly scratchName)
                     tabindex="1"
+                    keyDown=(action 'onKeydown' 'name')
                     input=(action (mut scratchName) value="target.value")
                     focus-out=(action 'setProperty' 'name' scratchName)}}
         <p class="description">Start with # to create internal tags. <a
@@ -23,6 +24,7 @@
                     id="tag-slug"
                     name="slug"
                     tabindex="2"
+                    keyDown=(action 'onKeydown' 'slug')
                     focus-out=(action 'setProperty' 'slug' scratchSlug)
                     input=(action (mut scratchSlug) value="target.value")}}
         {{gh-url-preview prefix="tag" slug=scratchSlug tagName="p" classNames="description"}}
@@ -37,6 +39,7 @@
                     class="gh-tag-details-textarea"
                     tabindex="3"
                     value=(readonly scratchDescription)
+                    keyDown=(action 'onKeydown' 'description')
                     input=(action (mut scratchDescription) value="target.value")
                     focus-out=(action 'setProperty' 'description' scratchDescription)
                 }}
@@ -67,6 +70,7 @@
                     placeholder=scratchName
                     tabindex="4"
                     value=(readonly scratchMetaTitle)
+                    keyDown=(action 'onKeydown' 'metaTitle')
                     input=(action (mut scratchMetaTitle) value="target.value")
                     focus-out=(action "setProperty" "metaTitle" scratchMetaTitle)}}
         {{gh-error-message errors=tag.errors property="metaTitle"}}
@@ -82,6 +86,7 @@
                     placeholder=scratchDescription
                     tabindex="5"
                     value=(readonly scratchMetaDescription)
+                    keyDown=(action 'onKeydown' 'metaDescription')
                     input=(action (mut scratchMetaDescription) value="target.value")
                     focus-out=(action "setProperty" "metaDescription" scratchMetaDescription)
                 }}


### PR DESCRIPTION
Add event keydown in tag page to trigger "setProperty"

-  Structure change : 

gh-tag-settings-form.js :
```
keyDown=(action 'onKeydown' 'property')
```

gh-tag-settings-form.hbs :
```
 onKeydown(property, event) {
            if (event.key === 'Enter' || (event.keyCode === 83 && event.metaKey)) {
                this.setProperty(property, event.target.value);
            }
 }
```

- Resovle issue : https://github.com/TryGhost/Ghost/issues/11138
- Ember tests : ✅ 

More info can be found by clicking the "guidelines for contributing" link above.
