### PR TITLE
Removed ember-addons Renovate group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,10 +21,6 @@
   },
   "packageRules": [
     {
-      "groupName": "ember addons",
-      "packagePatterns": ["^ember", "^@ember", "^broccoli", "^liquid"]
-    },
-    {
       "groupName": "ember-basic-dropdown addons",
       "packagePatterns": ["^ember-basic", "^ember-power"]
     },


### PR DESCRIPTION
no issue

- having so many addons grouped into a single PR is difficult to manage when not reviewing, updating and merging frequently. If a single addon requires deeper work or breaks our node support range than it blocks upgrades on all other addons which then compounds required effort over time