### PR TITLE
Prevented enter key submitting misleading member details save request

### DIFF
--- a/app/templates/components/gh-member-settings-form.hbs
+++ b/app/templates/components/gh-member-settings-form.hbs
@@ -77,8 +77,8 @@
                                 <tr>
                                     <td class="gh-member-stripe-label">Name</td>
                                     <td class="gh-member-stripe-data">
-                                        {{#if subscription.customer.name}} 
-                                            {{subscription.customer.name}} 
+                                        {{#if subscription.customer.name}}
+                                            {{subscription.customer.name}}
                                         {{else}}
                                             <span class="midlightgrey-l2">No name</span>
                                         {{/if}}

--- a/app/templates/member.hbs
+++ b/app/templates/member.hbs
@@ -1,5 +1,5 @@
 <section class="gh-canvas">
-    <form class="mb10 member-basic-info-form" {{action (perform "save") on="submit"}}>
+    <form class="mb10 member-basic-info-form">
         <GhCanvasHeader class="gh-canvas-header">
             <h2 class="gh-canvas-title" data-test-screen-title>
                 {{#link-to "members" data-test-link="members-back"}}Members{{/link-to}}
@@ -11,18 +11,18 @@
                 {{/if}}
             </h2>
             <section class="view-actions">
-                {{gh-task-button task=save class="gh-btn gh-btn-blue gh-btn-icon" data-test-button="save"}}
+                {{gh-task-button type="button" task=save class="gh-btn gh-btn-blue gh-btn-icon" data-test-button="save"}}
             </section>
         </GhCanvasHeader>
         <div class="flex items-center mb10 bt b--lightgrey-d1 pt8">
             <GhMemberAvatar @member={{member}} @sizeClass={{if member.name 'f-subheadline fw4 lh-zero tracked-1' 'f-headline fw4 lh-zero tracked-1'}} class="w18 h18 mr4" />
             <div>
                 <h3 class="f2 fw5 ma0 pa0">
-                    {{if member.name member.name member.email}}
+                    {{or member.name member.email}}
                 </h3>
                 <p class="f6 pa0 ma0 midgrey">
                     {{#if member.name}}
-                        <span class="darkgrey fw5">{{member.email}}</span> – 
+                        <span class="darkgrey fw5">{{member.email}}</span> –
                     {{/if}}
                     Created on {{this.subscribedAt}}
                 </p>
@@ -33,14 +33,15 @@
             isLoading=this.isLoading
             showDeleteTagModal=(action "toggleDeleteMemberModal")}}
     </form>
-        <button
-            type="button"
-            class="gh-btn gh-btn-red gh-btn-icon mt3"
-            {{action (toggle "showDeleteMemberModal" this)}}
-            data-test-button="delete-member"
-        >
-            <span>Delete member</span>
-        </button>
+
+    <button
+        type="button"
+        class="gh-btn gh-btn-red gh-btn-icon mt3"
+        {{action (toggle "showDeleteMemberModal" this)}}
+        data-test-button="delete-member"
+    >
+        <span>Delete member</span>
+    </button>
 </section>
 
 {{#if showUnsavedChangesModal}}


### PR DESCRIPTION
no issue

- `{{gh-task-button}}` was used inside a form but didn't have a `type="button"` property which meant the browser was treating it as a submit button and triggering the `save` action and related animation before the field's focus-out was called resulting in a save request before the scratch value is transferred to the model
- removed the submit action from the `<form>` element to prevent any other accidental triggers before scratch values have been transferred into real model values