### PR TITLE
Fixed enter in tag screen inputs triggering save

### DIFF
--- a/app/templates/tags/tag.hbs
+++ b/app/templates/tags/tag.hbs
@@ -1,5 +1,5 @@
 <section class="gh-canvas">
-    <form class="mb15" {{action (perform "save") on="submit"}}>
+    <form class="mb15">
         <GhCanvasHeader class="gh-canvas-header">
             <h2 class="gh-canvas-title" data-test-screen-title>
                 {{#link-to "tags.index" data-test-link="tags-back"}}Tags{{/link-to}}
@@ -7,7 +7,7 @@
                 {{if tag.name tag.name "New tag"}}
             </h2>
             <section class="view-actions">
-                {{gh-task-button task=save class="gh-btn gh-btn-blue gh-btn-icon" data-test-button="save"}}
+                {{gh-task-button task=save type="button" class="gh-btn gh-btn-blue gh-btn-icon" data-test-button="save"}}
             </section>
         </GhCanvasHeader>
         {{gh-tag-settings-form tag=tag


### PR DESCRIPTION
no issue

- `{{gh-task-button}}` was used inside a form but didn't have a `type="button"` property which meant the browser was treating it as a submit button and triggering the save action and related animation before the field's focus-out was called resulting in a save request before the scratch value is transferred to the model
- removed the submit action from the `<form>` element to prevent any other accidental triggers before scratch values have been transferred into real model values