### PR TITLE
Added membership plan currency selector  

### DIFF
--- a/app/components/gh-member-settings-form.js
+++ b/app/components/gh-member-settings-form.js
@@ -37,7 +37,7 @@ export default Component.extend({
                     status: subscription.status,
                     startDate: subscription.start_date ? moment(subscription.start_date).format('MMM DD YYYY') : '-',
                     plan: subscription.plan,
-                    dollarAmount: parseInt(subscription.plan.amount) ? (subscription.plan.amount / 100) : 0,
+                    amount: parseInt(subscription.plan.amount) ? (subscription.plan.amount / 100) : 0,
                     cancelAtPeriodEnd: subscription.cancel_at_period_end,
                     validUntil: subscription.current_period_end ? moment(subscription.current_period_end).format('MMM DD YYYY') : '-'
                 };

--- a/app/components/gh-members-lab-setting.js
+++ b/app/components/gh-members-lab-setting.js
@@ -150,7 +150,22 @@ export default Component.extend({
             }
 
             if (key === 'currency') {
-                stripeProcessor.config.plans.forEach(plan => (plan.currency = event.value));
+                stripeProcessor.config.plans.forEach((plan) => {
+                    if (plan.name !== 'Complimentary') {
+                        plan.currency = event.value;
+                    }
+                });
+
+                // NOTE: need to keep Complimentary plans with all available currencies so they don't conflict
+                //       when applied to members with existing subscriptions in different currencies (ref. https://stripe.com/docs/billing/customer#currency)
+                let currentCurrencyComplimentary = stripeProcessor.config.plans.filter(plan => (plan.currency === event.value && plan.name === 'Complimentary'));
+
+                if (!currentCurrencyComplimentary.length) {
+                    let complimentary = stripeProcessor.config.plans.find(plan => (plan.name === 'Complimentary'));
+                    let newComplimentary = Object.assign({}, complimentary, {currency: event.value});
+                    stripeProcessor.config.plans.push(newComplimentary);
+                }
+
                 stripeProcessor.config.currency = event.value;
             }
 

--- a/app/components/gh-members-lab-setting.js
+++ b/app/components/gh-members-lab-setting.js
@@ -7,10 +7,28 @@ import {set} from '@ember/object';
 const US = {flag: '🇺🇸', name: 'US', baseUrl: 'https://api.mailgun.net/v3'};
 const EU = {flag: '🇪🇺', name: 'EU', baseUrl: 'https://api.eu.mailgun.net/v3'};
 
+const currencies = [
+    {
+        label: 'USD', value: 'usd'
+    },
+    {
+        label: 'EUR', value: 'eur'
+    },
+    {
+        label: 'GBP', value: 'gbp'
+    },
+    {
+        label: 'AUD', value: 'aud'
+    }
+];
+
 export default Component.extend({
     feature: service(),
     config: service(),
     mediaQueries: service(),
+
+    currencies: currencies,
+    selectedCurrency: null,
 
     defaultContentVisibility: reads('settings.defaultContentVisibility'),
 
@@ -68,6 +86,7 @@ export default Component.extend({
     init() {
         this._super(...arguments);
         this.set('mailgunRegions', [US, EU]);
+        this.set('selectedCurrency', this.get('subscriptionSettings.stripeConfig.plans.monthly.currency'));
     },
 
     actions: {
@@ -117,6 +136,12 @@ export default Component.extend({
             if (key === 'fromAddress') {
                 subscriptionSettings.fromAddress = event.target.value;
             }
+
+            if (key === 'currency') {
+                this.set('selectedCurrency', event.value);
+                stripeProcessor.config.plans.forEach(plan => (plan.currency = event.value));
+            }
+
             this.setMembersSubscriptionSettings(subscriptionSettings);
         }
     }

--- a/app/components/gh-members-lab-setting.js
+++ b/app/components/gh-members-lab-setting.js
@@ -151,6 +151,7 @@ export default Component.extend({
 
             if (key === 'currency') {
                 stripeProcessor.config.plans.forEach(plan => (plan.currency = event.value));
+                stripeProcessor.config.currency = event.value;
             }
 
             this.setMembersSubscriptionSettings(subscriptionSettings);

--- a/app/components/gh-members-lab-setting.js
+++ b/app/components/gh-members-lab-setting.js
@@ -37,8 +37,12 @@ export default Component.extend({
         });
         let monthlyPlan = stripeProcessor.config.plans.find(plan => plan.interval === 'month');
         let yearlyPlan = stripeProcessor.config.plans.find(plan => plan.interval === 'year');
-        monthlyPlan.dollarAmount = parseInt(monthlyPlan.amount) ? (monthlyPlan.amount / 100) : 0;
-        yearlyPlan.dollarAmount = parseInt(yearlyPlan.amount) ? (yearlyPlan.amount / 100) : 0;
+
+        // NOTE: need to be careful about division by zero if we introduce zero decimal currencies
+        //       ref.: https://stripe.com/docs/currencies#zero-decimal
+        monthlyPlan.amount = parseInt(monthlyPlan.amount) ? (monthlyPlan.amount / 100) : 0;
+        yearlyPlan.amount = parseInt(yearlyPlan.amount) ? (yearlyPlan.amount / 100) : 0;
+
         stripeProcessor.config.plans = {
             monthly: monthlyPlan,
             yearly: yearlyPlan

--- a/app/components/gh-members-lab-setting.js
+++ b/app/components/gh-members-lab-setting.js
@@ -9,16 +9,16 @@ const EU = {flag: '🇪🇺', name: 'EU', baseUrl: 'https://api.eu.mailgun.net/v
 
 const CURRENCIES = [
     {
-        label: 'USD', value: 'usd'
+        label: 'USD - US Dollar', value: 'usd'
     },
     {
-        label: 'EUR', value: 'eur'
+        label: 'AUD - Australian Dollar', value: 'aud'
     },
     {
-        label: 'GBP', value: 'gbp'
+        label: 'EUR - Euro', value: 'eur'
     },
     {
-        label: 'AUD', value: 'aud'
+        label: 'GBP - British Pound', value: 'gbp'
     }
 ];
 

--- a/app/components/gh-members-lab-setting.js
+++ b/app/components/gh-members-lab-setting.js
@@ -15,6 +15,9 @@ const CURRENCIES = [
         label: 'AUD - Australian Dollar', value: 'aud'
     },
     {
+        label: 'CAD - Canadian Dollar', value: 'cad'
+    },
+    {
         label: 'EUR - Euro', value: 'eur'
     },
     {

--- a/app/templates/components/gh-member-settings-form.hbs
+++ b/app/templates/components/gh-member-settings-form.hbs
@@ -132,7 +132,7 @@
                                     <td class="gh-member-stripe-label">Plan</td>
                                     <td class="gh-member-stripe-data">
                                         {{subscription.plan.nickname}}
-                                        <span class="midgrey">({{subscription.dollarAmount}}
+                                        <span class="midgrey">({{subscription.amount}}
                                             <span class="ttu">{{subscription.plan.currency}}</span>/{{subscription.plan.interval}})
                                         </span>
                                     </td>

--- a/app/templates/components/gh-members-lab-setting.hbs
+++ b/app/templates/components/gh-members-lab-setting.hbs
@@ -71,11 +71,11 @@
 
                     <div class="flex items-center justify-center mt1 gh-input-group gh-labs-price-label">
                         <GhTextInput
-                            @value={{readonly this.subscriptionSettings.stripeConfig.plans.monthly.dollarAmount}}
+                            @value={{readonly this.subscriptionSettings.stripeConfig.plans.monthly.amount}}
                             @type="number"
                             @input={{action "setSubscriptionSettings" "month"}}
                         />
-                        <span class="gh-input-append">USD/month</span>
+                        <span class="gh-input-append">{{this.subscriptionSettings.stripeConfig.plans.monthly.currency}}/month</span>
                     </div>
                     </GhFormGroup>
                 </div>
@@ -84,7 +84,7 @@
                     <label class="fw6 f8">Yearly price</label>
                     <div class="flex items-center justify-center mt1 gh-input-group gh-labs-price-label">
                         <GhTextInput
-                            @value={{readonly this.subscriptionSettings.stripeConfig.plans.yearly.dollarAmount}}
+                            @value={{readonly this.subscriptionSettings.stripeConfig.plans.yearly.amount}}
                             @type="number"
                             @input={{action "setSubscriptionSettings" "year"}}
                         />

--- a/app/templates/components/gh-members-lab-setting.hbs
+++ b/app/templates/components/gh-members-lab-setting.hbs
@@ -65,7 +65,7 @@
 
         {{#liquid-if this.membersPricingOpen}}
             <div class="w-100 w-50-l flex flex-column flex-row-ns mt8">
-                <div class="w-100 w-50-ns mr3-ns">
+                <div class="w-100">
                     <GhFormGroup @class="for-select">
                         <label class="fw6 f8"for="currency">Plan currency</label>
                         <span class="gh-select mt1">

--- a/app/templates/components/gh-members-lab-setting.hbs
+++ b/app/templates/components/gh-members-lab-setting.hbs
@@ -68,7 +68,6 @@
                 <div class="w-100 w-50-ns mr3-ns">
                     <GhFormGroup @class="for-select">
                         <label class="fw6 f8"for="currency">Plan currency</label>
-                        <p>{{this.selectedCurrency.value}}</p>
                         <span class="gh-select">
                             {{one-way-select this.selectedCurrency
                                 id="currency"

--- a/app/templates/components/gh-members-lab-setting.hbs
+++ b/app/templates/components/gh-members-lab-setting.hbs
@@ -68,7 +68,7 @@
                 <div class="w-100 w-50-ns mr3-ns">
                     <GhFormGroup @class="for-select">
                         <label class="fw6 f8"for="currency">Plan currency</label>
-                        <span class="gh-select">
+                        <span class="gh-select mt1">
                             {{one-way-select this.selectedCurrency
                                 id="currency"
                                 name="currency"
@@ -82,8 +82,7 @@
                     </GhFormGroup>
                 </div>
             </div>
-
-            <div class="w-100 w-50-l flex flex-column flex-row-ns mt8">
+            <div class="w-100 w-50-l flex flex-column flex-row-ns">
                 <div class="w-100 w-50-ns mr3-ns">
                     <GhFormGroup>
                     <label class="fw6 f8">Monthly price</label>
@@ -112,7 +111,6 @@
                     </GhFormGroup>
                 </div>
             </div>
-            <div class="f8 fw4 midgrey">Currently only USD is supported, more currencies <a href="https://ghost.org/docs/members/" target="_blank" rel="noopener">coming soon</a></div>
         {{/liquid-if}}
     </section>
 

--- a/app/templates/components/gh-members-lab-setting.hbs
+++ b/app/templates/components/gh-members-lab-setting.hbs
@@ -75,7 +75,7 @@
                             @type="number"
                             @input={{action "setSubscriptionSettings" "month"}}
                         />
-                        <span class="gh-input-append">{{this.subscriptionSettings.stripeConfig.plans.monthly.currency}}/month</span>
+                        <span class="gh-input-append"><span class="ttu"></span>{{this.subscriptionSettings.stripeConfig.plans.monthly.currency}}</span>/month</span>
                     </div>
                     </GhFormGroup>
                 </div>
@@ -88,7 +88,7 @@
                             @type="number"
                             @input={{action "setSubscriptionSettings" "year"}}
                         />
-                        <span class="gh-input-append">USD/year</span>
+                        <span class="gh-input-append"><span class="ttu">{{this.subscriptionSettings.stripeConfig.plans.yearly.currency}}</span>/year</span>
                     </div>
                     </GhFormGroup>
                 </div>

--- a/app/templates/components/gh-members-lab-setting.hbs
+++ b/app/templates/components/gh-members-lab-setting.hbs
@@ -66,6 +66,26 @@
         {{#liquid-if this.membersPricingOpen}}
             <div class="w-100 w-50-l flex flex-column flex-row-ns mt8">
                 <div class="w-100 w-50-ns mr3-ns">
+                    <GhFormGroup @class="for-select">
+                        <label class="fw6 f8"for="currency">Plan currency</label>
+                        <p>{{this.selectedCurrency}}</p>
+                        <span class="gh-select">
+                            {{one-way-select this.selectedCurrency
+                                id="currency"
+                                name="currency"
+                                options=(readonly this.currencies)
+                                optionValuePath="value"
+                                optionLabelPath="label"
+                                update=(action "setSubscriptionSettings" "currency")
+                            }}
+                            {{svg-jar "arrow-down-small"}}
+                        </span>
+                    </GhFormGroup>
+                </div>
+            </div>
+
+            <div class="w-100 w-50-l flex flex-column flex-row-ns mt8">
+                <div class="w-100 w-50-ns mr3-ns">
                     <GhFormGroup>
                     <label class="fw6 f8">Monthly price</label>
 

--- a/app/templates/components/gh-members-lab-setting.hbs
+++ b/app/templates/components/gh-members-lab-setting.hbs
@@ -93,7 +93,7 @@
                             @type="number"
                             @input={{action "setSubscriptionSettings" "month"}}
                         />
-                        <span class="gh-input-append"><span class="ttu"></span>{{this.subscriptionSettings.stripeConfig.plans.monthly.currency}}</span>/month</span>
+                        <span class="gh-input-append"><span class="ttu">{{this.subscriptionSettings.stripeConfig.plans.monthly.currency}}</span>/month</span>
                     </div>
                     </GhFormGroup>
                 </div>

--- a/app/templates/components/gh-members-lab-setting.hbs
+++ b/app/templates/components/gh-members-lab-setting.hbs
@@ -68,7 +68,7 @@
                 <div class="w-100 w-50-ns mr3-ns">
                     <GhFormGroup @class="for-select">
                         <label class="fw6 f8"for="currency">Plan currency</label>
-                        <p>{{this.selectedCurrency}}</p>
+                        <p>{{this.selectedCurrency.value}}</p>
                         <span class="gh-select">
                             {{one-way-select this.selectedCurrency
                                 id="currency"


### PR DESCRIPTION
Changes:
- refactors variable naming to be more generic in regards to currencies
- adds a dropdown which controls setting plan currency on both monthly & yearly plans

TODO:
- [x] figure out the bug with dropdown select box, as it's not displaying selected value properly.