### PR TITLE
Allowed to toggle send email when batch has an error

### DIFF
--- a/app/components/gh-publishmenu-draft.js
+++ b/app/components/gh-publishmenu-draft.js
@@ -24,8 +24,9 @@ export default Component.extend({
         let mailgunIsConfigured = this.get('settings.bulkEmailSettings.isEnabled');
         let isPost = this.post.displayName === 'post';
         let hasSentEmail = !!this.post.email;
+        let emailBatchFailed = !!this.post.email && (this.post.email.status === 'failed');
 
-        return membersEnabled && mailgunIsConfigured && isPost && !hasSentEmail;
+        return membersEnabled && mailgunIsConfigured && isPost && (!hasSentEmail || emailBatchFailed);
     }),
 
     didInsertElement() {

--- a/app/templates/components/gh-post-settings-menu/email.hbs
+++ b/app/templates/components/gh-post-settings-menu/email.hbs
@@ -28,6 +28,12 @@
                             <td class="pa2 pl0 fw7 f8 w16 nowrap">Sent on:</td>
                             <td class="pa0 truncate midgrey">{{gh-format-post-time this.post.email.createdAtUTC}}</td>
                         </tr>
+                        {{#if post.email.error}}
+                        <tr>
+                            <td class="pa2 pl0 fw7 f8 w16 nowrap">Error:</td>
+                            <td class="pa0 truncate red">There was an error sending the post by email. Please doublecheck your Mailgun settings in Members > Labs</td>
+                        </tr>
+                        {{/if}}
                     </tbody>
                 </table>
             </div>


### PR DESCRIPTION
Still TODO:
- [ ] wording check for a failed email message in PSM