### PR TITLE
✨ Enabled manual typing of post publish dates

### DIFF
--- a/app/components/gh-date-time-picker.js
+++ b/app/components/gh-date-time-picker.js
@@ -145,7 +145,8 @@ export default Component.extend({
         this._timeInputElem = elem;
     }),
 
-    onDateInput: action(function (event) {
+    onDateInput: action(function (datepicker, event) {
+        datepicker.actions.close();
         this.set('_scratchDate', event.target.value);
     }),
 

--- a/app/components/gh-date-time-picker.js
+++ b/app/components/gh-date-time-picker.js
@@ -148,6 +148,7 @@ export default Component.extend({
         // make sure we're not doing anything just because the calendar dropdown
         // is opened and clicked
         if (event.target.value === this._date.format('YYYY-MM-DD')) {
+            this.set('_scratchDateError', null);
             return;
         }
 

--- a/app/components/gh-date-time-picker.js
+++ b/app/components/gh-date-time-picker.js
@@ -141,6 +141,10 @@ export default Component.extend({
         }
     },
 
+    registerTimeInput: action(function (elem) {
+        this._timeInputElem = elem;
+    }),
+
     onDateInput: action(function (event) {
         this.set('_scratchDate', event.target.value);
     }),
@@ -160,13 +164,30 @@ export default Component.extend({
         }
     }),
 
-    onDateKeydown: action(function (event) {
+    onDateKeydown: action(function (datepicker, event) {
         if (event.key === 'Escape') {
             this._resetScratchDate();
         }
 
         if (event.key === 'Enter') {
             this._setDate(event.target.value);
+        }
+
+        // close the dropdown and manually focus the time input if necessary
+        // so that keyboard focus behaves as expected
+        if (event.key === 'Tab' && datepicker.isOpen) {
+            datepicker.actions.close();
+
+            // manual focus is required because the dropdown is rendered in place
+            // and the default browser behaviour will move focus to the dropdown
+            // which is then removed from the DOM making it look like focus has
+            // disappeared. Shift+Tab is fine because the DOM is not changing in
+            // that direction
+            if (!event.shiftKey && this._timeInputElem) {
+                event.preventDefault();
+                this._timeInputElem.focus();
+                this._timeInputElem.select();
+            }
         }
 
         // capture a Ctrl/Cmd+S combo to make sure that the model value is updated

--- a/app/components/gh-date-time-picker.js
+++ b/app/components/gh-date-time-picker.js
@@ -33,7 +33,7 @@ export default Component.extend({
         if (this._scratchDate !== null) {
             return this._scratchDate;
         } else {
-            return this._date.format(DATE_FORMAT);
+            return moment(this._date).format(DATE_FORMAT);
         }
     }),
 
@@ -88,7 +88,7 @@ export default Component.extend({
         this._lastDate = this.date;
 
         if (isBlank(time)) {
-            this.set('_time', this._date.format('HH:mm'));
+            this.set('_time', moment(this._date).format('HH:mm'));
         } else {
             this.set('_time', this.time);
         }
@@ -152,7 +152,7 @@ export default Component.extend({
     onDateBlur: action(function (event) {
         // make sure we're not doing anything just because the calendar dropdown
         // is opened and clicked
-        if (event.target.value === this._date.format('YYYY-MM-DD')) {
+        if (event.target.value === moment(this._date).format('YYYY-MM-DD')) {
             this.set('_scratchDateError', null);
             return;
         }

--- a/app/components/gh-date-time-picker.js
+++ b/app/components/gh-date-time-picker.js
@@ -219,7 +219,7 @@ export default Component.extend({
         }
 
         let date = moment(dateStr, DATE_FORMAT);
-        if (!date.isValid) {
+        if (!date.isValid()) {
             this.set('_scratchDateError', 'Invalid date');
             return false;
         }

--- a/app/components/gh-date-time-picker.js
+++ b/app/components/gh-date-time-picker.js
@@ -81,8 +81,9 @@ export default Component.extend({
             this.set('_date', moment().tz(blogTimezone));
         }
 
+        // reset scratch date if date is changed externally
         if ((date && date.valueOf()) !== (this._lastDate && this._lastDate.valueOf())) {
-            this.set('_scratchDate', null);
+            this._resetScratchDate();
         }
         this._lastDate = this.date;
 
@@ -153,7 +154,7 @@ export default Component.extend({
         }
 
         if (!event.target.value) {
-            this._resetDate();
+            this._resetScratchDate();
         } else {
             this._setDate(event.target.value);
         }
@@ -161,7 +162,7 @@ export default Component.extend({
 
     onDateKeydown: action(function (event) {
         if (event.key === 'Escape') {
-            this._resetDate();
+            this._resetScratchDate();
         }
 
         if (event.key === 'Enter') {
@@ -181,8 +182,9 @@ export default Component.extend({
 
     // internal methods
 
-    _resetDate() {
+    _resetScratchDate() {
         this.set('_scratchDate', null);
+        this.set('_scratchDateError', null);
     },
 
     _setDate(dateStr) {
@@ -198,8 +200,7 @@ export default Component.extend({
         }
 
         this.send('setDate', date.toDate());
-        this.set('_scratchDate', null);
-        this.set('_scratchDateError', null);
+        this._resetScratchDate();
         return true;
     }
 });

--- a/app/components/gh-date-time-picker.js
+++ b/app/components/gh-date-time-picker.js
@@ -154,7 +154,7 @@ export default Component.extend({
         // make sure we're not doing anything just because the calendar dropdown
         // is opened and clicked
         if (event.target.value === moment(this._date).format('YYYY-MM-DD')) {
-            this.set('_scratchDateError', null);
+            this._resetScratchDate();
             return;
         }
 
@@ -172,6 +172,9 @@ export default Component.extend({
 
         if (event.key === 'Enter') {
             this._setDate(event.target.value);
+            event.preventDefault();
+            event.stopImmediatePropagation();
+            datepicker.actions.close();
         }
 
         // close the dropdown and manually focus the time input if necessary

--- a/app/components/gh-publishmenu.js
+++ b/app/components/gh-publishmenu.js
@@ -12,14 +12,15 @@ const CONFIRM_EMAIL_MAX_POLL_LENGTH = 15 * 1000;
 export default Component.extend({
     clock: service(),
 
+    backgroundTask: null,
     classNames: 'gh-publishmenu',
     displayState: 'draft',
     post: null,
     postStatus: 'draft',
-    saveTask: null,
     runningText: null,
-    backgroundTask: null,
+    saveTask: null,
     sendEmailWhenPublished: false,
+    typedDateError: null,
 
     _publishedAtBlogTZ: null,
     _previousStatus: null,
@@ -257,7 +258,18 @@ export default Component.extend({
     }),
 
     save: task(function* ({dropdown} = {}) {
-        let {post, sendEmailWhenPublished, sendEmailConfirmed, saveType} = this;
+        let {
+            post,
+            sendEmailWhenPublished,
+            sendEmailConfirmed,
+            saveType,
+            typedDateError
+        } = this;
+
+        // don't allow save if an invalid schedule date is present
+        if (typedDateError) {
+            return false;
+        }
 
         if (
             post.status === 'draft' &&

--- a/app/templates/components/gh-date-time-picker.hbs
+++ b/app/templates/components/gh-date-time-picker.hbs
@@ -12,7 +12,7 @@
                     placeholder={{this.dateFormat}}
                     value={{readonly this.dateValue}}
                     disabled={{this.disabled}}
-                    {{on "input" this.onDateInput}}
+                    {{on "input" (fn this.onDateInput dp)}}
                     {{on "blur" this.onDateBlur}}
                     {{on "keydown" (fn this.onDateKeydown dp)}}
                     data-test-date-time-picker-date-input>

--- a/app/templates/components/gh-date-time-picker.hbs
+++ b/app/templates/components/gh-date-time-picker.hbs
@@ -14,7 +14,7 @@
                     disabled={{this.disabled}}
                     {{on "input" this.onDateInput}}
                     {{on "blur" this.onDateBlur}}
-                    {{on "keydown" this.onDateKeydown}}
+                    {{on "keydown" (fn this.onDateKeydown dp)}}
                     data-test-date-time-picker-date-input>
                 {{svg-jar "calendar"}}
             </div>
@@ -32,6 +32,7 @@
             disabled={{this.disabled}}
             oninput={{action (mut this._time) value="target.value"}}
             onblur={{action "setTime" this._time}}
+            {{did-insert this.registerTimeInput}}
             data-test-date-time-picker-time-input
         >
         <small class="gh-date-time-picker-timezone">({{this.timezone}})</small>

--- a/app/templates/components/gh-date-time-picker.hbs
+++ b/app/templates/components/gh-date-time-picker.hbs
@@ -8,7 +8,14 @@
     }}
         {{#dp.trigger tabindex="-1" data-test-date-time-picker-datepicker=true}}
             <div class="gh-date-time-picker-date {{if this.dateError "error"}}">
-                <input type="text" readonly value={{moment-format this._date "YYYY-MM-DD"}} disabled={{this.disabled}} data-test-date-time-picker-date-input>
+                <input type="text"
+                    placeholder={{this.dateFormat}}
+                    value={{readonly this.dateValue}}
+                    disabled={{this.disabled}}
+                    {{on "input" this.onDateInput}}
+                    {{on "blur" this.onDateBlur}}
+                    {{on "keydown" this.onDateKeydown}}
+                    data-test-date-time-picker-date-input>
                 {{svg-jar "calendar"}}
             </div>
         {{/dp.trigger}}

--- a/app/templates/components/gh-post-settings-menu.hbs
+++ b/app/templates/components/gh-post-settings-menu.hbs
@@ -61,7 +61,7 @@
                         timeErrorProperty="publishedAtBlogTime"
                         maxDate='now'
                         disabled=this.post.isScheduled
-                        static=true
+                        isActive=(and this.showSettingsMenu (not this.isViewingSubview))
                     }}
                     {{#unless (or this.post.isDraft this.post.isPublished this.post.pastScheduledTime)}}
                     <p>Use the publish menu to re-schedule</p>

--- a/app/templates/components/gh-publishmenu-draft.hbs
+++ b/app/templates/components/gh-publishmenu-draft.hbs
@@ -17,10 +17,12 @@
                     time=this.post.publishedAtBlogTime
                     setDate=(action "setDate")
                     setTime=(action "setTime")
+                    setTypedDateError=this.setTypedDateError
                     errors=this.post.errors
                     dateErrorProperty="publishedAtBlogDate"
                     timeErrorProperty="publishedAtBlogTime"
                     minDate=this._minDate
+                    isActive=(eq this.saveType "schedule")
                 }}
                 <div class="gh-publishmenu-radio-desc">Set automatic future publish date</div>
             </div>

--- a/app/templates/components/gh-publishmenu-scheduled.hbs
+++ b/app/templates/components/gh-publishmenu-scheduled.hbs
@@ -17,10 +17,12 @@
                     time=this.post.publishedAtBlogTime
                     setDate=(action "setDate")
                     setTime=(action "setTime")
+                    setTypedDateError=this.setTypedDateError
                     errors=this.post.errors
                     dateErrorProperty="publishedAtBlogDate"
                     timeErrorProperty="publishedAtBlogTime"
                     minDate=this._minDate
+                    isActive=(eq this.saveType "schedule")
                 }}
                 <div class="gh-publishmenu-radio-desc">Set automatic future publish date</div>
             </div>

--- a/app/templates/components/gh-publishmenu.hbs
+++ b/app/templates/components/gh-publishmenu.hbs
@@ -17,13 +17,15 @@
                 saveType=this.saveType
                 isClosing=this.isClosing
                 memberCount=this.memberCount
-                setSaveType=(action "setSaveType")}}
+                setSaveType=(action "setSaveType")
+                setTypedDateError=(action (mut this.typedDateError))}}
 
         {{else}}
             {{gh-publishmenu-draft
                 post=this.post
                 saveType=this.saveType
                 setSaveType=(action "setSaveType")
+                setTypedDateError=(action (mut this.typedDateError))
                 backgroundTask=this.backgroundTask
                 memberCount=this.memberCount
                 sendEmailWhenPublished=this.sendEmailWhenPublished}}


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/9256

- stores the typed date internally to the component until
  - Enter is pressed whilst focused
  - Ctrl/Cmd+S is pressed whilst focused
  - the input loses focus
- shows an error message if the typed date is not in the correct format or is invalid
- stops Ctrl/Cmd+S propagating if the typed date is not in the correct format or is invalid
- as long as the date is valid it calls the `setDate` action when the input loses focus, Ctrl/Cmd+S or Enter is pressed

TODO / Problems:
- [x] date and error should reset if the post settings menu is closed
- [x] invalid date or format should prevent the post from being saved in the publish menu
- [ ] date and error should be reset if the post is saved outside of the date/time input