### PR TITLE
Added new bulk email settings

### DIFF
--- a/app/components/gh-members-lab-setting.js
+++ b/app/components/gh-members-lab-setting.js
@@ -29,17 +29,19 @@ export default Component.extend({
         subscriptionSettings.stripeConfig = stripeProcessor.config;
         subscriptionSettings.allowSelfSignup = !!subscriptionSettings.allowSelfSignup;
         subscriptionSettings.fromAddress = subscriptionSettings.fromAddress || '';
-        if (Object.keys(subscriptionSettings).includes('mailgunApiKey')) {
-            subscriptionSettings.mailgunApiKey = subscriptionSettings.mailgunApiKey || '';
-            subscriptionSettings.mailgunDomain = subscriptionSettings.mailgunDomain || '';
-        }
 
         return subscriptionSettings;
     }),
 
-    hasMailgunAPIKeyOption: computed('settings.membersSubscriptionSettings', function () {
-        let subscriptionSettings = this.parseSubscriptionSettings(this.get('settings.membersSubscriptionSettings'));
-        return Object.keys(subscriptionSettings).includes('mailgunApiKey');
+    bulkEmailSettings: computed('settings.bulkEmailSettings', function () {
+        let bulkEmailSettings = this.get('settings.bulkEmailSettings') || {};
+        const {apiKey = '', baseUrl = '', domain = ''} = bulkEmailSettings;
+        return {apiKey, baseUrl, domain};
+    }),
+
+    hasBulkEmailConfig: computed('settings.bulkEmailSettings', function () {
+        let bulkEmailSettings = this.get('settings.bulkEmailSettings');
+        return !!bulkEmailSettings.isConfig;
     }),
 
     defaultContentVisibility: computed('settings.defaultContentVisibility', function () {
@@ -49,6 +51,11 @@ export default Component.extend({
     actions: {
         setDefaultContentVisibility(value) {
             this.setDefaultContentVisibility(value);
+        },
+        setBulkEmailSettings(key, event) {
+            let bulkEmailSettings = this.get('settings.bulkEmailSettings') || {};
+            bulkEmailSettings[key] = event.target.value;
+            this.setBulkEmailSettings(bulkEmailSettings);
         },
         setSubscriptionSettings(key, event) {
             let subscriptionSettings = this.parseSubscriptionSettings(this.get('settings.membersSubscriptionSettings'));
@@ -79,12 +86,6 @@ export default Component.extend({
             }
             if (key === 'fromAddress') {
                 subscriptionSettings.fromAddress = event.target.value;
-            }
-            if (key === 'mailgunApiKey') {
-                subscriptionSettings.mailgunApiKey = event.target.value;
-            }
-            if (key === 'mailgunDomain') {
-                subscriptionSettings.mailgunDomain = event.target.value;
             }
             this.setMembersSubscriptionSettings(subscriptionSettings);
         }

--- a/app/components/gh-post-settings-menu/email.js
+++ b/app/components/gh-post-settings-menu/email.js
@@ -26,7 +26,7 @@ export default Component.extend({
     testEmailAddress: oneWay('session.user.email'),
 
     mailgunError: computed('settings.memberSubscriptionSettings', function () {
-        return !this._isMailgunConfigured();
+        return !this.settings.get('bulkEmailSettings.isEnabled');
     }),
 
     actions: {
@@ -70,7 +70,7 @@ export default Component.extend({
                 this.set('sendTestEmailError', 'Please enter a valid email');
                 return false;
             }
-            if (!this._isMailgunConfigured()) {
+            if (!this.settings.get('bulkEmailSettings.isEnabled')) {
                 this.set('sendTestEmailError', 'Please configure Mailgun in Labs → Members');
                 return false;
             }
@@ -87,15 +87,5 @@ export default Component.extend({
                 this.notifications.showAPIError(error, {key: 'send.previewEmail'});
             }
         }
-    }).drop(),
-
-    // TODO: put this on settings model
-    _isMailgunConfigured() {
-        let subSettingsValue = this.settings.get('membersSubscriptionSettings');
-        let subscriptionSettings = subSettingsValue ? JSON.parse(subSettingsValue) : {};
-        if (Object.keys(subscriptionSettings).includes('mailgunApiKey')) {
-            return (subscriptionSettings.mailgunApiKey && subscriptionSettings.mailgunDomain);
-        }
-        return true;
-    }
+    }).drop()
 });

--- a/app/components/gh-publishmenu-draft.js
+++ b/app/components/gh-publishmenu-draft.js
@@ -21,7 +21,7 @@ export default Component.extend({
 
     canSendEmail: computed('feature.labs.members', 'post.{displayName,email}', function () {
         let membersEnabled = this.feature.get('labs.members');
-        let mailgunIsConfigured = this._isMailgunConfigured();
+        let mailgunIsConfigured = this.get('settings.bulkEmailSettings.isEnabled');
         let isPost = this.post.displayName === 'post';
         let hasSentEmail = !!this.post.email;
 
@@ -79,16 +79,6 @@ export default Component.extend({
             post.set('publishedAtBlogTime', time);
             return post.validate();
         }
-    },
-
-    // TODO: put this on settings model
-    _isMailgunConfigured: function () {
-        let subSettingsValue = this.get('settings.membersSubscriptionSettings');
-        let subscriptionSettings = subSettingsValue ? JSON.parse(subSettingsValue) : {};
-        if (Object.keys(subscriptionSettings).includes('mailgunApiKey')) {
-            return subscriptionSettings.mailgunApiKey && subscriptionSettings.mailgunDomain;
-        }
-        return false;
     },
 
     // API only accepts dates at least 2 mins in the future, default the

--- a/app/controllers/settings/labs.js
+++ b/app/controllers/settings/labs.js
@@ -163,6 +163,10 @@ export default Controller.extend({
 
         setMembersSubscriptionSettings(subscriptionSettings) {
             this.set('settings.membersSubscriptionSettings', JSON.stringify(subscriptionSettings));
+        },
+
+        setBulkEmailSettings(bulkEmailSettings) {
+            this.set('settings.bulkEmailSettings', bulkEmailSettings);
         }
     },
 

--- a/app/models/setting.js
+++ b/app/models/setting.js
@@ -38,5 +38,6 @@ export default Model.extend(ValidationEngine, {
     twitterImage: attr('string'),
     ogTitle: attr('string'),
     ogDescription: attr('string'),
-    ogImage: attr('string')
+    ogImage: attr('string'),
+    bulkEmailSettings: attr('json-string')
 });

--- a/app/services/settings.js
+++ b/app/services/settings.js
@@ -27,7 +27,7 @@ export default Service.extend(_ProxyMixin, ValidationEngine, {
     _loadSettings() {
         if (!this._loadingPromise) {
             this._loadingPromise = this.store
-                .queryRecord('setting', {type: 'blog,theme,private,members'})
+                .queryRecord('setting', {type: 'blog,theme,private,members,bulk_email'})
                 .then((settings) => {
                     this._loadingPromise = null;
                     return settings;

--- a/app/templates/components/gh-members-lab-setting.hbs
+++ b/app/templates/components/gh-members-lab-setting.hbs
@@ -185,12 +185,12 @@
             </div>
             <div class="f8 fw4 midgrey mt1">Your members will receive system emails from this address</div>
             {{/gh-form-group}}
-            {{#if hasMailgunAPIKeyOption}}
+            {{#unless hasBulkEmailConfig}}
                 {{#gh-form-group}}
                     <label class="fw6 f8">Mailgun domain</label>
                     {{gh-text-input
-                        value=(readonly subscriptionSettings.mailgunDomain)
-                        input=(action "setSubscriptionSettings" "mailgunDomain")
+                        value=(readonly bulkEmailSettings.domain)
+                        input=(action "setBulkEmailSettings" "domain")
                         class="mt1"
                     }}
                     <a href="https://app.mailgun.com/app/sending/domains" target="_blank" class="mt1 fw4 f8">
@@ -201,8 +201,8 @@
                     <label class="fw6 f8">Mailgun API key</label>
                     {{gh-text-input
                         type="password"
-                        value=(readonly subscriptionSettings.mailgunApiKey)
-                        input=(action "setSubscriptionSettings" "mailgunApiKey")
+                        value=(readonly bulkEmailSettings.apiKey)
+                        input=(action "setBulkEmailSettings" "apiKey")
                         class="mt1 password"
                         autocomplete="new-password"
                     }}
@@ -210,7 +210,16 @@
                         Find your Mailgun API keys here &raquo;
                     </a>
                 {{/gh-form-group}}
-            {{/if}}
+
+                {{#gh-form-group}}
+                    <label class="fw6 f8">Mailgun base url</label>
+                    {{gh-text-input
+                        value=(readonly bulkEmailSettings.baseUrl)
+                        input=(action "setBulkEmailSettings" "baseUrl")
+                        class="mt1"
+                    }}
+                {{/gh-form-group}}
+            {{/unless}}
         </div>
         {{/liquid-if}}
     </section>

--- a/app/templates/settings/labs.hbs
+++ b/app/templates/settings/labs.hbs
@@ -27,6 +27,7 @@
                         settings=settings
                         setDefaultContentVisibility=(action "setDefaultContentVisibility")
                         setMembersSubscriptionSettings=(action "setMembersSubscriptionSettings")
+                        setBulkEmailSettings=(action "setBulkEmailSettings")
                     }}
                     <div class="mt5 pl5 pr5 pb5">
                         {{gh-task-button "Save members settings"

--- a/mirage/fixtures/settings.js
+++ b/mirage/fixtures/settings.js
@@ -182,5 +182,15 @@ export default [
         created_by: 1,
         updated_at: '2019-10-09T09:49:00.000Z',
         updated_by: 1
+    },
+    {
+        id: 24,
+        type: 'bulk_email',
+        key: 'bulk_email_settings',
+        value: '{"provider":"mailgun","apiKey":"","domain":"","baseUrl":""}',
+        created_at: '2019-10-09T09:49:00.000Z',
+        created_by: 1,
+        updated_at: '2019-10-09T09:49:00.000Z',
+        updated_by: 1
     }
 ];


### PR DESCRIPTION
This PR -

- Adds new bulk email settings in settings API
- Uses dynamic `isEnabled` and `isCondig` flags from bulk email settings to configure UI and bulk email usage
- Wires mailgun email settings to bulk email settings for read/edit