### PR TITLE
Prevent keypress to trigger form save for detail screens

### DIFF
--- a/app/controllers/member.js
+++ b/app/controllers/member.js
@@ -61,6 +61,10 @@ export default Controller.extend({
             }
         },
 
+        discardEnter() {
+            return false;
+        },
+
         leaveScreen() {
             let transition = this.leaveScreenTransition;
 

--- a/app/controllers/tags/tag.js
+++ b/app/controllers/tags/tag.js
@@ -30,6 +30,10 @@ export default Controller.extend({
         save() {
             return this.save.perform();
         },
+        
+        discardEnter() {
+            return false;
+        },
 
         toggleUnsavedChangesModal(transition) {
             let leaveTransition = this.leaveScreenTransition;

--- a/app/templates/components/gh-member-settings-form.hbs
+++ b/app/templates/components/gh-member-settings-form.hbs
@@ -9,6 +9,7 @@
                     value=(readonly scratchName)
                     tabindex="1"
                     input=(action (mut scratchName) value="target.value")
+                    stopEnterKeyDownPropagation=true
                     focus-out=(action 'setProperty' 'name' scratchName)}}
         {{gh-error-message errors=member.errors property="name"}}
         {{/gh-form-group}}
@@ -22,6 +23,7 @@
             name="email"
             tabindex="2"
             focus-out=(action 'setProperty' 'email' scratchEmail)
+            stopEnterKeyDownPropagation=true
             input=(action (mut scratchEmail) value="target.value")}}
         {{/gh-form-group}}
 

--- a/app/templates/components/gh-tag-settings-form.hbs
+++ b/app/templates/components/gh-tag-settings-form.hbs
@@ -8,6 +8,7 @@
                     name="name"
                     value=(readonly scratchName)
                     tabindex="1"
+                    stopEnterKeyDownPropagation=true
                     input=(action (mut scratchName) value="target.value")
                     focus-out=(action 'setProperty' 'name' scratchName)}}
         <p class="description">Start with # to create internal tags. <a
@@ -23,6 +24,7 @@
                     id="tag-slug"
                     name="slug"
                     tabindex="2"
+                    stopEnterKeyDownPropagation=true
                     focus-out=(action 'setProperty' 'slug' scratchSlug)
                     input=(action (mut scratchSlug) value="target.value")}}
         {{gh-url-preview prefix="tag" slug=scratchSlug tagName="p" classNames="description"}}
@@ -66,6 +68,7 @@
                     name="metaTitle"
                     placeholder=scratchName
                     tabindex="4"
+                    stopEnterKeyDownPropagation=true
                     value=(readonly scratchMetaTitle)
                     input=(action (mut scratchMetaTitle) value="target.value")
                     focus-out=(action "setProperty" "metaTitle" scratchMetaTitle)}}

--- a/app/templates/member.hbs
+++ b/app/templates/member.hbs
@@ -1,5 +1,5 @@
 <section class="gh-canvas">
-    <form class="mb10 member-basic-info-form" {{action (perform "save") on="submit"}}>
+    <form class="mb10 member-basic-info-form" {{action "discardEnter" on="submit"}}>
         <GhCanvasHeader class="gh-canvas-header">
             <h2 class="gh-canvas-title" data-test-screen-title>
                 {{#link-to "members" data-test-link="members-back"}}Members{{/link-to}}

--- a/app/templates/tags/tag.hbs
+++ b/app/templates/tags/tag.hbs
@@ -1,5 +1,5 @@
 <section class="gh-canvas">
-    <form class="mb15" {{action (perform "save") on="submit"}}>
+    <form class="mb15" {{action "discardEnter" on="submit"}}>
         <GhCanvasHeader class="gh-canvas-header">
             <h2 class="gh-canvas-title" data-test-screen-title>
                 {{#link-to "tags.index" data-test-link="tags-back"}}Tags{{/link-to}}


### PR DESCRIPTION
Fixes `Enter` key behavior on any tag/member detail pages input, which currently triggers a save operation without updating values.