### PR TITLE
Basic flow for triggering db export on user deletion

### DIFF
--- a/app/controllers/staff/user.js
+++ b/app/controllers/staff/user.js
@@ -84,11 +84,13 @@ export default Controller.extend({
         },
 
         deleteUser() {
-            return this._deleteUser().then(() => {
-                this._deleteUserSuccess();
-            }, () => {
-                this._deleteUserFailure();
-            });
+            return this._deleteUser()
+                .then(filename => this._exportDb(filename))
+                .then(() => {
+                    this._deleteUserSuccess();
+                }, () => {
+                    this._deleteUserFailure();
+                });
         },
 
         toggleDeleteUserModal() {
@@ -354,6 +356,21 @@ export default Controller.extend({
 
     _deleteUserFailure() {
         this.notifications.showAlert('The user could not be deleted. Please try again.', {type: 'error', key: 'user.delete.failed'});
+    },
+
+    async _exportDb(filename) {
+        let exportUrl = this.get('ghostPaths.url').api('db');
+        let downloadURL = `${exportUrl}?filename=${filename}`;
+        let iframe = document.getElementById('iframeDownload');
+
+        if (!iframe) {
+            iframe = document.createElement('iframe');
+            iframe.id = 'iframeDownload';
+            iframe.style.display = 'none';
+            document.body.append(iframe);
+        }
+
+        iframe.setAttribute('src', downloadURL);
     },
 
     updateSlug: task(function* (newSlug) {

--- a/app/models/base.js
+++ b/app/models/base.js
@@ -1,0 +1,12 @@
+import Model from 'ember-data/model';
+
+export default Model.extend({
+    // this is a hack that gives us access to meta data in single resource responses
+    // allows similar response.get('_meta') as with multi-resource responses but can
+    // suffer from race conditions
+    // TODO: review once the record links and meta RFC lands
+    // https://github.com/emberjs/rfcs/blob/master/text/0332-ember-data-record-links-and-meta.md
+    get _meta() {
+        return this._internalModel.type.___meta;
+    }
+});

--- a/app/models/base.js
+++ b/app/models/base.js
@@ -1,4 +1,4 @@
-import Model from 'ember-data/model';
+import Model from '@ember-data/model';
 
 export default Model.extend({
     // this is a hack that gives us access to meta data in single resource responses

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -1,12 +1,13 @@
 /* eslint-disable camelcase */
-import Model, {attr, hasMany} from '@ember-data/model';
+import BaseModel from './base';
 import ValidationEngine from 'ghost-admin/mixins/validation-engine';
+import {attr, hasMany} from '@ember-data/model';
 import {computed} from '@ember/object';
 import {equal, or} from '@ember/object/computed';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 
-export default Model.extend(ValidationEngine, {
+export default BaseModel.extend(ValidationEngine, {
     validationType: 'user',
 
     name: attr('string'),

--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -3,6 +3,16 @@ import {camelize, decamelize, underscore} from '@ember/string';
 import {pluralize} from 'ember-inflector';
 
 export default RESTSerializer.extend({
+    // hacky method for getting access to meta data for single-resource responses
+    // https://github.com/emberjs/data/pull/4077#issuecomment-200780097
+    // TODO: review once the record links and meta RFC lands
+    // https://github.com/emberjs/rfcs/blob/master/text/0332-ember-data-record-links-and-meta.md
+    extractMeta(store, typeClass) {
+        let meta = this._super(...arguments);
+        typeClass.___meta = meta;
+        return meta;
+    },
+
     serialize(/*snapshot, options*/) {
         let json = this._super(...arguments);
 

--- a/app/templates/components/modal-delete-user.hbs
+++ b/app/templates/components/modal-delete-user.hbs
@@ -8,15 +8,15 @@
     {{#if this.user.count.posts}}
         <ul>
             <li>The user will not have access to this site anymore</li>
-            <li><strong data-test-text="user-post-count">{{pluralize this.user.count.posts 'post'}}</strong> created by this user will be deleted</li>
+            <li><strong data-test-text="user-post-count">{{pluralize this.user.count.posts 'post'}}</strong> by this user will be deleted</li>
             <li>All other user data will be deleted</li>
-            <li>A backup of the site contents will be automatically downloaded to your computer before deletion</li>
+            <li>A backup of the site will be automatically downloaded to your computer before deletion</li>
         </ul>
     {{else}}
         <ul>
-            <li>User will not have access to this site anymore</li>
+            <li>The user will not have access to this site anymore</li>
             <li>All user data will be deleted</li>
-            <li>A backup of the site contents will be automatically downloaded to your computer before deletion</li>
+            <li>A backup of the site will be automatically downloaded to your computer before deletion</li>
         </ul>
     {{/if}}
 </div>

--- a/app/templates/components/modal-delete-user.hbs
+++ b/app/templates/components/modal-delete-user.hbs
@@ -7,14 +7,16 @@
     <p><strong>WARNING:</strong> You are about to delete the user '<strong>{{this.user.name}}</strong>'. There is no way to recover this.</p>
     {{#if this.user.count.posts}}
         <ul>
-            <li>The user will not have access to this blog anymore</li>
+            <li>The user will not have access to this site anymore</li>
             <li><strong data-test-text="user-post-count">{{pluralize this.user.count.posts 'post'}}</strong> created by this user will be deleted</li>
             <li>All other user data will be deleted</li>
+            <li>A backup of the site contents will be automatically downloaded to your computer before deletion</li>
         </ul>
     {{else}}
         <ul>
-            <li>User will not have access to this blog anymore</li>
-            <li>All user data will be deleted.</li>
+            <li>User will not have access to this site anymore</li>
+            <li>All user data will be deleted</li>
+            <li>A backup of the site contents will be automatically downloaded to your computer before deletion</li>
         </ul>
     {{/if}}
 </div>

--- a/app/templates/components/modal-delete-user.hbs
+++ b/app/templates/components/modal-delete-user.hbs
@@ -4,20 +4,17 @@
 <a class="close" href="" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
 
 <div class="modal-body">
-    <p><strong>WARNING:</strong> You are about to delete the user '<strong>{{this.user.name}}</strong>'. There is no way to recover this.</p>
     {{#if this.user.count.posts}}
-        <ul>
-            <li>The user will not have access to this site anymore</li>
-            <li><strong data-test-text="user-post-count">{{pluralize this.user.count.posts 'post'}}</strong> by this user will be deleted</li>
-            <li>All other user data will be deleted</li>
-            <li>A backup of the site will be automatically downloaded to your computer before deletion</li>
-        </ul>
+        <p>
+            <strong>{{this.user.name}}</strong> and their <strong data-test-text="user-post-count">{{pluralize this.user.count.posts 'post'}}</strong> will be permanently deleted. If you don’t want to lose these posts, you should assign them to a different author.
+        </p>
+        <p>
+            A backup will be automatically downloaded to your device before deletion.
+        </p>
     {{else}}
-        <ul>
-            <li>The user will not have access to this site anymore</li>
-            <li>All user data will be deleted</li>
-            <li>A backup of the site will be automatically downloaded to your computer before deletion</li>
-        </ul>
+        <p>
+            <strong>{{this.user.name}}</strong> will be permanently deleted. A backup will be automatically downloaded to your device before deletion.
+        </p>
     {{/if}}
 </div>
 
@@ -25,7 +22,7 @@
     <button {{action "closeModal"}} class="gh-btn" data-test-button="cancel-delete-user">
         <span>Cancel</span>
     </button>
-    <GhTaskButton @buttonText={{if this.user.count.posts "Delete user and their posts" "Delete user"}}
+    <GhTaskButton @buttonText="Download backup & delete user"
         @successText="Deleted"
         @task={{this.deleteUser}}
         @class="gh-btn gh-btn-red gh-btn-icon"

--- a/app/templates/staff/user.hbs
+++ b/app/templates/staff/user.hbs
@@ -70,7 +70,7 @@
             {{#if this.showDeleteUserModal}}
                 <GhFullscreenModal @modal="delete-user"
                     @model={{this.user}}
-                    @confirm={{action "deleteUser"}}
+                    @confirm={{action (perform this.deleteUser)}}
                     @close={{action "toggleDeleteUserModal"}}
                     @modifier="action wide" />
             {{/if}}


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/pull/11466

Adds db export download after popup for user deletion is closed.

TODO: 
- [x] figure out where and why the `meta` is stripped from `DELETE /users/:id` response