### PR TITLE
🐛 Fixed members count on list page

### DIFF
--- a/app/controllers/member.js
+++ b/app/controllers/member.js
@@ -31,8 +31,8 @@ export default Controller.extend({
         finaliseDeletion() {
             // decrememnt the total member count manually so there's no flash
             // when transitioning back to the members list
-            if (this.members.meta) {
-                this.members.decrementProperty('meta.pagination.total');
+            if (this.members.memberCount) {
+                this.members.decrementProperty('memberCount');
             }
             this.router.transitionTo('members');
         },

--- a/app/controllers/members.js
+++ b/app/controllers/members.js
@@ -9,7 +9,7 @@ import {task} from 'ember-concurrency';
 export default Controller.extend({
     store: service(),
 
-    meta: null,
+    memberCount: null,
     members: null,
     searchText: '',
     init() {
@@ -54,25 +54,23 @@ export default Controller.extend({
     
     fetchMembers: task(function* () {
         let newFetchDate = new Date();
-        let results;
 
         if (this._hasFetchedAll) {
             // fetch any records modified since last fetch
-            results = yield this.store.query('member', {
+            yield this.store.query('member', {
                 limit: 'all',
                 filter: `updated_at:>='${moment.utc(this._lastFetchDate).format('YYYY-MM-DD HH:mm:ss')}'`,
                 order: 'created_at desc'
             });
         } else {
             // fetch all records
-            results = yield this.store.query('member', {
+            yield this.store.query('member', {
                 limit: 'all',
                 order: 'created_at desc'
             });
             this._hasFetchedAll = true;
-            this.set('meta', results.meta);
         }
-
+        this.set('memberCount', this.store.peekAll('member').length);
         this._lastFetchDate = newFetchDate;
     })
 });

--- a/app/templates/members.hbs
+++ b/app/templates/members.hbs
@@ -38,7 +38,7 @@
                                 Search result
                             {{else}}
                                 {{#if this.fetchMembers.lastSuccessful}}
-                                    {{pluralize this.meta.pagination.total "member"}}
+                                    {{pluralize memberCount "member"}}
                                 {{else}}
                                     Loading...
                                 {{/if}}


### PR DESCRIPTION
no issue

Members calculation was breaking when viewed on admin without refresh after adding/deleting new members and coming back after navigation, updated to more robust calculation logic.
