### PR TITLE
Switched to Renovate's LTS support policy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,7 @@
   "ignorePaths": ["lib/koenig-editor/package.json"],
   "travis": { "enabled": true },
   "node": {
-    "supportPolicy": ["lts_latest"]
+    "supportPolicy": ["lts"]
   },
   "separateMinorPatch": true,
   "patch": {


### PR DESCRIPTION
no issue

- we want to support all LTS versions and not just the latest