### PR TITLE
Added ability to retry failed emails from confirm email modal

### DIFF
--- a/app/adapters/email.js
+++ b/app/adapters/email.js
@@ -1,0 +1,14 @@
+import ApplicationAdapter from './application';
+
+export default ApplicationAdapter.extend({
+
+    retry(model) {
+        let url = `${this.buildURL('email', model.get('id'))}retry/`;
+
+        return this.ajax(url, 'PUT', {data: {}}).then((data) => {
+            this.store.pushPayload(data);
+            return model;
+        });
+    }
+
+});

--- a/app/components/modal-confirm-email-send.js
+++ b/app/components/modal-confirm-email-send.js
@@ -26,5 +26,25 @@ export default ModalComponent.extend({
                 throw e;
             }
         }
+    }),
+
+    retryEmailTask: task(function* () {
+        try {
+            yield this.model.retryEmailSend();
+            this.closeModal();
+            return true;
+        } catch (e) {
+            // update "failed" state if email fails again
+            if (e && e.name === 'EmailFailedError') {
+                this.set('errorMessage', e.message);
+                return;
+            }
+
+            // TODO: test a non-email failure - maybe this needs to go through
+            // the notifications service
+            if (e) {
+                throw e;
+            }
+        }
     })
 });

--- a/app/controllers/editor.js
+++ b/app/controllers/editor.js
@@ -722,8 +722,8 @@ export default Controller.extend({
 
         // post.tags is an array so hasDirtyAttributes doesn't pick up
         // changes unless the array ref is changed
-        let currentTags = this.getWithDefault('_tagNames', []).join('');
-        let previousTags = this.getWithDefault('_previousTagNames', []).join('');
+        let currentTags = (this._tagNames || []).join('');
+        let previousTags = (this._previousTagNames || []).join('');
         if (currentTags !== previousTags) {
             return true;
         }

--- a/app/models/email.js
+++ b/app/models/email.js
@@ -18,5 +18,9 @@ export default Model.extend({
     updatedAtUTC: attr('moment-utc'),
     updatedBy: attr('string'),
 
-    post: belongsTo('post')
+    post: belongsTo('post'),
+
+    retry() {
+        return this.store.adapterFor('email').retry(this);
+    }
 });

--- a/app/templates/components/gh-publishmenu.hbs
+++ b/app/templates/components/gh-publishmenu.hbs
@@ -57,6 +57,7 @@
             memberCount=this.memberCount
             isScheduled=(eq this.saveType "schedule")
             paidOnly=(eq this.post.visibility "paid")
+            retryEmailSend=this.retryEmailSend
         }}
         @confirm={{this.confirmEmailSend}}
         @close={{this.closeEmailConfirmationModal}}

--- a/app/templates/components/modal-confirm-email-send.hbs
+++ b/app/templates/components/modal-confirm-email-send.hbs
@@ -44,5 +44,12 @@
         <button {{on "click" this.closeModal}} class="gh-btn" data-test-button="cancel-publish-and-email">
             <span>Close</span>
         </button>
+        <GhTaskButton
+            @buttonText="Retry email"
+            @runningText="Sending..."
+            @task={{this.retryEmailTask}}
+            @class="gh-btn gh-btn-red gh-btn-icon"
+            data-test-button="retry-email"
+        />
     </div>
 {{/unless}}

--- a/tests/acceptance/editor-test.js
+++ b/tests/acceptance/editor-test.js
@@ -350,7 +350,7 @@ describe('Acceptance: Editor', function () {
 
             // expect countdown to show warning that post is scheduled to be published
             expect(find('[data-test-schedule-countdown]').textContent.trim(), 'notification countdown')
-                .to.contain('Scheduled to be published  in 4 minutes');
+                .to.match(/Scheduled to be published {2}in (4|5) minutes/);
 
             expect(
                 find('[data-test-publishmenu-trigger]').textContent.trim(),
@@ -360,7 +360,7 @@ describe('Acceptance: Editor', function () {
             expect(
                 find('[data-test-editor-post-status]').textContent.trim(),
                 'scheduled post status'
-            ).to.equal('Scheduled to be published  in 4 minutes.');
+            ).to.match(/Scheduled to be published {2}in (4|5) minutes./);
 
             // Re-schedule
             await click('[data-test-publishmenu-trigger]');
@@ -387,7 +387,7 @@ describe('Acceptance: Editor', function () {
             expect(
                 find('[data-test-editor-post-status]').textContent.trim(),
                 'scheduled status text'
-            ).to.equal('Scheduled to be published  in 4 minutes.');
+            ).to.match(/Scheduled to be published {2}in (4|5) minutes\./);
 
             // unschedule
             await click('[data-test-publishmenu-trigger]');
@@ -542,7 +542,7 @@ describe('Acceptance: Editor', function () {
                 .to.equal('Scheduled');
             // expect countdown to show warning, that post is scheduled to be published
             expect(find('[data-test-schedule-countdown]').textContent.trim(), 'notification countdown')
-                .to.contain('Scheduled to be published  in 4 minutes');
+                .to.match(/Scheduled to be published {2}in (4|5) minutes/);
         });
 
         it('shows author token input and allows changing of authors in PSM', async function () {


### PR DESCRIPTION
no issue

- adds a `.retry()` method to the email model+adapter
- adds a retry email task to the publishmenu that follows the same retry-then-poll behaviour as the regular email confirmation
- show a retry button in the confirm email modal if the original send failed