### PR TITLE
Fixed Cmd+S in member details form

### DIFF
--- a/app/controllers/member.js
+++ b/app/controllers/member.js
@@ -39,23 +39,23 @@ export default Controller.extend({
 
         toggleUnsavedChangesModal(transition) {
             let leaveTransition = this.leaveScreenTransition;
-    
+
             if (!transition && this.showUnsavedChangesModal) {
                 this.set('leaveScreenTransition', null);
                 this.set('showUnsavedChangesModal', false);
                 return;
             }
-    
+
             if (!leaveTransition || transition.targetName === leaveTransition.targetName) {
                 this.set('leaveScreenTransition', transition);
-    
+
                 // if a save is running, wait for it to finish then transition
                 if (this.save.isRunning) {
                     return this.save.last.then(() => {
                         transition.retry();
                     });
                 }
-    
+
                 // we genuinely have unsaved data, show the modal
                 this.set('showUnsavedChangesModal', true);
             }
@@ -73,6 +73,10 @@ export default Controller.extend({
             this.member.rollbackAttributes();
 
             return transition.retry();
+        },
+
+        save() {
+            return this.save.perform();
         }
     },
 


### PR DESCRIPTION
no issue

- a route-level `save` action was set up on the `member` route which calls `controller.send('save')` but the corresponding `save` action was never set up on the controller which meant the action bubbled back up to the route creating an infinite loop