### PR TITLE
Migrated to `<AngleBracketSyntax />`

### DIFF
--- a/app/components/gh-cm-editor.js
+++ b/app/components/gh-cm-editor.js
@@ -119,8 +119,4 @@ const CmEditorComponent = Component.extend({
     }
 });
 
-CmEditorComponent.reopenClass({
-    positionalParams: ['value']
-});
-
 export default CmEditorComponent;

--- a/app/components/gh-feature-flag.js
+++ b/app/components/gh-feature-flag.js
@@ -41,8 +41,4 @@ const FeatureFlagComponent = Component.extend({
     }
 });
 
-FeatureFlagComponent.reopenClass({
-    positionalParams: ['flag', '_disabled']
-});
-
 export default FeatureFlagComponent;

--- a/app/components/gh-fullscreen-modal.js
+++ b/app/components/gh-fullscreen-modal.js
@@ -56,8 +56,4 @@ const FullScreenModalComponent = Component.extend({
     confirm: () => RSVP.resolve()
 });
 
-FullScreenModalComponent.reopenClass({
-    positionalParams: ['modal']
-});
-
 export default FullScreenModalComponent;

--- a/app/components/gh-task-button.js
+++ b/app/components/gh-task-button.js
@@ -159,8 +159,4 @@ const GhTaskButton = Component.extend({
     })
 });
 
-GhTaskButton.reopenClass({
-    positionalParams: ['buttonText']
-});
-
 export default GhTaskButton;

--- a/app/components/gh-tour-item.js
+++ b/app/components/gh-tour-item.js
@@ -165,8 +165,4 @@ const GhTourItemComponent = Component.extend({
     }
 });
 
-GhTourItemComponent.reopenClass({
-    positionalParams: ['throbberId']
-});
-
 export default GhTourItemComponent;

--- a/app/services/tour.js
+++ b/app/services/tour.js
@@ -14,7 +14,7 @@ export default Service.extend(Evented, {
     // tour items need to be centrally defined here so that we have a single
     // source of truth for marking all tour items as viewed
     //
-    // a {{gh-tour-item "unique-id"}} component can be inserted in any template,
+    // a <GhTourItem @trobberId="unique-id"/> component can be inserted in any template,
     // this will use the tour service to grab content and determine visibility
     // with the component in control of rendering the throbber/controlling the
     // modal - this allows the component lifecycle hooks to perform automatic
@@ -97,7 +97,7 @@ export default Service.extend(Evented, {
     },
 
     // returns throbber content for a given ID only if that throbber hasn't been
-    // viewed. Used by the {{gh-tour-item}} component to determine visibility
+    // viewed. Used by the <GhTourItem /> component to determine visibility
     activeThrobber(id) {
         let activeThrobbers = this._activeThrobbers;
         return activeThrobbers.findBy('id', id);

--- a/app/templates/application-error.hbs
+++ b/app/templates/application-error.hbs
@@ -3,13 +3,13 @@
         <section class="error-details">
             <img class="error-ghost" src="assets/img/404-ghost@2x.png" srcset="assets/img/404-ghost.png 1x, assets/img/404-ghost@2x.png 2x" />
             <section class="error-message">
-                <h1 class="error-code">{{model.code}}</h1>
+                <h1 class="error-code">{{this.model.code}}</h1>
                 <h2 class="error-description">
-                    {{or model.payload.errors.firstObject.message model.message}}
+                    {{or this.model.payload.errors.firstObject.message this.model.message}}
                 </h2>
             </section>
         </section>
     </section>
 </div>
 
-{{ember-load-remover}}
+<EmberLoadRemover />

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,27 +1,25 @@
-{{#gh-app showSettingsMenu=this.ui.showSettingsMenu}}
-    {{#gh-skip-link anchor=".gh-main"}}Skip to main content{{/gh-skip-link}}
+<GhApp @showSettingsMenu={{this.ui.showSettingsMenu}}>
+    <GhSkipLink @anchor=".gh-main">Skip to main content</GhSkipLink>
 
-    {{gh-alerts}}
+    <GhAlerts />
 
     <div class="gh-viewport {{if this.ui.showSettingsMenu 'settings-menu-expanded'}} {{if this.ui.showMobileMenu 'mobile-menu-expanded'}}">
         {{#if this.showNavMenu}}
-            {{gh-nav-menu
-                icon=this.settings.settledIcon
-            }}
+            <GhNavMenu @icon={{this.settings.settledIcon}} />
         {{/if}}
 
         <main class="gh-main {{this.ui.mainClass}}" role="main">
             {{outlet}}
         </main>
 
-        {{gh-notifications}}
+        <GhNotifications />
 
-        {{gh-content-cover}}
+        <GhContentCover />
 
-        {{gh-mobile-nav-bar}}
+        <GhMobileNavBar />
 
         <GhWhatsNew />
     </div>{{!gh-viewport}}
-{{/gh-app}}
+</GhApp>
 
-{{ember-load-remover}}
+<EmberLoadRemover />

--- a/app/templates/components/gh-activating-list-item.hbs
+++ b/app/templates/components/gh-activating-list-item.hbs
@@ -1,1 +1,1 @@
-{{#link-to this.route alternateActive=(action "setActive") classNameBindings="linkClasses"}}{{title}}{{yield}}{{/link-to}}
+<LinkTo @route={{this.route}} @alternateActive={{action "setActive"}} @class={{@linkClasses}}>{{this.title}}{{yield}}</LinkTo>

--- a/app/templates/components/gh-alerts.hbs
+++ b/app/templates/components/gh-alerts.hbs
@@ -1,3 +1,3 @@
 {{#each this.messages as |message|}}
-    {{gh-alert message=message}}
+    <GhAlert @message={{message}} />
 {{/each}}

--- a/app/templates/components/gh-cm-editor.hbs
+++ b/app/templates/components/gh-cm-editor.hbs
@@ -1,5 +1,6 @@
 {{!-- display a standard textarea whilst waiting for CodeMirror to load/initialize --}}
-{{gh-textarea
-    class=(concat "gh-cm-editor-textarea " this.textareaClass)
-    value=(readonly this._value)
-    input=(action "updateFromTextarea" value="target.value")}}
+<GhTextarea
+    @class={{concat "gh-cm-editor-textarea " this.textareaClass}}
+    @value={{readonly this._value}}
+    @input={{action "updateFromTextarea" value="target.value"}}
+/>

--- a/app/templates/components/gh-file-uploader.hbs
+++ b/app/templates/components/gh-file-uploader.hbs
@@ -13,8 +13,8 @@
     {{/if}}
 {{else}}
     <div class="upload-form">
-        {{#gh-file-input multiple=false alt=this.labelText action=(action 'fileSelected') accept=this.accept}}
+        <GhFileInput @multiple={{false}} @alt={{this.labelText}} @action={{action "fileSelected"}} @accept={{this.accept}}>
             <div class="description">{{this.labelText}}</div>
-        {{/gh-file-input}}
+        </GhFileInput>
     </div>
 {{/if}}

--- a/app/templates/components/gh-fullscreen-modal.hbs
+++ b/app/templates/components/gh-fullscreen-modal.hbs
@@ -1,4 +1,4 @@
-{{#liquid-wormhole class="fullscreen-modal-container"}}
+<LiquidWormhole @class="fullscreen-modal-container">
     <div class="fullscreen-modal-background" {{action "clickOverlay"}}></div>
     <div class={{this.modalClasses}}>
         {{#if hasBlock}}
@@ -10,4 +10,4 @@
                       closeModal=(action 'close')}}
         {{/if}}
     </div>
-{{/liquid-wormhole}}
+</LiquidWormhole>

--- a/app/templates/components/gh-image-uploader-with-preview.hbs
+++ b/app/templates/components/gh-image-uploader-with-preview.hbs
@@ -1,18 +1,18 @@
-{{#if image}}
+{{#if this.image}}
     <div class="gh-image-uploader -with-image">
-        <div><img src={{image}}></div>
+        <div><img src={{this.image}}></div>
         <a class="image-cancel" title="Delete" {{action "remove"}}>
             {{svg-jar "trash"}}
             <span class="hidden">Delete</span>
         </a>
     </div>
 {{else}}
-    {{gh-image-uploader
-        text=text
-        altText=this.altText
-        allowUnsplash=this.allowUnsplash
-        update=(action 'update')
-        uploadStarted=(action 'uploadStarted')
-        uploadFinished=(action 'uploadFinished')
-    }}
+    <GhImageUploader
+        @text={{this.text}}
+        @altText={{this.altText}}
+        @allowUnsplash={{this.allowUnsplash}}
+        @update={{action "update"}}
+        @uploadStarted={{action "uploadStarted"}}
+        @uploadFinished={{action "uploadFinished"}}
+    />
 {{/if}}

--- a/app/templates/components/gh-image-uploader.hbs
+++ b/app/templates/components/gh-image-uploader.hbs
@@ -14,9 +14,9 @@
 {{else}}
     {{!-- file selection/drag-n-drop  --}}
     <div class="upload-form">
-        {{#gh-file-input multiple=false alt=this.description action=(action "fileSelected") accept=this.accept}}
+        <GhFileInput @multiple={{false}} @alt={{this.description}} @action={{action "fileSelected"}} @accept={{this.accept}}>
             <div class="gh-btn gh-btn-outline" data-test-file-input-description><span>{{this.description}}</span></div>
-        {{/gh-file-input}}
+        </GhFileInput>
 
         {{#if (and this.allowUnsplash this.settings.unsplash.isActive)}}
             <div class="gh-image-uploader-unsplash" {{action (toggle "_showUnsplash" this)}}>
@@ -27,8 +27,8 @@
 {{/if}}
 
 {{#if this._showUnsplash}}
-    {{gh-unsplash
-        select=(action "addUnsplashPhoto")
-        close=(action (toggle "_showUnsplash" this))
-    }}
+    <GhUnsplash
+        @select={{action "addUnsplashPhoto"}}
+        @close={{action (toggle "_showUnsplash" this)}}
+    />
 {{/if}}

--- a/app/templates/components/gh-koenig-editor.hbs
+++ b/app/templates/components/gh-koenig-editor.hbs
@@ -4,32 +4,31 @@
     onmousedown={{action "trackMousedown"}}
     onmouseup={{action "focusEditor"}}
 >
-    {{gh-textarea
-        class="gh-editor-title"
-        placeholder=this.titlePlaceholder
-        tabindex="1"
-        autoExpand=".gh-koenig-editor"
-        value=(readonly this.title)
-        input=(action "onTitleChange" value="target.value")
-        focus-out=(action "onTitleFocusOut")
-        keyDown=(action "onTitleKeydown")
-        didCreateTextarea=(action "onTitleCreated")
-        data-test-editor-title-input=true
-    }}
+    <GhTextarea
+        @class="gh-editor-title"
+        @placeholder={{this.titlePlaceholder}}
+        @tabindex="1"
+        @autoExpand=".gh-koenig-editor"
+        @value={{readonly this.title}}
+        @input={{action "onTitleChange" value="target.value"}}
+        @focus-out={{action "onTitleFocusOut"}}
+        @keyDown={{action "onTitleKeydown"}}
+        @didCreateTextarea={{action "onTitleCreated"}} data-test-editor-title-input={{true}}
+    />
 
-    {{koenig-editor
-        mobiledoc=this.body
-        placeholder=this.bodyPlaceholder
-        autofocus=this.bodyAutofocus
-        spellcheck=true
-        onChange=(action "onBodyChange")
-        didCreateEditor=(action "onEditorCreated")
-        cursorDidExitAtTop=(action "focusTitle")
-        headerOffset=this.headerOffset
-        dropTargetSelector=".gh-koenig-editor-pane"
-        scrollContainerSelector=this.scrollContainerSelector
-        scrollOffsetTopSelector=this.scrollOffsetTopSelector
-        scrollOffsetBottomSelector=this.scrollOffsetBottomSelector
-        wordCountDidChange=(action this.onWordCountChange)
-    }}
+    <KoenigEditor
+        @mobiledoc={{this.body}}
+        @placeholder={{this.bodyPlaceholder}}
+        @autofocus={{this.bodyAutofocus}}
+        @spellcheck={{true}}
+        @onChange={{action "onBodyChange"}}
+        @didCreateEditor={{action "onEditorCreated"}}
+        @cursorDidExitAtTop={{action "focusTitle"}}
+        @headerOffset={{this.headerOffset}}
+        @dropTargetSelector=".gh-koenig-editor-pane"
+        @scrollContainerSelector={{this.scrollContainerSelector}}
+        @scrollOffsetTopSelector={{this.scrollOffsetTopSelector}}
+        @scrollOffsetBottomSelector={{this.scrollOffsetBottomSelector}}
+        @wordCountDidChange={{action this.onWordCountChange}}
+    />
 </div>

--- a/app/templates/components/gh-markdown-editor.hbs
+++ b/app/templates/components/gh-markdown-editor.hbs
@@ -14,20 +14,20 @@
 )}}
 
 <div style="display:none">
-    {{gh-file-input
-        multiple=true
-        action=(action this.onImageFilesSelected)
-        accept=this.imageMimeTypes}}
+    <GhFileInput
+        @multiple={{true}}
+        @action={{action this.onImageFilesSelected}}
+        @accept={{this.imageMimeTypes}} />
 </div>
 
 {{#if this._showUnsplash}}
-    {{gh-unsplash
-        select=(action "insertUnsplashPhoto")
-        close=(action "toggleUnsplash")}}
+    <GhUnsplash
+        @select={{action "insertUnsplashPhoto"}}
+        @close={{action "toggleUnsplash"}} />
 {{/if}}
 
 {{#if this.showMarkdownHelp}}
-    {{gh-fullscreen-modal "markdown-help"
-        close=(action "toggleMarkdownHelp")
-        modifier="wide"}}
+    <GhFullscreenModal @modal="markdown-help"
+        @close={{action "toggleMarkdownHelp"}}
+        @modifier="wide" />
 {{/if}}

--- a/app/templates/components/gh-member-settings-form.hbs
+++ b/app/templates/components/gh-member-settings-form.hbs
@@ -2,56 +2,55 @@
 <div class="br4 shadow-1 bg-grouped-table mt2 flex flex-column items-stretch gh-member-basic-settings-form">
     <div class="pa5 pb0 pt4 flex flex-column flex-row-ns justify-between">
         <div class="flex flex-column items-start mr8 w-100 w-50-ns">
-            {{#gh-form-group errors=member.errors hasValidated=member.hasValidated property="name"}}
+            <GhFormGroup @errors={{this.member.errors}} @hasValidated={{this.member.hasValidated}} @property="name">
                 <label for="member-name">Name</label>
-                {{gh-text-input
-                    id="member-name"
-                    name="name"
-                    value=this.scratchMember.name
-                    tabindex="1"
-                    focus-out=(action 'setProperty' 'name' this.scratchMember.name)}}
+                <GhTextInput
+                    @id="member-name"
+                    @name="name"
+                    @value={{this.scratchMember.name}}
+                    @tabindex="1"
+                    @focus-out={{action "setProperty" "name" this.scratchMember.name}} />
                 <GhErrorMessage @errors={{member.errors}} @property="name" />
-            {{/gh-form-group}}
+            </GhFormGroup>
 
-            {{#gh-form-group errors=member.errors hasValidated=member.hasValidated property="email"}}
+            <GhFormGroup @errors={{this.member.errors}} @hasValidated={{this.member.hasValidated}} @property="email">
                 <label for="member-email">Email</label>
                 {{#if this.canEditEmail}}
-                    {{gh-text-input
-                        value=this.scratchMember.email
-                        id="member-email"
-                        name="email"
-                        tabindex="2"
-                        autocapitalize="off"
-                        autocorrect="off"
-                        autocomplete="off"
-                        focus-out=(action 'setProperty' 'email' this.scratchMember.email)}}
-                    <GhErrorMessage @errors={{member.errors}} @property="email" />
+                    <GhTextInput
+                        @value={{this.scratchMember.email}}
+                        @id="member-email"
+                        @name="email"
+                        @tabindex="2"
+                        @autocapitalize="off"
+                        @autocorrect="off"
+                        @autocomplete="off"
+                        @focus-out={{action "setProperty" "email" this.scratchMember.email}} />
+                    <GhErrorMessage @errors={{this.member.errors}} @property="email" />
                 {{else}}
-                    {{gh-text-input
-                        name="email-disabled"
-                        disabled=true
-                        value=this.scratchMember.email}}
+                    <GhTextInput
+                        @name="email-disabled"
+                        @disabled={{true}}
+                        @value={{this.scratchMember.email}} />
                 {{/if}}
-            {{/gh-form-group}}
+            </GhFormGroup>
         </div>
         <div class="mb6 mb0-ns w-100 w-50-ns">
-            {{#gh-form-group errors=member.errors hasValidated=member.hasValidated property="note"}}
+            <GhFormGroup @errors={{this.member.errors}} @hasValidated={{this.member.hasValidated}} @property="note">
                 <label for="member-note">Note</label>
-                {{gh-textarea
-                    id="member-note"
-                    name="note"
-                    class="gh-member-details-textarea"
-                    tabindex="3"
-                    value=this.scratchMember.note
-                    focus-out=(action 'setProperty' 'note' this.scratchMember.note)
-                }}
-                <GhErrorMessage @errors={{member.errors}} @property="note" />
+                <GhTextarea
+                    @id="member-note"
+                    @name="note"
+                    @class="gh-member-details-textarea"
+                    @tabindex="3"
+                    @value={{this.scratchMember.note}}
+                    @focus-out={{action "setProperty" "note" this.scratchMember.note}} />
+                <GhErrorMessage @errors={{this.member.errors}} @property="note" />
                 <p>Not visible to member. Maximum: <b>500</b> characters. You’ve used {{gh-count-down-characters this.scratchMember.note 500}}</p>
-            {{/gh-form-group}}
+            </GhFormGroup>
         </div>
     </div>
     <div class="pa5 pb0 pt4 flex flex-column justify-between bt b--whitegrey">
-        {{#gh-form-group classNames="gh-members-subscribed-checkbox"}}
+        <GhFormGroup @classNames="gh-members-subscribed-checkbox">
             <div class="flex justify-between items-center">
                 <div>
                     <h4 class="gh-setting-title">Subscribed to newsletter</h4>
@@ -64,7 +63,7 @@
                     </label>
                 </div>
             </div>
-        {{/gh-form-group}}
+        </GhFormGroup>
     </div>
 </div>
 

--- a/app/templates/components/gh-members-chart.hbs
+++ b/app/templates/components/gh-members-chart.hbs
@@ -25,10 +25,10 @@
             </div>
         </div>
         <div class="gh-members-chart-container">
-            {{ember-chart type='LineWithLine' options=subData.chartData.options data=subData.chartData.data height=300}}
+            <EmberChart @type="LineWithLine" @options={{this.subData.chartData.options}} @data={{this.subData.chartData.data}} @height={{300}} />
         </div>
         <div class="flex justify-between pa4 pt0 pb2 nt1">
-            <span class="f8 midlightgrey">{{subData.startDateLabel}}</span>
+            <span class="f8 midlightgrey">{{this.subData.startDateLabel}}</span>
             <span class="f8 midlightgrey">Today</span>
         </div>
     </div>
@@ -37,19 +37,19 @@
     <div class="flex flex-column justify-between gh-members-chart-summary bg-white br3 shadow-1 bg-grouped-table">
         <div class="flex-auto flex flex-column justify-center items-start pa4 bb b--whitegrey">
             <h3 class="f-small ttu midgrey fw5">Total Members</h3>
-            <div class="gh-members-chart-summary-data">{{subData.totalSubs}}</div>
+            <div class="gh-members-chart-summary-data">{{this.subData.totalSubs}}</div>
         </div>
         <div class="flex-auto flex flex-column justify-center items-start pa4 bb b--whitegrey">
-            {{#if (eq range "all-time")}}
+            {{#if (eq this.range "all-time")}}
                 <h3 class="f-small ttu midgrey fw5">All time signups</h3>
             {{else}}
-                <h3 class="f-small ttu midgrey fw5">Signed up in the last {{range}} days</h3>
+                <h3 class="f-small ttu midgrey fw5">Signed up in the last {{this.range}} days</h3>
             {{/if}}
-            <div class="gh-members-chart-summary-data">{{subData.totalSubsInRange}}</div>
+            <div class="gh-members-chart-summary-data">{{this.subData.totalSubsInRange}}</div>
         </div>
         <div class="flex-auto flex flex-column justify-center items-start pa4">
             <h3 class="f-small ttu midgrey fw5">Signed up today</h3>
-            <div class="gh-members-chart-summary-data">{{subData.totalSubsToday}}</div>
+            <div class="gh-members-chart-summary-data">{{this.subData.totalSubsToday}}</div>
         </div>
     </div>
 </div>

--- a/app/templates/components/gh-members-lab-setting.hbs
+++ b/app/templates/components/gh-members-lab-setting.hbs
@@ -16,21 +16,21 @@
                 <div class="w-100 w-50-l">
                     <div class="mb4">
                         <label class="fw6 f8">Stripe Publishable key</label>
-                        {{gh-text-input
-                            type="password"
-                            value=(readonly this.subscriptionSettings.stripeConfig.public_token)
-                            input=(action "setSubscriptionSettings" "public_token")
-                            class="mt1 password"
-                        }}
+                        <GhTextInput
+                            @type="password"
+                            @value={{readonly this.subscriptionSettings.stripeConfig.public_token}}
+                            @input={{action "setSubscriptionSettings" "public_token"}}
+                            @class="mt1 password"
+                        />
                     </div>
                     <div class="nudge-top--3">
                         <label class="fw6 f8 mt4">Stripe Secret key</label>
-                        {{gh-text-input
-                            type="password"
-                            value=(readonly this.subscriptionSettings.stripeConfig.secret_token)
-                            input=(action "setSubscriptionSettings" "secret_token")
-                            class="mt1 password"
-                        }}
+                        <GhTextInput
+                            @type="password"
+                            @value={{readonly this.subscriptionSettings.stripeConfig.secret_token}}
+                            @input={{action "setSubscriptionSettings" "secret_token"}}
+                            @class="mt1 password"
+                        />
                         <a href="https://dashboard.stripe.com/account/apikeys" target="_blank" class="mt1 fw4 f8">
                             Find your Stripe API keys here &raquo;
                         </a>
@@ -66,31 +66,31 @@
         {{#liquid-if this.membersPricingOpen}}
             <div class="w-100 w-50-l flex flex-column flex-row-ns mt8">
                 <div class="w-100 w-50-ns mr3-ns">
-                    {{#gh-form-group}}
+                    <GhFormGroup>
                     <label class="fw6 f8">Monthly price</label>
 
                     <div class="flex items-center justify-center mt1 gh-input-group gh-labs-price-label">
-                        {{gh-text-input
-                            value=(readonly this.subscriptionSettings.stripeConfig.plans.monthly.dollarAmount)
-                            type="number"
-                            input=(action "setSubscriptionSettings" "month")
-                        }}
+                        <GhTextInput
+                            @value={{readonly this.subscriptionSettings.stripeConfig.plans.monthly.dollarAmount}}
+                            @type="number"
+                            @input={{action "setSubscriptionSettings" "month"}}
+                        />
                         <span class="gh-input-append">USD/month</span>
                     </div>
-                    {{/gh-form-group}}
+                    </GhFormGroup>
                 </div>
                 <div class="w-100 w-50-ns ml2-ns">
-                    {{#gh-form-group class="description-container"}}
+                    <GhFormGroup @class="description-container">
                     <label class="fw6 f8">Yearly price</label>
                     <div class="flex items-center justify-center mt1 gh-input-group gh-labs-price-label">
-                        {{gh-text-input
-                                value=(readonly this.subscriptionSettings.stripeConfig.plans.yearly.dollarAmount)
-                                type="number"
-                                input=(action "setSubscriptionSettings" "year")
-                            }}
+                        <GhTextInput
+                            @value={{readonly this.subscriptionSettings.stripeConfig.plans.yearly.dollarAmount}}
+                            @type="number"
+                            @input={{action "setSubscriptionSettings" "year"}}
+                        />
                         <span class="gh-input-append">USD/year</span>
                     </div>
-                    {{/gh-form-group}}
+                    </GhFormGroup>
                 </div>
             </div>
             <div class="f8 fw4 midgrey">Currently only USD is supported, more currencies <a href="https://ghost.org/docs/members/" target="_blank" rel="noopener">coming soon</a></div>
@@ -170,62 +170,61 @@
 
         {{#liquid-if this.membersEmailOpen}}
         <div class="flex flex-column w-100 w-50-l flex mt8">
-            {{#gh-form-group}}
-            <label class="fw6 f8">From Address</label>
-            <div class="flex items-center justify-center mt1 gh-input-group">
-                {{gh-text-input
-                    value=(readonly this.subscriptionSettings.fromAddress)
-                    input=(action "setSubscriptionSettings" "fromAddress")
-                    class="w20"
-                }}
-                <span class="gh-input-append"> @{{this.blogDomain}}</span>
-            </div>
-            <div class="f8 fw4 midgrey mt1">Your members will receive system emails from this address</div>
-            {{/gh-form-group}}
+            <GhFormGroup>
+                <label class="fw6 f8">From Address</label>
+                <div class="flex items-center justify-center mt1 gh-input-group">
+                    <GhTextInput
+                        @value={{readonly this.subscriptionSettings.fromAddress}}
+                        @input={{action "setSubscriptionSettings" "fromAddress"}}
+                        @class="w20"
+                    />
+                    <span class="gh-input-append"> @{{this.blogDomain}}</span>
+                </div>
+                <div class="f8 fw4 midgrey mt1">Your members will receive system emails from this address</div>
+            </GhFormGroup>
 
             {{#unless this.hasBulkEmailConfig}}
                 <div class="flex items-center">
-                    {{#gh-form-group class="gh-labs-mailgun-region"}}
-                    <label class="fw6 f8">Mailgun region</label>
-                    <div class="mt1">
-                        <PowerSelect
-                            @options={{this.mailgunRegions}}
-                            @selected={{this.mailgunRegion}}
-                            @onChange={{action "setBulkEmailRegion"}}
-                            @searchEnabled={{false}}
-                            as |region|
-                        >
-                            {{region.flag}} {{region.name}}
-                        </PowerSelect>
-                    </div>
-                    {{/gh-form-group}}
-                    {{#gh-form-group}}
-                    <label class="fw6 f8">Mailgun domain</label>
-                    {{gh-text-input
-                                            value=(readonly this.bulkEmailSettings.domain)
-                                            input=(action "setBulkEmailSettings" "domain")
-                                            class="mt1"
-                                        }}
-                    {{/gh-form-group}}
+                    <GhFormGroup @class="gh-labs-mailgun-region">
+                        <label class="fw6 f8">Mailgun region</label>
+                        <div class="mt1">
+                            <PowerSelect
+                                @options={{this.mailgunRegions}}
+                                @selected={{this.mailgunRegion}}
+                                @onChange={{action "setBulkEmailRegion"}}
+                                @searchEnabled={{false}}
+                                as |region|
+                            >
+                                {{region.flag}} {{region.name}}
+                            </PowerSelect>
+                        </div>
+                    </GhFormGroup>
+                    <GhFormGroup>
+                        <label class="fw6 f8">Mailgun domain</label>
+                        <GhTextInput
+                            @value={{readonly this.bulkEmailSettings.domain}}
+                            @input={{action "setBulkEmailSettings" "domain"}}
+                            @class="mt1"
+                        />
+                    </GhFormGroup>
                 </div>
                 <div class="nt5 mb5">
                     <a href="https://app.mailgun.com/app/sending/domains" target="_blank" class="mt1 fw4 f8">
                         Find your Mailgun region and domain here &raquo;
                     </a>
                 </div>
-                {{#gh-form-group}}
+                <GhFormGroup>
                     <label class="fw6 f8">Mailgun API key</label>
-                    {{gh-text-input
-                        type="password"
-                        value=(readonly this.bulkEmailSettings.apiKey)
-                        input=(action "setBulkEmailSettings" "apiKey")
-                        class="mt1 password"
-                        autocomplete="new-password"
-                    }}
+                    <GhTextInput
+                        @type="password"
+                        @value={{readonly this.bulkEmailSettings.apiKey}}
+                        @input={{action "setBulkEmailSettings" "apiKey"}}
+                        @class="mt1 password" @autocomplete="new-password"
+                    />
                     <a href="https://app.mailgun.com/app/account/security/api_keys" target="_blank" class="mt1 fw4 f8">
                         Find your Mailgun API keys here &raquo;
                     </a>
-                {{/gh-form-group}}
+                </GhFormGroup>
             {{/unless}}
         </div>
         {{/liquid-if}}

--- a/app/templates/components/gh-members-no-members.hbs
+++ b/app/templates/components/gh-members-no-members.hbs
@@ -5,12 +5,12 @@
     </button>
     
     <div class="flex flex-column items-stretch mt8 pt8 pb10 bt b--lightgrey-d1">
-        {{#link-to "member.new" class="gh-btn gh-btn-outline mb3"}}
+        <LinkTo @route="member.new" class="gh-btn gh-btn-outline mb3">
             <span>Manually add a member</span>
-        {{/link-to}}
+        </LinkTo>
         
-        {{#link-to "members.import" class="gh-btn gh-btn-outline"}}
+        <LinkTo @route="members.import" class="gh-btn gh-btn-outline">
             <span>Import members from CSV</span>
-        {{/link-to}}
+        </LinkTo>
     </div>
 </div>

--- a/app/templates/components/gh-mobile-nav-bar.hbs
+++ b/app/templates/components/gh-mobile-nav-bar.hbs
@@ -1,9 +1,9 @@
-{{#link-to "editor.new" "post" data-test-mobile-nav="new-post"}}{{svg-jar "pen"}}New post{{/link-to}}
+<LinkTo @route="editor.new" @model="post" data-test-mobile-nav="new-post">{{svg-jar "pen"}}New post</LinkTo>
 {{#if (eq this.router.currentRouteName "posts")}}
-    {{#link-to "posts" (query-params type=null) classNames="active" data-test-mobile-nav="posts"}}{{svg-jar "content"}}Posts{{/link-to}}
+    <LinkTo @route="posts" @query={{hash type=null}} @classNames="active" data-test-mobile-nav="posts">{{svg-jar "content"}}Posts</LinkTo>
 {{else}}
-    {{#link-to "posts"}}{{svg-jar "content" data-test-mobile-nav="posts"}}Posts{{/link-to}}
+    <LinkTo @route="posts">{{svg-jar "content" data-test-mobile-nav="posts"}}Posts</LinkTo>
 {{/if}}
-{{#link-to "staff" classNames="gh-nav-main-users" data-test-mobile-nav="staff"}}{{svg-jar "account-group"}}Staff{{/link-to}}
+<LinkTo @route="staff" @classNames="gh-nav-main-users" data-test-mobile-nav="staff">{{svg-jar "account-group"}}Staff</LinkTo>
 <div class="gh-mobile-nav-bar-more" {{action "openMobileMenu" target=this.ui data-test-mobile-nav="more"}}>{{svg-jar "icon" class="icon-gh"}}More</div>
 {{yield}}

--- a/app/templates/components/gh-nav-menu.hbs
+++ b/app/templates/components/gh-nav-menu.hbs
@@ -9,9 +9,9 @@
 </header>
 
 {{#if this.showSearchModal}}
-    {{gh-fullscreen-modal "search"
-        close=(action "toggleSearchModal")
-        modifier="action wide"}}
+    <GhFullscreenModal @modal="search"
+        @close={{action "toggleSearchModal"}}
+        @modifier="action wide" />
 {{/if}}
 
 <section class="gh-nav-body">
@@ -19,9 +19,9 @@
         <ul class="gh-nav-list gh-nav-main">
             <li class="relative">
                 <span {{action "transitionToOrRefreshSite" on="click"}}>
-                    {{#link-to "site" data-test-nav="site" current-when=this.isOnSite preventDefault=false}}
+                    <LinkTo @route="site" data-test-nav="site" @current-when={{this.isOnSite}} @preventDefault={{false}}>
                         {{svg-jar "house"}} View site
-                    {{/link-to}}
+                    </LinkTo>
                 </span>
                 <a href="{{this.config.blogUrl}}/" class="gh-secondary-action" title="Open site in new tab" target="_blank">
                     <span>{{svg-jar "expand"}}</span>
@@ -33,42 +33,42 @@
             <li class="gh-nav-list-new relative">
                 {{!-- clicking the Content link whilst on the content screen should reset the filter --}}
                 {{#if (eq this.router.currentRouteName "posts")}}
-                    {{#link-to "posts" (query-params type=null author=null tag=null order=null) classNames="active" data-test-nav="posts"}}{{svg-jar "content"}}Posts{{/link-to}}
+                    <LinkTo @route="posts" @query={{hash type=null author=null tag=null order=null}} @classNames="active" data-test-nav="posts">{{svg-jar "content"}}Posts</LinkTo>
                 {{else}}
-                    {{#link-to "posts" data-test-nav="posts"}}{{svg-jar "content"}}Posts{{/link-to}}
+                    <LinkTo @route="posts" data-test-nav="posts">{{svg-jar "content"}}Posts</LinkTo>
                 {{/if}}
-                {{#link-to "editor.new" "post" classNames="gh-secondary-action gh-nav-new-post" alt="New story" data-test-nav="new-story"}}<span>{{svg-jar "add-stroke"}}</span>{{/link-to}}
+                <LinkTo @route="editor.new" @model="post" @classNames="gh-secondary-action gh-nav-new-post" @alt="New story" data-test-nav="new-story"><span>{{svg-jar "add-stroke"}}</span></LinkTo>
             </li>
             <li>
                 {{!-- clicking the Content link whilst on the content screen should reset the filter --}}
                 {{#if (eq this.router.currentRouteName "pages")}}
-                    {{#link-to "pages" (query-params type=null author=null tag=null order=null) classNames="active" data-test-nav="pages"}}{{svg-jar "page"}}Pages{{/link-to}}
+                    <LinkTo @route="pages" @query={{hash type=null author=null tag=null order=null}} @classNames="active" data-test-nav="pages">{{svg-jar "page"}}Pages</LinkTo>
                 {{else}}
-                    {{#link-to "pages" data-test-nav="pages"}}{{svg-jar "page"}}Pages{{/link-to}}
+                    <LinkTo @route="pages" data-test-nav="pages">{{svg-jar "page"}}Pages</LinkTo>
                 {{/if}}
             </li>
             {{#if (gh-user-can-admin this.session.user)}}
-                <li>{{#link-to "tags" data-test-nav="tags"}}{{svg-jar "tag"}}Tags{{/link-to}}</li>
+                <li><LinkTo @route="tags" data-test-nav="tags">{{svg-jar "tag"}}Tags</LinkTo></li>
             {{/if}}
             {{#if (and this.feature.members (gh-user-can-admin this.session.user))}}
                 <li>
-                    {{#link-to "members" current-when="members member" data-test-nav="members"}}{{svg-jar "members"}}Members{{/link-to}}
+                    <LinkTo @route="members" @current-when="members member" data-test-nav="members">{{svg-jar "members"}}Members</LinkTo>
                 </li>
             {{/if}}
-            <li>{{#link-to "staff" data-test-nav="staff"}}{{svg-jar "staff"}}Staff{{/link-to}}</li>
+            <li><LinkTo @route="staff" data-test-nav="staff">{{svg-jar "staff"}}Staff</LinkTo></li>
         </ul>
         {{#if (gh-user-can-admin this.session.user)}}
             <ul class="gh-nav-list gh-nav-settings">
                 <li class="gh-nav-list-h">Settings</li>
-                <li>{{#link-to "settings.general" data-test-nav="settings"}}{{svg-jar "settings"}}General{{/link-to}}</li>
-                <li>{{#link-to "settings.design" data-test-nav="design"}}{{svg-jar "paintbrush"}}Design{{/link-to}}</li>
-                <li>{{#link-to "settings.code-injection" data-test-nav="code-injection"}}{{svg-jar "brackets"}}Code injection{{/link-to}}</li>
-                <li>{{#link-to "settings.integrations" current-when=this.isIntegrationRoute data-test-nav="integrations"}}{{svg-jar "modules"}}Integrations{{/link-to}}</li>
+                <li><LinkTo @route="settings.general" data-test-nav="settings">{{svg-jar "settings"}}General</LinkTo></li>
+                <li><LinkTo @route="settings.design" data-test-nav="design">{{svg-jar "paintbrush"}}Design</LinkTo></li>
+                <li><LinkTo @route="settings.code-injection" data-test-nav="code-injection">{{svg-jar "brackets"}}Code injection</LinkTo></li>
+                <li><LinkTo @route="settings.integrations" @current-when={{this.isIntegrationRoute}} data-test-nav="integrations">{{svg-jar "modules"}}Integrations</LinkTo></li>
                 <li class="relative">
                     <button class="gh-secondary-action" title="Toggle Night shift" {{action (toggle "nightShift" this.feature)}}>
                         <span>{{svg-jar "nightshift"}}</span>
                     </button>
-                    {{#link-to "settings.labs" data-test-nav="labs"}}{{svg-jar "labs"}}Labs{{/link-to}}
+                    <LinkTo @route="settings.labs" data-test-nav="labs">{{svg-jar "labs"}}Labs</LinkTo>
                 </li>
             </ul>
         {{/if}}
@@ -109,9 +109,9 @@
             <dropdown.Content class="gh-nav-menu-dropdown">
                 <ul class="dropdown-menu dropdown-triangle-top" role="menu" {{action dropdown.actions.close on="click" preventDefault=false}}>
                     <li role="presentation">
-                        {{#link-to "about" classNames="dropdown-item" role="menuitem" tabindex="-1" data-test-nav="about"}}
+                        <LinkTo @route="about" @classNames="dropdown-item" @role="menuitem" @tabindex="-1" data-test-nav="about">
                             {{svg-jar "store"}} About Ghost
-                        {{/link-to}}
+                        </LinkTo>
                     </li>
                     <li role="presentation">
                         <button class="dropdown-item" role="menuitem" tabindex="-1" {{on "click" this.whatsNew.showModal}}>
@@ -123,9 +123,9 @@
                     </li>
                     <li class="divider"></li>
                     <li role="presentation">
-                        {{#link-to "staff.user" this.session.user.slug classNames="dropdown-item" role="menuitem" tabindex="-1" data-test-nav="user-profile"}}
+                        <LinkTo @route="staff.user" @model={{this.session.user.slug}} @classNames="dropdown-item" @role="menuitem" @tabindex="-1" data-test-nav="user-profile">
                             {{svg-jar "user-circle"}} Your Profile
-                        {{/link-to}}
+                        </LinkTo>
                     </li>
                     <li role="presentation">
                         <a class="dropdown-item" role="menuitem" tabindex="-1" href="https://ghost.org/docs/" target="_blank">
@@ -162,9 +162,9 @@
                     {{/if}}
 
                     <li role="presentation">
-                        {{#link-to "signout" classNames="dropdown-item user-menu-signout" role="menuitem" tabindex="-1"}}
+                        <LinkTo @route="signout" @classNames="dropdown-item user-menu-signout" @role="menuitem" @tabindex="-1">
                             {{svg-jar "signout"}} Sign Out
-                        {{/link-to}}
+                        </LinkTo>
                     </li>
                 </ul>
             </dropdown.Content>
@@ -172,9 +172,9 @@
     </div>
 </section>
 
-{{gh-tour-item "getting-started"
-    target=".gh-nav-main"
-    throbberAttachment="middle right"
-    popoverTriangleClass="left-top"
-    throbberOffset="0px 0px"
-}}
+<GhTourItem @throbberId="getting-started"
+    @target=".gh-nav-main"
+    @throbberAttachment="middle right"
+    @popoverTriangleClass="left-top"
+    @throbberOffset="0px 0px"
+/>

--- a/app/templates/components/gh-navitem.hbs
+++ b/app/templates/components/gh-navitem.hbs
@@ -6,29 +6,41 @@
 {{/unless}}
 
 <div class="gh-blognav-line">
-    {{#gh-validation-status-container tagName="span" class="gh-blognav-label" errors=this.navItem.errors property="label" hasValidated=this.navItem.hasValidated}}
-        {{gh-trim-focus-input
-            shouldFocus=this.navItem.last
-            placeholder="Label"
-            value=(readonly this.navItem.label)
-            input=(action (mut this.navItem.label) value="target.value")
-            keyPress=(action "clearLabelErrors")
-            focus-out=(action "updateLabel" this.navItem.label)
-            data-test-input="label"
-        }}
-        <GhErrorMessage @errors={{this.navItem.errors}} @property="label" data-test-error="label" />
-    {{/gh-validation-status-container}}
-    {{#gh-validation-status-container tagName="span" class="gh-blognav-url" errors=this.navItem.errors property="url" hasValidated=this.navItem.hasValidated}}
-        {{gh-navitem-url-input
-            baseUrl=this.baseUrl
-            isNew=this.navItem.isNew
-            url=(readonly this.navItem.url)
-            update=(action "updateUrl")
-            clearErrors=(action "clearUrlErrors")
-            data-test-input="url"
-        }}
-        <GhErrorMessage @errors={{this.navItem.errors}} @property="url" data-test-error="url" />
-    {{/gh-validation-status-container}}
+    <GhValidationStatusContainer
+        @tagName="span"
+        @class="gh-blognav-label"
+        @errors={{this.navItem.errors}}
+        @property="label"
+        @hasValidated={{this.navItem.hasValidated}}
+    >
+        <GhTrimFocusInput
+            @shouldFocus={{this.navItem.last}}
+            @placeholder="Label"
+            @value={{readonly this.navItem.label}}
+            @input={{action (mut this.navItem.label) value="target.value"}}
+            @keyPress={{action "clearLabelErrors"}}
+            @focus-out={{action "updateLabel" this.navItem.label}} data-test-input="label" />
+        <GhErrorMessage
+            @errors={{this.navItem.errors}}
+            @property="label" data-test-error="label" />
+    </GhValidationStatusContainer>
+    <GhValidationStatusContainer
+        @tagName="span"
+        @class="gh-blognav-url"
+        @errors={{this.navItem.errors}}
+        @property="url"
+        @hasValidated={{this.navItem.hasValidated}}
+    >
+        <GhNavitemUrlInput
+            @baseUrl={{this.baseUrl}}
+            @isNew={{this.navItem.isNew}}
+            @url={{readonly this.navItem.url}}
+            @update={{action "updateUrl"}}
+            @clearErrors={{action "clearUrlErrors"}} data-test-input="url" />
+        <GhErrorMessage
+            @errors={{this.navItem.errors}}
+            @property="url" data-test-error="url" />
+    </GhValidationStatusContainer>
 </div>
 
 {{#if this.navItem.isNew}}

--- a/app/templates/components/gh-notifications.hbs
+++ b/app/templates/components/gh-notifications.hbs
@@ -1,3 +1,3 @@
 {{#each this.messages as |message|}}
-    {{gh-notification message=message}}
+    <GhNotification @message={{message}} />
 {{/each}}

--- a/app/templates/components/gh-post-settings-menu.hbs
+++ b/app/templates/components/gh-post-settings-menu.hbs
@@ -8,13 +8,13 @@
                 </button>
             </div>
             <div class="settings-menu-content">
-                {{gh-image-uploader-with-preview
-                    image=this.post.featureImage
-                    text=(concat "Upload " this.post.displayName " image")
-                    allowUnsplash=true
-                    update=(action "setCoverImage")
-                    remove=(action "clearCoverImage")
-                }}
+                <GhImageUploaderWithPreview
+                    @image={{this.post.featureImage}}
+                    @text={{concat "Upload " this.post.displayName " image"}}
+                    @allowUnsplash={{true}}
+                    @update={{action "setCoverImage"}}
+                    @remove={{action "clearCoverImage"}}
+                />
                 <form>
                 <div class="form-group">
                     <label for="url">{{capitalize this.post.displayName}} URL</label>
@@ -33,16 +33,16 @@
 
                     <div class="gh-input-icon gh-icon-link">
                         {{svg-jar "link"}}
-                        {{gh-text-input
-                            class="post-setting-slug"
-                            id="url"
-                            name="post-setting-slug"
-                            value=(readonly this.slugValue)
-                            input=(action (mut this.slugValue) value="target.value")
-                            focus-out=(action "updateSlug" this.slugValue)
-                            stopEnterKeyDownPropagation=true}}
+                        <GhTextInput
+                            @class="post-setting-slug"
+                            @id="url"
+                            @name="post-setting-slug"
+                            @value={{readonly this.slugValue}}
+                            @input={{action (mut this.slugValue) value="target.value"}}
+                            @focus-out={{action "updateSlug" this.slugValue}}
+                            @stopEnterKeyDownPropagation={{true}} />
                     </div>
-                    {{gh-url-preview slug=this.slugValue tagName="p" classNames="description"}}
+                    <GhUrlPreview @slug={{this.slugValue}} @tagName="p" @classNames="description" />
                 </div>
 
                 <div class="form-group">
@@ -51,18 +51,18 @@
                     {{else}}
                         <label>Scheduled date</label>
                     {{/if}}
-                    {{gh-date-time-picker
-                        date=this.post.publishedAtBlogDate
-                        time=this.post.publishedAtBlogTime
-                        setDate=(action "setPublishedAtBlogDate")
-                        setTime=(action "setPublishedAtBlogTime")
-                        errors=this.post.errors
-                        dateErrorProperty="publishedAtBlogDate"
-                        timeErrorProperty="publishedAtBlogTime"
-                        maxDate='now'
-                        disabled=this.post.isScheduled
-                        isActive=(and this.showSettingsMenu (not this.isViewingSubview))
-                    }}
+                    <GhDateTimePicker
+                        @date={{this.post.publishedAtBlogDate}}
+                        @time={{this.post.publishedAtBlogTime}}
+                        @setDate={{action "setPublishedAtBlogDate"}}
+                        @setTime={{action "setPublishedAtBlogTime"}}
+                        @errors={{this.post.errors}}
+                        @dateErrorProperty="publishedAtBlogDate"
+                        @timeErrorProperty="publishedAtBlogTime"
+                        @maxDate="now"
+                        @disabled={{this.post.isScheduled}}
+                        @isActive={{and this.showSettingsMenu (not this.isViewingSubview)}}
+                    />
                     {{#unless (or this.post.isDraft this.post.isPublished this.post.pastScheduledTime)}}
                     <p>Use the publish menu to re-schedule</p>
                     {{/unless}}
@@ -71,7 +71,7 @@
                 {{#unless this.session.user.isContributor}}
                 <div class="form-group">
                     <label for="tag-input">Tags</label>
-                    {{gh-psm-tags-input post=this.post triggerId="tag-input"}}
+                    <GhPsmTagsInput @post={{this.post}} @triggerId="tag-input" />
                 </div>
                 {{/unless}}
 
@@ -80,32 +80,33 @@
                     {{#if this.showVisibilityInput}}
                         <div class="form-group">
                             <label for="visibility-input">Post access</label>
-                            {{gh-psm-visibility-input post=this.post triggerId="visibility-input"}}
+                            <GhPsmVisibilityInput @post={{this.post}} @triggerId="visibility-input" />
                         </div>
                     {{/if}}
                 {{/if}}
 
 
-                {{#gh-form-group errors=this.post.errors hasValidated=this.post.hasValidated property="customExcerpt"}}
+                <GhFormGroup @errors={{this.post.errors}} @hasValidated={{this.post.hasValidated}} @property="customExcerpt">
                     <label for="custom-excerpt">Excerpt</label>
-                    {{gh-textarea
-                        class="post-setting-custom-excerpt"
-                        id="custom-excerpt"
-                        name="post-setting-custom-excerpt"
-                        value=(readonly this.customExcerptScratch)
-                        input=(action (mut this.customExcerptScratch) value="target.value")
-                        focus-out=(action "setCustomExcerpt" this.customExcerptScratch)
-                        stopEnterKeyDownPropagation="true"
-                        data-test-field="custom-excerpt"}}
+                    <GhTextarea
+                        @class="post-setting-custom-excerpt"
+                        @id="custom-excerpt"
+                        @name="post-setting-custom-excerpt"
+                        @value={{readonly this.customExcerptScratch}}
+                        @input={{action (mut this.customExcerptScratch) value="target.value"}}
+                        @focus-out={{action "setCustomExcerpt" this.customExcerptScratch}}
+                        @stopEnterKeyDownPropagation="true"
+                        data-test-field="custom-excerpt"
+                    />
                     <GhErrorMessage @errors={{this.post.errors}} @property="customExcerpt" data-test-error="custom-excerpt" />
-                {{/gh-form-group}}
+                </GhFormGroup>
 
                 {{#unless this.session.user.isAuthorOrContributor}}
-                    {{#gh-form-group class="for-select" errors=this.post.errors hasValidated=this.post.hasValidated property="authors" data-test-input="authors"}}
+                    <GhFormGroup @class="for-select" @errors={{this.post.errors}} @hasValidated={{this.post.hasValidated}} @property="authors" data-test-input="authors">
                         <label for="author-list">Authors</label>
-                        {{gh-psm-authors-input selectedAuthors=this.post.authors updateAuthors=(action "changeAuthors") triggerId="author-list"}}
+                        <GhPsmAuthorsInput @selectedAuthors={{this.post.authors}} @updateAuthors={{action "changeAuthors"}} @triggerId="author-list" />
                         <GhErrorMessage @errors={{this.post.errors}} @property="authors" data-test-error="authors" />
-                    {{/gh-form-group}}
+                    </GhFormGroup>
                 {{/unless}}
 
                 <ul class="nav-list nav-list-block">
@@ -164,9 +165,9 @@
                 </div>
                 {{/unless}}
 
-                {{gh-psm-template-select
-                    post=this.post
-                    onTemplateSelect=(action (mut this.post.customTemplate))}}
+                <GhPsmTemplateSelect
+                    @post={{this.post}}
+                    @onTemplateSelect={{action (mut this.post.customTemplate)}} />
 
                 {{#unless this.post.isNew}}
                     <button type="button" class="gh-btn gh-btn-hover-red gh-btn-icon settings-menu-delete-button" {{action "deletePost"}}><span>{{svg-jar "trash"}} Delete {{this.post.displayName}}</span></button>
@@ -188,48 +189,48 @@
 
                         <div class="settings-menu-content">
                             <form {{action "discardEnter" on="submit"}}>
-                                {{#gh-form-group errors=this.post.errors hasValidated=this.post.hasValidated property="metaTitle"}}
+                                <GhFormGroup @errors={{this.post.errors}} @hasValidated={{this.post.hasValidated}} @property="metaTitle">
                                     <label for="meta-title">Meta title</label>
-                                    {{gh-text-input
-                                        class="post-setting-meta-title"
-                                        id="meta-title"
-                                        name="post-setting-meta-title"
-                                        value=(readonly this.metaTitleScratch)
-                                        input=(action (mut this.metaTitleScratch) value="target.value")
-                                        focus-out=(action "setMetaTitle" this.metaTitleScratch)
-                                        stopEnterKeyDownPropagation=true
-                                        data-test-field="meta-title"}}
+                                    <GhTextInput
+                                        @class="post-setting-meta-title"
+                                        @id="meta-title"
+                                        @name="post-setting-meta-title"
+                                        @value={{readonly this.metaTitleScratch}}
+                                        @input={{action (mut this.metaTitleScratch) value="target.value"}}
+                                        @focus-out={{action "setMetaTitle" this.metaTitleScratch}}
+                                        @stopEnterKeyDownPropagation={{true}}
+                                        data-test-field="meta-title" />
                                     <p>Recommended: <b>70</b> characters. You’ve used {{gh-count-down-characters this.metaTitleScratch 70}}</p>
                                     <GhErrorMessage @errors={{this.post.errors}} @property="meta-title" />
-                                {{/gh-form-group}}
+                                </GhFormGroup>
 
-                                {{#gh-form-group errors=this.post.errors hasValidated=this.post.hasValidated property="metaDescription"}}
+                                <GhFormGroup @errors={{this.post.errors}} @hasValidated={{this.post.hasValidated}} @property="metaDescription">
                                     <label for="meta-description">Meta description</label>
-                                    {{gh-textarea
-                                        class="post-setting-meta-description"
-                                        id="meta-description"
-                                        name="post-setting-meta-description"
-                                        value=(readonly this.metaDescriptionScratch)
-                                        input=(action (mut this.metaDescriptionScratch) value="target.value")
-                                        focus-out=(action "setMetaDescription" this.metaDescriptionScratch)
-                                        stopEnterKeyDownPropagation="true"
-                                        data-test-field="meta-description"}}
+                                    <GhTextarea
+                                        @class="post-setting-meta-description"
+                                        @id="meta-description"
+                                        @name="post-setting-meta-description"
+                                        @value={{readonly this.metaDescriptionScratch}}
+                                        @input={{action (mut this.metaDescriptionScratch) value="target.value"}}
+                                        @focus-out={{action "setMetaDescription" this.metaDescriptionScratch}}
+                                        @stopEnterKeyDownPropagation="true"
+                                        data-test-field="meta-description" />
                                     <p>Recommended: <b>156</b> characters. You’ve used {{gh-count-down-characters this.metaDescriptionScratch 156}}</p>
                                     <GhErrorMessage @errors={{this.post.errors}} @property="meta-description" />
-                                {{/gh-form-group}}
+                                </GhFormGroup>
 
-                                {{#gh-form-group errors=this.post.errors hasValidated=this.post.hasValidated property="canonicalUrl"}}
+                                <GhFormGroup @errors={{this.post.errors}} @hasValidated={{this.post.hasValidated}} @property="canonicalUrl">
                                     <label for="canonicalUrl">Canonical URL</label>
-                                    {{gh-text-input
-                                        class="post-setting-canonicalUrl"
-                                        name="post-setting-canonicalUrl"
-                                        value=(readonly this.canonicalUrlScratch)
-                                        input=(action (mut this.canonicalUrlScratch) value="target.value")
-                                        focus-out=(action "setCanonicalUrl" this.canonicalUrlScratch)
-                                        stopEnterKeyDownPropagation="true"
-                                        data-test-field="canonicalUrl"}}
+                                    <GhTextInput
+                                        @class="post-setting-canonicalUrl"
+                                        @name="post-setting-canonicalUrl"
+                                        @value={{readonly this.canonicalUrlScratch}}
+                                        @input={{action (mut this.canonicalUrlScratch) value="target.value"}}
+                                        @focus-out={{action "setCanonicalUrl" this.canonicalUrlScratch}}
+                                        @stopEnterKeyDownPropagation="true"
+                                        data-test-field="canonicalUrl" />
                                     <GhErrorMessage @errors={{this.post.errors}} @property="canonicalUrl" />
-                                {{/gh-form-group}}
+                                </GhFormGroup>
 
                                 <div class="form-group">
                                     <label>Search Engine Result Preview</label>
@@ -253,42 +254,42 @@
                         <div class="settings-menu-content">
 
                             <form {{action "discardEnter" on="submit"}}>
-                                {{gh-image-uploader-with-preview
-                                    image=this.post.twitterImage
-                                    text="Add Twitter image"
-                                    allowUnsplash=true
-                                    update=(action "setTwitterImage")
-                                    remove=(action "clearTwitterImage")
-                                }}
-                                {{#gh-form-group errors=this.post.errors hasValidated=this.post.hasValidated property="twitterTitle"}}
+                                <GhImageUploaderWithPreview
+                                    @image={{this.post.twitterImage}}
+                                    @text="Add Twitter image"
+                                    @allowUnsplash={{true}}
+                                    @update={{action "setTwitterImage"}}
+                                    @remove={{action "clearTwitterImage"}}
+                                />
+                                <GhFormGroup @errors={{this.post.errors}} @hasValidated={{this.post.hasValidated}} @property="twitterTitle">
                                     <label for="twitter-title">Twitter title</label>
-                                    {{gh-text-input
-                                        class="post-setting-twitter-title"
-                                        id="twitter-title"
-                                        name="post-setting-twitter-title"
-                                        placeholder=(truncate this.twitterTitle 40)
-                                        value=(readonly this.twitterTitleScratch)
-                                        input=(action (mut this.twitterTitleScratch) value="target.value")
-                                        focus-out=(action "setTwitterTitle" this.twitterTitleScratch)
-                                        stopEnterKeyDownPropagation=true
-                                        data-test-field="twitter-title"}}
+                                    <GhTextInput
+                                        @class="post-setting-twitter-title"
+                                        @id="twitter-title"
+                                        @name="post-setting-twitter-title"
+                                        @placeholder={{truncate this.twitterTitle 40}}
+                                        @value={{readonly this.twitterTitleScratch}}
+                                        @input={{action (mut this.twitterTitleScratch) value="target.value"}}
+                                        @focus-out={{action "setTwitterTitle" this.twitterTitleScratch}}
+                                        @stopEnterKeyDownPropagation={{true}}
+                                        data-test-field="twitter-title" />
                                     <GhErrorMessage @errors={{this.post.errors}} @property="twitterTitle" data-test-error="twitter-title" />
-                                {{/gh-form-group}}
+                                </GhFormGroup>
 
-                                {{#gh-form-group errors=this.post.errors hasValidated=this.post.hasValidated property="twitterDescription"}}
+                                <GhFormGroup @errors={{this.post.errors}} @hasValidated={{this.post.hasValidated}} @property="twitterDescription">
                                     <label for="twitter-description">Twitter description</label>
-                                    {{gh-textarea
-                                        class="post-setting-twitter-description"
-                                        id="twitter-description"
-                                        name="post-setting-twitter-description"
-                                        placeholder=(truncate this.twitterDescription 155)
-                                        stopEnterKeyDownPropagation="true"
-                                        value=(readonly this.twitterDescriptionScratch)
-                                        input=(action (mut this.twitterDescriptionScratch) value="target.value")
-                                        focus-out=(action "setTwitterDescription" this.twitterDescriptionScratch)
-                                        data-test-field="twitter-description"}}
+                                    <GhTextarea
+                                        @class="post-setting-twitter-description"
+                                        @id="twitter-description"
+                                        @name="post-setting-twitter-description"
+                                        @placeholder={{truncate this.twitterDescription 155}}
+                                        @stopEnterKeyDownPropagation="true"
+                                        @value={{readonly this.twitterDescriptionScratch}}
+                                        @input={{action (mut this.twitterDescriptionScratch) value="target.value"}}
+                                        @focus-out={{action "setTwitterDescription" this.twitterDescriptionScratch}}
+                                        data-test-field="twitter-description" />
                                     <GhErrorMessage @errors={{this.post.errors}} @property="twitterDescription" data-test-error="twitter-description" />
-                                {{/gh-form-group}}
+                                </GhFormGroup>
 
                                 <div class="form-group">
                                     <label>Preview</label>
@@ -332,42 +333,41 @@
 
                         <div class="settings-menu-content">
                             <form {{action "discardEnter" on="submit"}}>
-                                {{gh-image-uploader-with-preview
-                                    image=this.post.ogImage
-                                    text="Add Facebook image"
-                                    allowUnsplash=true
-                                    update=(action "setOgImage")
-                                    remove=(action "clearOgImage")
-                                }}
-                                {{#gh-form-group errors=this.post.errors hasValidated=this.post.hasValidated property="ogTitle"}}
+                                <GhImageUploaderWithPreview
+                                    @image={{this.post.ogImage}}
+                                    @text="Add Facebook image"
+                                    @allowUnsplash={{true}}
+                                    @update={{action "setOgImage"}}
+                                    @remove={{action "clearOgImage"}}
+                                />
+                                <GhFormGroup @errors={{this.post.errors}} @hasValidated={{this.post.hasValidated}} @property="ogTitle">
                                     <label for="og-title">Facebook title</label>
-                                    {{gh-text-input
-                                        class="post-setting-og-title"
-                                        id="og-title"
-                                        name="post-setting-og-title"
-                                        placeholder=(truncate this.facebookTitle 40)
-                                        value=(readonly this.ogTitleScratch)
-                                        input=(action (mut this.ogTitleScratch) value="target.value")
-                                        focus-out=(action "setOgTitle" this.ogTitleScratch)
-                                        stopEnterKeyDownPropagation=true
-                                        data-test-field="og-title"}}
+                                    <GhTextInput
+                                        @class="post-setting-og-title"
+                                        @id="og-title"
+                                        @name="post-setting-og-title"
+                                        @placeholder={{truncate this.facebookTitle 40}}
+                                        @value={{readonly this.ogTitleScratch}}
+                                        @input={{action (mut this.ogTitleScratch) value="target.value"}}
+                                        @focus-out={{action "setOgTitle" this.ogTitleScratch}}
+                                        @stopEnterKeyDownPropagation={{true}}
+                                        data-test-field="og-title" />
                                     <GhErrorMessage @errors={{this.post.errors}} @property="ogTitle" data-test-error="og-title" />
-                                {{/gh-form-group}}
+                                </GhFormGroup>
 
-                                {{#gh-form-group errors=this.post.errors hasValidated=this.post.hasValidated property="ogDescription"}}
+                                <GhFormGroup @errors={{this.post.errors}} @hasValidated={{this.post.hasValidated}} @property="ogDescription">
                                     <label for="og-description">Facebook description</label>
-                                    {{gh-textarea
-                                        class="post-setting-og-description"
-                                        id="og-description"
-                                        name="post-setting-og-description"
-                                        placeholder=(truncate this.facebookDescription 160)
-                                        value=(readonly this.ogDescriptionScratch)
-                                        input=(action (mut this.ogDescriptionScratch) value="target.value")
-                                        focus-out=(action "setOgDescription" this.ogDescriptionScratch)
-                                        stopEnterKeyDownPropagation="true"
-                                        data-test-field="og-description"}}
+                                    <GhTextarea
+                                        @class="post-setting-og-description"
+                                        @id="og-description" @name="post-setting-og-description"
+                                        @placeholder={{truncate this.facebookDescription 160}}
+                                        @value={{readonly this.ogDescriptionScratch}}
+                                        @input={{action (mut this.ogDescriptionScratch) value="target.value"}}
+                                        @focus-out={{action "setOgDescription" this.ogDescriptionScratch}}
+                                        @stopEnterKeyDownPropagation="true"
+                                        data-test-field="og-description" />
                                     <GhErrorMessage @errors={{this.post.errors}} @property="ogDescription" data-test-error="og-description" />
-                                {{/gh-form-group}}
+                                </GhFormGroup>
 
                                 <div class="form-group">
                                     <label>Preview</label>
@@ -402,31 +402,31 @@
 
                         <div class="settings-menu-content settings-menu-content-codeinjection">
                             <form {{action "discardEnter" on="submit"}}>
-                                {{#gh-form-group errors=this.post.errors hasValidated=this.post.hasValidated property="codeinjectionHead"}}
+                                <GhFormGroup @errors={{this.post.errors}} @hasValidated={{this.post.hasValidated}} @property="codeinjectionHead">
                                     <label for="codeinjection-head">{{capitalize this.post.displayName}} header <code>\{{ghost_head}}</code></label>
-                                    {{gh-cm-editor this.codeinjectionHeadScratch
-                                        id="post-setting-codeinjection-head"
-                                        class="post-setting-codeinjection"
-                                        name="post-setting-codeinjection-head"
-                                        focusOut=(action "setHeaderInjection" this.codeinjectionHeadScratch)
-                                        stopEnterKeyDownPropagation="true"
-                                        update=(action (mut this.codeinjectionHeadScratch))
-                                        data-test-field="codeinjection-head"}}
+                                    <GhCmEditor @value={{this.codeinjectionHeadScratch}}
+                                        @id="post-setting-codeinjection-head"
+                                        @class="post-setting-codeinjection"
+                                        @name="post-setting-codeinjection-head"
+                                        @focusOut={{action "setHeaderInjection" this.codeinjectionHeadScratch}}
+                                        @stopEnterKeyDownPropagation="true"
+                                        @update={{action (mut this.codeinjectionHeadScratch)}}
+                                        data-test-field="codeinjection-head" />
                                     <GhErrorMessage @errors={{this.post.errors}} @property="codeinjectionHead" data-test-error="codeinjection-head" />
-                                {{/gh-form-group}}
+                                </GhFormGroup>
 
-                                {{#gh-form-group errors=this.post.errors hasValidated=this.post.hasValidated property="codeinjectionFoot"}}
+                                <GhFormGroup @errors={{this.post.errors}} @hasValidated={{this.post.hasValidated}} @property="codeinjectionFoot">
                                     <label for="codeinjection-foot">{{capitalize this.post.displayName}} footer <code>\{{ghost_foot}}</code></label>
-                                    {{gh-cm-editor this.codeinjectionFootScratch
-                                        id="post-setting-codeinjection-foot"
-                                        class="post-setting-codeinjection"
-                                        name="post-setting-codeinjection-foot"
-                                        focusOut=(action "setFooterInjection" this.codeinjectionFootScratch)
-                                        stopEnterKeyDownPropagation="true"
-                                        update=(action (mut this.codeinjectionFootScratch))
-                                        data-test-field="codeinjection-foot"}}
+                                    <GhCmEditor @value={{this.codeinjectionFootScratch}}
+                                        @id="post-setting-codeinjection-foot"
+                                        @class="post-setting-codeinjection"
+                                        @name="post-setting-codeinjection-foot"
+                                        @focusOut={{action "setFooterInjection" this.codeinjectionFootScratch}}
+                                        @stopEnterKeyDownPropagation="true"
+                                        @update={{action (mut this.codeinjectionFootScratch)}}
+                                        data-test-field="codeinjection-foot" />
                                     <GhErrorMessage @errors={{this.post.errors}} @property="codeinjectionFoot" data-test-error="codeinjection-foot" />
-                                {{/gh-form-group}}
+                                </GhFormGroup>
                             </form>
                         </div>
                     {{/if}}
@@ -443,11 +443,11 @@
 --}}
 {{#if this._showThrobbers}}
     {{#unless this.session.user.isAuthorOrContributor}}
-        {{gh-tour-item "featured-post"
-            target="label[for='featured'] p"
-            throbberAttachment="middle middle"
-            throbberOffset="0px -20px"
-            popoverTriangleClass="bottom-right"
-        }}
+        <GhTourItem @throbberId="featured-post"
+            @target="label[for='featured'] p"
+            @throbberAttachment="middle middle"
+            @throbberOffset="0px -20px"
+            @popoverTriangleClass="bottom-right"
+        />
     {{/unless}}
 {{/if}}

--- a/app/templates/components/gh-post-settings-menu/email.hbs
+++ b/app/templates/components/gh-post-settings-menu/email.hbs
@@ -91,26 +91,26 @@
         {{#if this.mailgunError}}
             <p class="gh-box gh-box-warning settings-menu-mailgun-warning">
                 {{svg-jar "info" class="w5 h5 fill-yellow nl1"}}
-                You need to configure Mailgun in {{#link-to "settings.labs" data-test-nav="labs"}}Labs → Members settings{{/link-to}} to enable email newsletters.
+                You need to configure Mailgun in <LinkTo @route="settings.labs" data-test-nav="labs">Labs → Members settings</LinkTo> to enable email newsletters.
             </p>
         {{/if}}
 
         <form {{action "discardEnter" on="submit"}}>
-            {{#gh-form-group errors=this.post.errors hasValidated=this.post.hasValidated property="emailSubject"}}
+            <GhFormGroup @errors={{this.post.errors}} @hasValidated={{this.post.hasValidated}} @property="emailSubject">
                 <label for="og-title">Subject</label>
-                {{gh-text-input
-                    class="post-setting-email-subject"
-                    id="email-subject"
-                    name="post-setting-email-subject"
-                    placeholder=(truncate this.emailSubject 40)
-                    value=(readonly this.emailSubjectScratch)
-                    input=(action (mut this.emailSubjectScratch) value="target.value")
-                    focus-out=(action "setEmailSubject" this.emailSubjectScratch)
-                    stopEnterKeyDownPropagation=true
-                    disabled=this.mailgunError
-                    data-test-field="email-subject"}}
+                <GhTextInput
+                    @class="post-setting-email-subject"
+                    @id="email-subject"
+                    @name="post-setting-email-subject"
+                    @placeholder={{truncate this.emailSubject 40}}
+                    @value={{readonly this.emailSubjectScratch}}
+                    @input={{action (mut this.emailSubjectScratch) value="target.value"}}
+                    @focus-out={{action "setEmailSubject" this.emailSubjectScratch}}
+                    @stopEnterKeyDownPropagation={{true}}
+                    @disabled={{this.mailgunError}}
+                    data-test-field="email-subject" />
                 <GhErrorMessage @errors={{this.post.errors}} @property="emailSubject" data-test-error="email-subject" />
-            {{/gh-form-group}}
+            </GhFormGroup>
 
             <div class="form-group">
                 <div class="flex">
@@ -123,28 +123,28 @@
                 </div>
 
                 <div class="{{if this.mailgunError "disabled"}}">
-                    {{gh-text-input
-                        class="post-setting-email-test"
-                        id="email-test"
-                        name="post-setting-email-test"
-                        placeholder="noreply@example.com"
-                        value=this.testEmailAddress
-                        stopEnterKeyDownPropagation=true
-                        disabled=this.mailgunError
-                        data-test-field="email-test"}}
+                    <GhTextInput
+                        @class="post-setting-email-test"
+                        @id="email-test"
+                        @name="post-setting-email-test"
+                        @placeholder="noreply@example.com"
+                        @value={{this.testEmailAddress}}
+                        @stopEnterKeyDownPropagation={{true}}
+                        @disabled={{this.mailgunError}}
+                        data-test-field="email-test" />
 
                     {{#if this.sendTestEmailError}}
                         <div class="error"><p class="response">{{this.sendTestEmailError}}</p></div>
                     {{/if}}
 
-                    {{gh-task-button "Send test email"
-                        task=this.sendTestEmail
-                        successText="Email sent"
-                        runningText="Sending..."
-                        class="gh-btn w-100 mt2 gh-btn-icon"
-                        disabled=this.mailgunError
-                        data-test-send-test-mail=true
-                    }}
+                    <GhTaskButton @buttonText="Send test email"
+                        @task={{this.sendTestEmail}}
+                        @successText="Email sent"
+                        @runningText="Sending..."
+                        @class="gh-btn w-100 mt2 gh-btn-icon"
+                        @disabled={{this.mailgunError}}
+                        data-test-send-test-mail="true"
+                    />
                 </div>
             </div>
         </form>

--- a/app/templates/components/gh-posts-list-item.hbs
+++ b/app/templates/components/gh-posts-list-item.hbs
@@ -1,10 +1,10 @@
-{{#link-to "editor.edit" this.post.displayName this.post.id class="permalink gh-list-data gh-post-list-featured" title="Edit this post"}}
+<LinkTo @route="editor.edit" @models={{array this.post.displayName this.post.id}} class="permalink gh-list-data gh-post-list-featured" @title="Edit this post">
     {{#if this.isFeatured}}
         <span data-tooltip="Featured" class="dib pl1 pr1 nr1 nl1">{{svg-jar "star-filled" class="fill-blue w3 h3"}}</span>
     {{/if}}
-{{/link-to}}
+</LinkTo>
 
-{{#link-to "editor.edit" this.post.displayName this.post.id class="permalink gh-list-data gh-post-list-title" title="Edit this post"}}
+<LinkTo @route="editor.edit" @models={{array this.post.displayName this.post.id}} class="permalink gh-list-data gh-post-list-title" @title="Edit this post">
     <h3 class="gh-content-entry-title">
         {{this.post.title}}
     </h3>
@@ -21,9 +21,9 @@
             {{/if}}
         </span>
     </p>
-{{/link-to}}
+</LinkTo>
 
-{{#link-to "editor.edit" this.post.displayName this.post.id class="permalink gh-list-data gh-post-list-status" title="Edit this post"}}
+<LinkTo @route="editor.edit" @models={{array this.post.displayName this.post.id}} class="permalink gh-list-data gh-post-list-status" @title="Edit this post">
     <div class="flex items-center">
         {{#if this.isScheduled}}
         <span class="gh-content-status-draft gh-badge nowrap">
@@ -63,8 +63,8 @@
             {{/if}}
         {{/if}}
     </div>
-{{/link-to}}
+</LinkTo>
 
-{{#link-to "editor.edit" this.post.displayName this.post.id class="permalink gh-list-data gh-post-list-updated" title="Edit this post"}}
+<LinkTo @route="editor.edit" @models={{array this.post.displayName this.post.id}} class="permalink gh-list-data gh-post-list-updated" @title="Edit this post">
     <span class="nowrap">{{gh-format-post-time this.post.updatedAtUTC draft=true}}</span>
-{{/link-to}}
+</LinkTo>

--- a/app/templates/components/gh-profile-image.hbs
+++ b/app/templates/components/gh-profile-image.hbs
@@ -16,10 +16,10 @@
         <span class="sr-only">Upload an image</span>
     </span>
 
-    {{gh-file-input
-        alt=null
-        name="uploadimage"
-        multiple=false
-        action=(action "imageSelected")
-        accept=this.imageMimeTypes}}
+    <GhFileInput
+        @alt={{null}}
+        @name="uploadimage"
+        @multiple={{false}}
+        @action={{action "imageSelected"}}
+        @accept={{this.imageMimeTypes}} />
 </figure>

--- a/app/templates/components/gh-psm-template-select.hbs
+++ b/app/templates/components/gh-psm-template-select.hbs
@@ -4,13 +4,13 @@
         <span class="gh-input-icon gh-icon-user">
             {{svg-jar "file-text-document"}}
             <span class="gh-select {{if this.matchedSlugTemplate "disabled"}}">
-                {{one-way-select this.selectedTemplate
-                    options=this.customTemplates
-                    optionValuePath="filename"
-                    optionLabelPath="name"
-                    update=(action "selectTemplate")
-                    disabled=this.matchedSlugTemplate
-                    data-test-select="custom-template"}}
+                <OneWaySelect @value={{this.selectedTemplate}}
+                    @options={{this.customTemplates}}
+                    @optionValuePath="filename"
+                    @optionLabelPath="name"
+                    @update={{action "selectTemplate"}}
+                    @disabled={{this.matchedSlugTemplate}}
+                    data-test-select="custom-template" />
                 {{svg-jar "arrow-down-small"}}
             </span>
         </span>

--- a/app/templates/components/gh-psm-visibility-input.hbs
+++ b/app/templates/components/gh-psm-visibility-input.hbs
@@ -1,10 +1,10 @@
 <span class="gh-select">
-    {{one-way-select this.selectedVisibility
-        options=this.availableVisibilities
-        optionValuePath="name"
-        optionLabelPath="label"
-        optionTargetPath="name"
-        update=(action "updateVisibility")
-    }}
+    <OneWaySelect @value={{this.selectedVisibility}}
+        @options={{this.availableVisibilities}}
+        @optionValuePath="name"
+        @optionLabelPath="label"
+        @optionTargetPath="name"
+        @update={{action "updateVisibility"}}
+    />
     {{svg-jar "arrow-down-small"}}
 </span>

--- a/app/templates/components/gh-publishmenu-draft.hbs
+++ b/app/templates/components/gh-publishmenu-draft.hbs
@@ -12,18 +12,18 @@
             <div class="gh-publishmenu-radio-button" data-test-publishmenu-scheduled-option></div>
             <div class="gh-publishmenu-radio-content">
                 <div class="gh-publishmenu-radio-label">Schedule it for later</div>
-                {{gh-date-time-picker
-                    date=this.post.publishedAtBlogDate
-                    time=this.post.publishedAtBlogTime
-                    setDate=(action "setDate")
-                    setTime=(action "setTime")
-                    setTypedDateError=this.setTypedDateError
-                    errors=this.post.errors
-                    dateErrorProperty="publishedAtBlogDate"
-                    timeErrorProperty="publishedAtBlogTime"
-                    minDate=this._minDate
-                    isActive=(eq this.saveType "schedule")
-                }}
+                <GhDateTimePicker
+                    @date={{this.post.publishedAtBlogDate}}
+                    @time={{this.post.publishedAtBlogTime}}
+                    @setDate={{action "setDate"}}
+                    @setTime={{action "setTime"}}
+                    @setTypedDateError={{this.setTypedDateError}}
+                    @errors={{this.post.errors}}
+                    @dateErrorProperty="publishedAtBlogDate"
+                    @timeErrorProperty="publishedAtBlogTime"
+                    @minDate={{this._minDate}}
+                    @isActive={{eq this.saveType "schedule"}}
+                />
                 <div class="gh-publishmenu-radio-desc">Set automatic future publish date</div>
             </div>
         </div>

--- a/app/templates/components/gh-publishmenu-scheduled.hbs
+++ b/app/templates/components/gh-publishmenu-scheduled.hbs
@@ -12,18 +12,18 @@
             <div class="gh-publishmenu-radio-button" data-test-publishmenu-scheduled-option></div>
             <div class="gh-publishmenu-radio-content">
                 <div class="gh-publishmenu-radio-label">Schedule for later</div>
-                {{gh-date-time-picker
-                    date=this.post.publishedAtBlogDate
-                    time=this.post.publishedAtBlogTime
-                    setDate=(action "setDate")
-                    setTime=(action "setTime")
-                    setTypedDateError=this.setTypedDateError
-                    errors=this.post.errors
-                    dateErrorProperty="publishedAtBlogDate"
-                    timeErrorProperty="publishedAtBlogTime"
-                    minDate=this._minDate
-                    isActive=(eq this.saveType "schedule")
-                }}
+                <GhDateTimePicker
+                    @date={{this.post.publishedAtBlogDate}}
+                    @time={{this.post.publishedAtBlogTime}}
+                    @setDate={{action "setDate"}}
+                    @setTime={{action "setTime"}}
+                    @setTypedDateError={{this.setTypedDateError}}
+                    @errors={{this.post.errors}}
+                    @dateErrorProperty="publishedAtBlogDate"
+                    @timeErrorProperty="publishedAtBlogTime"
+                    @minDate={{this._minDate}}
+                    @isActive={{eq this.saveType "schedule"}}
+                />
                 <div class="gh-publishmenu-radio-desc">Set automatic future publish date</div>
             </div>
         </div>

--- a/app/templates/components/gh-publishmenu.hbs
+++ b/app/templates/components/gh-publishmenu.hbs
@@ -5,30 +5,30 @@
 
     <dd.Content class="gh-publishmenu-dropdown">
         {{#if (eq this.displayState "published")}}
-            {{gh-publishmenu-published
-                post=this.post
-                saveType=this.saveType
-                setSaveType=(action "setSaveType")
-                backgroundTask=this.backgroundTask}}
+            <GhPublishmenuPublished
+                @post={{this.post}}
+                @saveType={{this.saveType}}
+                @setSaveType={{action "setSaveType"}}
+                @backgroundTask={{this.backgroundTask}} />
 
         {{else if (eq this.displayState "scheduled")}}
-            {{gh-publishmenu-scheduled
-                post=this.post
-                saveType=this.saveType
-                isClosing=this.isClosing
-                memberCount=this.memberCount
-                setSaveType=(action "setSaveType")
-                setTypedDateError=(action (mut this.typedDateError))}}
+            <GhPublishmenuScheduled
+                @post={{this.post}}
+                @saveType={{this.saveType}}
+                @isClosing={{this.isClosing}}
+                @memberCount={{this.memberCount}}
+                @setSaveType={{action "setSaveType"}}
+                @setTypedDateError={{action (mut this.typedDateError)}} />
 
         {{else}}
-            {{gh-publishmenu-draft
-                post=this.post
-                saveType=this.saveType
-                setSaveType=(action "setSaveType")
-                setTypedDateError=(action (mut this.typedDateError))
-                backgroundTask=this.backgroundTask
-                memberCount=this.memberCount
-                sendEmailWhenPublished=this.sendEmailWhenPublished}}
+            <GhPublishmenuDraft
+                @post={{this.post}}
+                @saveType={{this.saveType}}
+                @setSaveType={{action "setSaveType"}}
+                @setTypedDateError={{action (mut this.typedDateError)}}
+                @backgroundTask={{this.backgroundTask}}
+                @memberCount={{this.memberCount}}
+                @sendEmailWhenPublished={{this.sendEmailWhenPublished}} />
         {{/if}}
 
         {{!--

--- a/app/templates/components/gh-tag-settings-form.hbs
+++ b/app/templates/components/gh-tag-settings-form.hbs
@@ -1,93 +1,93 @@
 <h4 class="midlightgrey f-small fw5 ttu">Basic settings</h4>
 <div class="pa5 pt4 br4 shadow-1 bg-grouped-table mt2 flex flex-column flex-row-ns items-start justify-between gh-tag-basic-settings-form">
     <div class="order-1 flex flex-column items-start mr5 w-100 w-50-m w-two-thirds-l">
-        {{#gh-form-group errors=this.tag.errors hasValidated=this.tag.hasValidated property="name"}}
+        <GhFormGroup @errors={{this.tag.errors}} @hasValidated={{this.tag.hasValidated}} @property="name">
             <label for="tag-name">Name</label>
-            {{gh-text-input
-                id="tag-name"
-                name="name"
-                value=this.scratchTag.name
-                tabindex="1"
-                focus-out=(action 'setProperty' 'name' this.scratchTag.name)
-            }}
+            <GhTextInput
+                @id="tag-name"
+                @name="name"
+                @value={{this.scratchTag.name}}
+                @tabindex="1"
+                @focus-out={{action "setProperty" "name" this.scratchTag.name}}
+            />
             <p class="description">
                 Start with # to create internal tags
                 <a href="https://ghost.org/docs/concepts/tags/#internal-tag" target="_blank" rel="noreferrer">Learn more</a>
             </p>
             <GhErrorMessage @errors={{this.tag.errors}} @property="name" />
-        {{/gh-form-group}}
+        </GhFormGroup>
 
-        {{#gh-form-group errors=this.tag.errors hasValidated=this.tag.hasValidated property="slug"}}
+        <GhFormGroup @errors={{this.tag.errors}} @hasValidated={{this.tag.hasValidated}} @property="slug">
             <label for="tag-slug">Slug</label>
-            {{gh-text-input
-                value=this.scratchTag.slug
-                id="tag-slug"
-                name="slug"
-                tabindex="2"
-                focus-out=(action 'setProperty' 'slug' this.scratchTag.slug)
-            }}
-            {{gh-url-preview prefix="tag" slug=this.scratchTag.slug tagName="p" classNames="description"}}
+            <GhTextInput
+                @value={{this.scratchTag.slug}}
+                @id="tag-slug"
+                @name="slug"
+                @tabindex="2"
+                @focus-out={{action "setProperty" "slug" this.scratchTag.slug}}
+            />
+            <GhUrlPreview @prefix="tag" @slug={{this.scratchTag.slug}} @tagName="p" @classNames="description" />
             <GhErrorMessage @errors={{this.activeTag.errors}} @property="slug" />
-        {{/gh-form-group}}
+        </GhFormGroup>
 
-        {{#gh-form-group errors=this.tag.errors hasValidated=this.tag.hasValidated property="description"}}
+        <GhFormGroup @errors={{this.tag.errors}} @hasValidated={{this.tag.hasValidated}} @property="description">
             <label for="tag-description">Description</label>
-            {{gh-textarea
-                id="tag-description"
-                name="description"
-                class="gh-tag-details-textarea"
-                tabindex="3"
-                value=this.scratchTag.description
-                focus-out=(action 'setProperty' 'description' this.scratchTag.description)
-            }}
+            <GhTextarea
+                @id="tag-description"
+                @name="description"
+                @class="gh-tag-details-textarea"
+                @tabindex="3"
+                @value={{this.scratchTag.description}}
+                @focus-out={{action "setProperty" "description" this.scratchTag.description}}
+            />
             <GhErrorMessage @errors={{this.tag.errors}} @property="description" />
             <p>Maximum: <b>500</b> characters. You’ve used {{gh-count-down-characters this.scratchTag.description 500}}</p>
-        {{/gh-form-group}}
+        </GhFormGroup>
     </div>
     <div class="order-0 mb6 mb0-ns order-2-ns w-100 w-50-m w-third-l">
         <label for="tag-image">Tag image</label>
-        {{gh-image-uploader-with-preview
-            image=this.tag.featureImage
-            text="Upload tag image"
-            class="gh-tag-image-uploader"
-            allowUnsplash=true
-            update=(action "setCoverImage")
-            remove=(action "clearCoverImage")
-        }}
+        <GhImageUploaderWithPreview
+            @image={{this.tag.featureImage}}
+            @text="Upload tag image"
+            @class="gh-tag-image-uploader"
+            @allowUnsplash={{true}}
+            @update={{action "setCoverImage"}}
+            @remove={{action "clearCoverImage"}}
+        />
     </div>
 </div>
 
 <h4 class="midlightgrey f-small fw5 ttu mt15">Meta data</h4>
 <div class="pa5 pt4 br4 shadow-1 bg-grouped-table mt2 flex flex-column flex-row-ns items-start justify-between">
     <div class="flex flex-column items-start mr5 w-100 w-50-m w-two-thirds-l">
-        {{#gh-form-group errors=this.tag.errors hasValidated=this.tag.hasValidated property="metaTitle"}}
+        <GhFormGroup @errors={{this.tag.errors}} @hasValidated={{this.tag.hasValidated}} @property="metaTitle">
             <label for="meta-title">Meta Title</label>
-            {{gh-text-input
-                id="meta-title"
-                name="metaTitle"
-                placeholder=this.scratchTag.name
-                tabindex="4"
-                value=this.scratchTag.metaTitle
-                focus-out=(action "setProperty" "metaTitle" this.scratchTag.metaTitle)
-            }}
+            <GhTextInput
+                @id="meta-title"
+                @name="metaTitle"
+                @placeholder={{this.scratchTag.name}}
+                @tabindex="4"
+                @value={{this.scratchTag.metaTitle}}
+                @focus-out={{action "setProperty" "metaTitle" this.scratchTag.metaTitle}}
+            />
             <GhErrorMessage @errors={{this.tag.errors}} @property="metaTitle" />
             <p>Recommended: <b>70</b> characters. You’ve used {{gh-count-down-characters this.scratchTag.metaTitle 70}}</p>
-        {{/gh-form-group}}
+        </GhFormGroup>
 
-        {{#gh-form-group errors=this.tag.errors hasValidated=this.tag.hasValidated property="metaDescription"}}
+        <GhFormGroup @errors={{this.tag.errors}} @hasValidated={{this.tag.hasValidated}} @property="metaDescription">
             <label for="meta-description">Meta Description</label>
-            {{gh-textarea
-                id="meta-description"
-                name="metaDescription"
-                class="gh-tag-details-textarea"
-                placeholder=this.scratchTag.description
-                tabindex="5"
-                value=this.scratchTag.metaDescription
-                focus-out=(action "setProperty" "metaDescription" this.scratchTag.metaDescription)
-            }}
+            <GhTextarea
+                @id="meta-description"
+                @name="metaDescription"
+                @class="gh-tag-details-textarea"
+                @placeholder={{this.scratchTag.description}}
+                @tabindex="5"
+                @value={{this.scratchTag.metaDescription}}
+                @focus-out={{action "setProperty" "metaDescription" this.scratchTag.metaDescription}}
+            />
             <GhErrorMessage @errors={{this.tag.errors}} @property="metaDescription" />
             <p>Recommended: <b>156</b> characters. You’ve used {{gh-count-down-characters this.scratchTag.metaDescription 156}}</p>
-        {{/gh-form-group}}
+        </GhFormGroup>
     </div>
     <div class="w-100 w-50-m w-third-l">
         <div class="form-group">

--- a/app/templates/components/gh-tags-list-item.hbs
+++ b/app/templates/components/gh-tags-list-item.hbs
@@ -1,4 +1,4 @@
-{{#link-to "tag" tag class="gh-list-data gh-tag-list-title" title="Edit tag"}}
+<LinkTo @route="tag" @model={{tag}} class="gh-list-data gh-tag-list-title" @title="Edit tag">
     <h3 class="gh-tag-list-name">
         {{this.tag.name}}
     </h3>
@@ -7,24 +7,24 @@
             {{this.description}}
         </p>
     {{/if}}
-{{/link-to}}
+</LinkTo>
 
-{{#link-to "tag" tag class="gh-list-data middarkgrey f8 gh-tag-list-slug gh-list-cellwidth-10" title="Edit tag"}}
+<LinkTo @route="tag" @model={{tag}} class="gh-list-data middarkgrey f8 gh-tag-list-slug gh-list-cellwidth-10" @title="Edit tag">
     <span title="{{this.slug}}">{{this.slug}}</span>
-{{/link-to}}
+</LinkTo>
 
 {{#if this.postsCount}}
-    {{#link-to "posts" (query-params type=null author=null tag=tag.slug order=null) class="gh-list-data blue gh-tag-list-posts-count gh-list-cellwidth-10 f8" title=(concat "List posts tagged with '" this.tag.name "'")}}
+    <LinkTo @route="posts" @query={{hash type=null author=null tag=tag.slug order=null}} class="gh-list-data blue gh-tag-list-posts-count gh-list-cellwidth-10 f8" @title={{concat "List posts tagged with '" this.tag.name "'"}}>
         <span class="nowrap">{{this.postsLabel}}</span>
-    {{/link-to}}
+    </LinkTo>
 {{else}}
-    {{#link-to "tag" tag class="gh-list-data gh-tag-list-posts-count gh-list-cellwidth-10" title="Edit tag"}}
+    <LinkTo @route="tag" @model={{tag}} class="gh-list-data gh-tag-list-posts-count gh-list-cellwidth-10" @title="Edit tag">
         <span class="nowrap f8 midlightgrey">{{this.postsLabel}}</span>
-    {{/link-to}}
+    </LinkTo>
 {{/if}}
 
-{{#link-to "tag" tag class="gh-list-data gh-list-cellwidth-min gh-tag-list-chevron" title="Edit tag"}}
+<LinkTo @route="tag" @model={{tag}} class="gh-list-data gh-list-cellwidth-min gh-tag-list-chevron" @title="Edit tag">
     <div class="flex items-center justify-end w-100 h-100">
         <span class="nr2">{{svg-jar "arrow-right" class="w6 h6 fill-midgrey pa1"}}</span>
     </div>
-{{/link-to}}
+</LinkTo>

--- a/app/templates/components/gh-timezone-select.hbs
+++ b/app/templates/components/gh-timezone-select.hbs
@@ -1,13 +1,13 @@
 <span class="gh-select" data-select-text="{{this.selectedTimezone.label}}" tabindex="0">
-    {{one-way-select
-        id="activeTimezone"
-        name="general[activeTimezone]"
-        options=this.selectableTimezones
-        optionValuePath="name"
-        optionLabelPath="label"
-        value=this.selectedTimezone
-        update=(action "setTimezone")
-    }}
+    <OneWaySelect
+        @id="activeTimezone"
+        @name="general[activeTimezone]"
+        @options={{this.selectableTimezones}}
+        @optionValuePath="name"
+        @optionLabelPath="label"
+        @value={{this.selectedTimezone}}
+        @update={{action "setTimezone"}}
+    />
     {{svg-jar "arrow-down-small"}}
 </span>
 {{#if this.hasTimezoneOverride}}

--- a/app/templates/components/gh-token-input/trigger.hbs
+++ b/app/templates/components/gh-token-input/trigger.hbs
@@ -1,11 +1,12 @@
-{{#sortable-objects tagName="ul"
-    id=(concat "ember-power-select-multiple-options-" select.uniqueId)
-    class="ember-power-select-multiple-options"
-    sortableObjectList=select.selected
-    enableSort=true
-    useSwap=false
-    sortEndAction=(action "reorderItems")
-}}
+<SortableObjects
+    @tagName="ul"
+    @id={{concat "ember-power-select-multiple-options-" select.uniqueId}}
+    @class="ember-power-select-multiple-options"
+    @sortableObjectList={{select.selected}}
+    @enableSort={{true}}
+    @useSwap={{false}}
+    @sortEndAction={{action "reorderItems"}}
+>
     {{#each select.selected as |opt idx|}}
         {{#component (or this.extra.tokenComponent "draggable-object")
             tagName="li"
@@ -60,5 +61,5 @@
             {{did-insert this.storeInputStyles}}
         >
     {{/if}}
-{{/sortable-objects}}
+</SortableObjects>
 <span class="ember-power-select-status-icon"></span>

--- a/app/templates/components/gh-tour-item.hbs
+++ b/app/templates/components/gh-tour-item.hbs
@@ -1,31 +1,31 @@
 {{#if this.isVisible}}
     {{!-- tether the throbber --}}
-    {{#liquid-tether
-        class="throbber-container"
-        target=this.target
-        attachment="middle center"
-        targetAttachment=this.throbberAttachment
-        targetOffset=this.throbberOffset
-    }}
+    <LiquidTether
+        @class="throbber-container"
+        @target={{this.target}}
+        @attachment="middle center"
+        @targetAttachment={{this.throbberAttachment}}
+        @targetOffset={{this.throbberOffset}}
+    >
         <a class="throbber-trigger" href="#" {{action "open"}} id={{this._throbberElementId}}>
             <span class="throbber"></span>
         </a>
-    {{/liquid-tether}}
+    </LiquidTether>
 
     {{#if this.isOpen}}
         {{!-- wormhole the background click overlay --}}
-        {{#liquid-wormhole class="tour-container"}}
+        <LiquidWormhole @class="tour-container">
             <div class="tour-background" {{action "close" on="click"}}></div>
-        {{/liquid-wormhole}}
+        </LiquidWormhole>
 
         {{!-- tether the popover --}}
-        {{#liquid-tether
-            class="tour"
-            target=this._throbberElementSelector
-            attachment=this._popoverAttachment
-            targetAttachment=this._popoverTargetAttachment
-            offset=this._popoverOffset
-        }}
+        <LiquidTether
+            @class="tour"
+            @target={{this._throbberElementSelector}}
+            @attachment={{this._popoverAttachment}}
+            @targetAttachment={{this._popoverTargetAttachment}}
+            @offset={{this._popoverOffset}}
+        >
             <div class="popover-item popover-triangle-{{this.popoverTriangleClass}}">
                 <h3 class="popover-title">{{this._throbber.title}}</h3>
                 <div class="popover-body">
@@ -36,6 +36,6 @@
                     <a class="tour-dismiss gh-btn gh-btn-black" href="#" {{action 'markAsViewed'}}><span>Ok, got it</span></a>
                 </footer>
             </div>
-        {{/liquid-tether}}
+        </LiquidTether>
     {{/if}}
 {{/if}}

--- a/app/templates/components/gh-unsplash.hbs
+++ b/app/templates/components/gh-unsplash.hbs
@@ -1,4 +1,4 @@
-{{#liquid-wormhole class="unsplash"}}
+<LiquidWormhole @class="unsplash">
     {{!-- TODO: why does this modal background not cover the PSM without style override? --}}
     <div class="fullscreen-modal-background" {{action "close"}} style="z-index: 999"></div>
     <div class="absolute top-8 right-8 bottom-8 left-8 br4 overflow-hidden bg-white z-9999" data-unsplash>
@@ -16,18 +16,18 @@
                 </h1>
                 <span class="gh-input-icon mw88-l flex-auto w-100 mt3 mt0-l">
                     {{svg-jar "search"}}
-                    {{gh-text-input
-                        class="gh-unsplash-search"
-                        name="searchKeyword"
-                        placeholder="Search free high-resolution photos"
-                        tabindex="1"
-                        shouldFocus=true
-                        autocorrect="off"
-                        value=(readonly this.unsplash.searchTerm)
-                        input=(action "search" value="target.value")
-                        focusIn=(action "setKeyScope")
-                        focus-out=(action "resetKeyScope")
-                    }}
+                    <GhTextInput
+                        @class="gh-unsplash-search"
+                        @name="searchKeyword"
+                        @placeholder="Search free high-resolution photos"
+                        @tabindex="1"
+                        @shouldFocus={{true}}
+                        @autocorrect="off"
+                        @value={{readonly this.unsplash.searchTerm}}
+                        @input={{action "search" value="target.value"}}
+                        @focusIn={{action "setKeyScope"}}
+                        @focus-out={{action "resetKeyScope"}}
+                    />
                 </span>
             </header>
 
@@ -40,7 +40,7 @@
                             {{#each this.unsplash.columns as |photos|}}
                                 <div class="gh-unsplash-grid-column">
                                     {{#each photos as |photo|}}
-                                        {{gh-unsplash-photo photo=photo zoom=(action "zoomPhoto") select=(action "select")}}
+                                        <GhUnsplashPhoto @photo={{photo}} @zoom={{action "zoomPhoto"}} @select={{action "select"}} />
                                     {{/each}}
                                 </div>
                             {{/each}}
@@ -70,23 +70,23 @@
                         </div>
                     {{/if}}
 
-                    {{gh-scroll-trigger
-                        enter=(action "loadNextPage")
-                        triggerOffset=1000}}
+                    <GhScrollTrigger
+                        @enter={{action "loadNextPage"}}
+                        @triggerOffset={{1000}} />
                 </div>
 
                 {{!-- zoomed image overlay --}}
                 {{#if this.zoomedPhoto}}
                     <div class="absolute flex justify-center top-0 right-0 bottom-0 left-0 pr20 pb10 pl20 bg-white overflow-hidden" {{action "closeZoom"}}>
-                        {{gh-unsplash-photo
-                            photo=this.zoomedPhoto
-                            zoomed=true
-                            zoom=(action "closeZoom")
-                            select=(action "select")}}
+                        <GhUnsplashPhoto
+                            @photo={{this.zoomedPhoto}}
+                            @zoomed={{true}}
+                            @zoom={{action "closeZoom"}}
+                            @select={{action "select"}} />
                     </div>
                 {{/if}}
             </div>
         </div>
     </div>
 
-{{/liquid-wormhole}}
+</LiquidWormhole>

--- a/app/templates/components/gh-user-list-item.hbs
+++ b/app/templates/components/gh-user-list-item.hbs
@@ -1,5 +1,5 @@
 <div class="apps-grid-cell">
-    {{#link-to 'staff.user' user.slug data-test-user-id=user.id}}
+    <LinkTo @route="staff.user" @model={{user.slug}} data-test-user-id={{user.id}}>
     <article class="apps-card-app">
         <div class="apps-card-left">
             <span class="user-list-item-figure" style={{background-image-style user.profileImageUrl}}>
@@ -24,5 +24,5 @@
             </div>
         </div>
     </article>
-    {{/link-to}}
+    </LinkTo>
 </div>

--- a/app/templates/components/modal-delete-all.hbs
+++ b/app/templates/components/modal-delete-all.hbs
@@ -9,5 +9,5 @@
 
 <div class="modal-footer">
     <button {{action "closeModal"}} class="gh-btn"><span>Cancel</span></button>
-    {{gh-task-button "Delete" successText="Deleted" task=this.deleteAll class="gh-btn gh-btn-red gh-btn-icon"}}
+    <GhTaskButton @buttonText="Delete" @successText="Deleted" @task={{this.deleteAll}} @class="gh-btn gh-btn-red gh-btn-icon" />
 </div>

--- a/app/templates/components/modal-delete-integration.hbs
+++ b/app/templates/components/modal-delete-integration.hbs
@@ -9,5 +9,5 @@
 </div>
 <div class="modal-footer">
     <button {{action "closeModal"}} class="gh-btn"><span>Cancel</span></button>
-    {{gh-task-button "Delete Integration" successText="Deleted" task=this.deleteIntegration class="gh-btn gh-btn-red gh-btn-icon"}}
+    <GhTaskButton @buttonText="Delete Integration" successText="Deleted" task={{this.deleteIntegration}} @class="gh-btn gh-btn-red gh-btn-icon" />
 </div>

--- a/app/templates/components/modal-delete-member.hbs
+++ b/app/templates/components/modal-delete-member.hbs
@@ -11,5 +11,5 @@
 
 <div class="modal-footer">
     <button {{action "closeModal"}} class="gh-btn"><span>Cancel</span></button>
-    {{gh-task-button "Delete" successText="Deleted" task=this.deleteMember class="gh-btn gh-btn-red gh-btn-icon"}}
+    <GhTaskButton @buttonText="Delete" @successText="Deleted" @task={{this.deleteMember}} @class="gh-btn gh-btn-red gh-btn-icon" />
 </div>

--- a/app/templates/components/modal-delete-post.hbs
+++ b/app/templates/components/modal-delete-post.hbs
@@ -11,5 +11,5 @@
 
 <div class="modal-footer">
     <button {{action "closeModal"}} class="gh-btn"><span>Cancel</span></button>
-    {{gh-task-button "Delete" successText="Deleted" task=this.deletePost class="gh-btn gh-btn-red gh-btn-icon"}}
+    <GhTaskButton @buttonText="Delete" @successText="Deleted" @task={{this.deletePost}} @class="gh-btn gh-btn-red gh-btn-icon" />
 </div>

--- a/app/templates/components/modal-delete-tag.hbs
+++ b/app/templates/components/modal-delete-tag.hbs
@@ -12,5 +12,5 @@
 
 <div class="modal-footer">
     <button {{action "closeModal"}} class="gh-btn"><span>Cancel</span></button>
-    {{gh-task-button "Delete" successText="Deleted" task=this.deleteTag class="gh-btn gh-btn-red gh-btn-icon"}}
+    <GhTaskButton @buttonText="Delete" @successText="Deleted" @task={{this.deleteTag}} @class="gh-btn gh-btn-red gh-btn-icon" />
 </div>

--- a/app/templates/components/modal-delete-theme.hbs
+++ b/app/templates/components/modal-delete-theme.hbs
@@ -9,5 +9,5 @@
 
 <div class="modal-footer">
     <button {{action "closeModal"}} class="gh-btn" data-test-cancel-button><span>Cancel</span></button>
-    {{gh-task-button "Delete" successText="Deleted" task=this.deleteTheme class="gh-btn gh-btn-red gh-btn-icon" data-test-delete-button=true}}
+    <GhTaskButton @buttonText="Delete" @successText="Deleted" @task={{this.deleteTheme}} @class="gh-btn gh-btn-red gh-btn-icon" data-test-delete-button="true" />
 </div>

--- a/app/templates/components/modal-delete-user.hbs
+++ b/app/templates/components/modal-delete-user.hbs
@@ -23,9 +23,9 @@
     <button {{action "closeModal"}} class="gh-btn" data-test-button="cancel-delete-user">
         <span>Cancel</span>
     </button>
-    {{gh-task-button (if this.user.count.posts "Delete user and their posts" "Delete user")
-        successText="Deleted"
-        task=this.deleteUser
-        class="gh-btn gh-btn-red gh-btn-icon"
-        data-test-button="confirm-delete-user"}}
+    <GhTaskButton @buttonText={{if this.user.count.posts "Delete user and their posts" "Delete user"}}
+        @successText="Deleted"
+        @task={{this.deleteUser}}
+        @class="gh-btn gh-btn-red gh-btn-icon"
+        data-test-button="confirm-delete-user" />
 </div>

--- a/app/templates/components/modal-delete-webhook.hbs
+++ b/app/templates/components/modal-delete-webhook.hbs
@@ -11,5 +11,5 @@
 
 <div class="modal-footer">
     <button {{action "closeModal"}} class="gh-btn"><span>Cancel</span></button>
-    {{gh-task-button "Delete Webhook" successText="Deleted" task=this.deleteWebhook class="gh-btn gh-btn-red gh-btn-icon"}}
+    <GhTaskButton @buttonText="Delete Webhook" @successText="Deleted" @task={{this.deleteWebhook}} @class="gh-btn gh-btn-red gh-btn-icon" />
 </div>

--- a/app/templates/components/modal-import-members.hbs
+++ b/app/templates/components/modal-import-members.hbs
@@ -30,13 +30,13 @@
             {{/if}}
         </table>
     {{else}}
-        {{gh-file-uploader
-            url=this.uploadUrl
-            paramName="membersfile"
-            labelText="Select or drag-and-drop a CSV file."
-            uploadStarted=(action "uploadStarted")
-            uploadFinished=(action "uploadFinished")
-            uploadSuccess=(action "uploadSuccess")}}
+        <GhFileUploader
+            @url={{this.uploadUrl}}
+            @paramName="membersfile"
+            @labelText="Select or drag-and-drop a CSV file."
+            @uploadStarted={{action "uploadStarted"}}
+            @uploadFinished={{action "uploadFinished"}}
+            @uploadSuccess={{action "uploadSuccess"}} />
     {{/if}}
 </div>
 

--- a/app/templates/components/modal-invite-new-user.hbs
+++ b/app/templates/components/modal-invite-new-user.hbs
@@ -8,52 +8,52 @@
 
 <div class="modal-body">
     <fieldset>
-        {{#gh-form-group errors=this.errors hasValidated=this.hasValidated property="email"}}
+        <GhFormGroup @errors={{this.errors}} @hasValidated={{this.hasValidated}} @property="email">
             <label for="new-user-email">Email Address</label>
-            {{gh-text-input
-                class="email"
-                id="new-user-email"
-                type="email"
-                placeholder="Email Address"
-                name="email"
-                shouldFocus=true
-                autocapitalize="off"
-                autocorrect="off"
-                value=(readonly email)
-                input=(action (mut email) value="target.value")
-                keyEvents=(hash
+            <GhTextInput
+                @class="email"
+                @id="new-user-email"
+                @type="email"
+                @placeholder="Email Address"
+                @name="email"
+                @shouldFocus={{true}}
+                @autocapitalize="off"
+                @autocorrect="off"
+                @value={{readonly email}}
+                @input={{action (mut email) value="target.value"}}
+                @keyEvents={{hash
                     Enter=(action "confirm")
-                )
-                focus-out=(action "validate" "email")
-            }}
+                }}
+                @focus-out={{action "validate" "email"}}
+            />
             <GhErrorMessage @errors={{this.errors}} @property="email" />
-        {{/gh-form-group}}
+        </GhFormGroup>
 
 
-        {{#gh-form-group class="for-select" errors=this.errors hasValidated=this.hasValidated property="role"}}
+        <GhFormGroup @class="for-select" @errors={{this.errors}} @hasValidated={{this.hasValidated}} @property="role">
             <label for="new-user-role">Role</label>
             <span class="gh-select">
-                {{one-way-select
-                    id="new-user-role"
-                    name="role"
-                    options=(readonly this.roles)
-                    optionValuePath="id"
-                    optionLabelPath="name"
-                    value=this.role
-                    update=(action "setRole")
-                }}
+                <OneWaySelect
+                    @id="new-user-role"
+                    @name="role"
+                    @options={{readonly this.roles}}
+                    @optionValuePath="id"
+                    @optionLabelPath="name"
+                    @value={{this.role}}
+                    @update={{action "setRole"}}
+                />
                 {{svg-jar "arrow-down-small"}}
             </span>
             <GhErrorMessage @errors={{this.errors}} @property="role" />
-        {{/gh-form-group}}
+        </GhFormGroup>
     </fieldset>
 </div>
 
 <div class="modal-footer">
-    {{gh-task-button "Send invitation now"
-        successText="Sent"
-        task=this.sendInvitation
-        class="gh-btn gh-btn-green gh-btn-icon"
-        disabled=this.fetchRoles.isRunning
-        disableMouseDown=true}}
+    <GhTaskButton @buttonText="Send invitation now"
+        @successText="Sent"
+        @task={{this.sendInvitation}}
+        @class="gh-btn gh-btn-green gh-btn-icon"
+        @disabled={{this.fetchRoles.isRunning}}
+        @disableMouseDown="true" />
 </div>

--- a/app/templates/components/modal-new-integration.hbs
+++ b/app/templates/components/modal-new-integration.hbs
@@ -8,7 +8,7 @@
 
 <div class="modal-body">
     <fieldset>
-        {{#gh-form-group errors=this.integration.errors hasValidated=this.integration.hasValidated property="name"}}
+        <GhFormGroup @errors={{this.integration.errors}} @hasValidated={{this.integration.hasValidated}} @property="name">
             <label for="new-integration-name" class="fw6">Name</label>
             <input type="text"
                 value={{this.integration.name}}
@@ -22,7 +22,7 @@
                 autocorrect="off"
                 data-test-input="new-integration-name">
             <GhErrorMessage @errors={{this.integration.errors}} @property="name" data-test-error="new-integration-name" />
-        {{/gh-form-group}}
+        </GhFormGroup>
     </fieldset>
 </div>
 
@@ -36,9 +36,9 @@
     >
         <span>Cancel</span>
     </button>
-    {{gh-task-button "Create"
-        successText="Created"
-        task=this.createIntegration
-        class="gh-btn gh-btn-green gh-btn-icon"
-        data-test-button="create-integration"}}
+    <GhTaskButton @buttonText="Create"
+        @successText="Created"
+        @task={{this.createIntegration}}
+        @class="gh-btn gh-btn-green gh-btn-icon"
+        data-test-button="create-integration" />
 </div>

--- a/app/templates/components/modal-re-authenticate.hbs
+++ b/app/templates/components/modal-re-authenticate.hbs
@@ -6,17 +6,17 @@
 <div class="modal-body {{if this.authenticationError 'error'}}">
 
     <form id="login" class="login-form" method="post" novalidate="novalidate" {{action "confirm" on="submit"}}>
-        {{#gh-validation-status-container class="password-wrap" errors=this.errors property="password" hasValidated=this.hasValidated}}
-            {{gh-text-input
-                class="password"
-                type="password"
-                placeholder="Password"
-                name="password"
-                value=(readonly this.password)
-                input=(action (mut this.password) value="target.value")}}
-        {{/gh-validation-status-container}}
+        <GhValidationStatusContainer @class="password-wrap" @errors={{this.errors}} @property="password" @hasValidated={{this.hasValidated}}>
+            <GhTextInput
+                @class="password"
+                @type="password"
+                @placeholder="Password"
+                @name="password"
+                @value={{readonly this.password}}
+                @input={{action (mut this.password) value="target.value"}} />
+        </GhValidationStatusContainer>
         <div>
-            {{gh-task-button "Log in" task=this.reauthenticate class="gh-btn gh-btn-blue gh-btn-icon" type="submit"}}
+            <GhTaskButton @buttonText="Log in" @task={{this.reauthenticate}} @class="gh-btn gh-btn-blue gh-btn-icon" @type="submit" />
         </div>
     </form>
 

--- a/app/templates/components/modal-search.hbs
+++ b/app/templates/components/modal-search.hbs
@@ -1,4 +1,4 @@
 <div class="gh-nav-search-modal">
-    {{gh-search-input class="gh-nav-search-input" onSelected=(action "confirm")}}
+    <GhSearchInput @class="gh-nav-search-input" @onSelected={{action "confirm"}} />
     <div class="gh-search-tips">Open with Ctrl/⌘ + K</div>
 </div>

--- a/app/templates/components/modal-suspend-user.hbs
+++ b/app/templates/components/modal-suspend-user.hbs
@@ -9,5 +9,5 @@
 
 <div class="modal-footer">
     <button {{action "closeModal"}} class="gh-btn"><span>Cancel</span></button>
-    {{gh-task-button "Suspend" successText="Suspended" task=this.suspendUser class="gh-btn gh-btn-red gh-btn-icon" data-test-modal-confirm=true}}
+    <GhTaskButton @buttonText="Suspend" @successText="Suspended" @task={{this.suspendUser}} @class="gh-btn gh-btn-red gh-btn-icon" data-test-modal-confirm="true" />
 </div>

--- a/app/templates/components/modal-theme-warnings.hbs
+++ b/app/templates/components/modal-theme-warnings.hbs
@@ -19,7 +19,7 @@
             <ul class="pa0" data-test-theme-fatal-errors>
             {{#each this.fatalErrors as |error|}}
                 <li class="theme-validation-item theme-fatal-error">
-                    {{gh-theme-error-li error=error}}
+                    <GhThemeErrorLi @error={{error}} />
                 </li>
             {{/each}}
             </ul>
@@ -34,7 +34,7 @@
             <ul class="pa0" data-test-theme-errors>
             {{#each this.errors as |error|}}
                 <li class="theme-validation-item theme-error">
-                    {{gh-theme-error-li error=error}}
+                    <GhThemeErrorLi @error={{error}} />
                 </li>
             {{/each}}
             </ul>
@@ -49,7 +49,7 @@
             <ul class="pa0" data-test-theme-warnings>
             {{#each this.warnings as |error|}}
                 <li class="theme-validation-item theme-warning">
-                    {{gh-theme-error-li error=error}}
+                    <GhThemeErrorLi @error={{error}} />
                 </li>
             {{/each}}
             </ul>

--- a/app/templates/components/modal-transfer-owner.hbs
+++ b/app/templates/components/modal-transfer-owner.hbs
@@ -12,5 +12,5 @@
 
 <div class="modal-footer">
     <button {{action "closeModal"}} class="gh-btn"><span>Cancel</span></button>
-    {{gh-task-button "Yep - I'm sure" task=this.transferOwnership class="gh-btn gh-btn-red gh-btn-icon"}}
+    <GhTaskButton @buttonText="Yep - I'm sure" @task={{this.transferOwnership}} @class="gh-btn gh-btn-red gh-btn-icon" />
 </div>

--- a/app/templates/components/modal-unsuspend-user.hbs
+++ b/app/templates/components/modal-unsuspend-user.hbs
@@ -9,5 +9,5 @@
 
 <div class="modal-footer">
     <button {{action "closeModal"}} class="gh-btn"><span>Cancel</span></button>
-    {{gh-task-button "Un-suspend" successText="Suspended" task=this.unsuspendUser class="gh-btn gh-btn-red gh-btn-icon" data-test-modal-confirm=true}}
+    <GhTaskButton @buttonText="Un-suspend" @successText="Suspended" @task={{this.unsuspendUser}} @class="gh-btn gh-btn-red gh-btn-icon" data-test-modal-confirm="true" />
 </div>

--- a/app/templates/components/modal-upload-image.hbs
+++ b/app/templates/components/modal-upload-image.hbs
@@ -8,17 +8,17 @@
             </a>
         </div>
     {{else}}
-        {{gh-image-uploader
-            image=this.newUrl
-            saveButton=false
-            update=(action 'fileUploaded')
-            uploadStarted=(action 'isUploading')
-            uploadFinished=(action 'isUploading')
-            accept=this.model.accept
-            extensions=this.model.extensions
-            uploadUrl=this.model.uploadUrl
-            paramsHash=this.model.paramsHas
-        }}
+        <GhImageUploader
+            @image={{this.newUrl}}
+            @saveButton={{false}}
+            @update={{action "fileUploaded"}}
+            @uploadStarted={{action "isUploading"}}
+            @uploadFinished={{action "isUploading"}}
+            @accept={{this.model.accept}}
+            @extensions={{this.model.extensions}}
+            @uploadUrl={{this.model.uploadUrl}}
+            @paramsHash={{this.model.paramsHas}}
+        />
     {{/if}}
 </div>
 
@@ -27,6 +27,6 @@
     {{#if this._isUploading}}
         <button class="gh-btn gh-btn-blue right gh-btn-icon disabled"><span>Save</span></button>
     {{else}}
-        {{gh-task-button task=this.uploadImage class="gh-btn gh-btn-blue right gh-btn-icon" data-test-modal-accept-button=true}}
+        <GhTaskButton @task={{this.uploadImage}} @class="gh-btn gh-btn-blue right gh-btn-icon" data-test-modal-accept-button={{true}} />
     {{/if}}
 </div>

--- a/app/templates/components/modal-upload-theme.hbs
+++ b/app/templates/components/modal-upload-theme.hbs
@@ -36,7 +36,7 @@
                     <ul class="pa0">
                     {{#each this.validationErrors as |error|}}
                         <li class="theme-validation-item theme-error">
-                            {{gh-theme-error-li error=error}}
+                            <GhThemeErrorLi @error={{error}} />
                         </li>
                     {{/each}}
                     </ul>
@@ -49,7 +49,7 @@
                     <ul class="pa0">
                     {{#each this.validationWarnings as |error|}}
                         <li class="theme-validation-item theme-warning">
-                            {{gh-theme-error-li error=error}}
+                            <GhThemeErrorLi @error={{error}} />
                         </li>
                     {{/each}}
                     </ul>
@@ -79,7 +79,7 @@
                 <ul class="pa0">
                 {{#each this.fatalValidationErrors as |error|}}
                     <li class="theme-validation-item theme-fatal-error">
-                        {{gh-theme-error-li error=error}}
+                        <GhThemeErrorLi @error={{error}} />
                     </li>
                 {{/each}}
                 </ul>
@@ -93,23 +93,23 @@
                 <ul class="pa0">
                 {{#each this.validationErrors as |error|}}
                     <li class="theme-validation-item theme-error">
-                        {{gh-theme-error-li error=error}}
+                        <GhThemeErrorLi @error={{error}} />
                     </li>
                 {{/each}}
                 </ul>
             {{/if}}
         {{else}}
-            {{gh-file-uploader
-                url=this.uploadUrl
-                paramName="file"
-                accept=this.accept
-                labelText="Click to select or drag-and-drop your theme zip file here."
-                validate=(action "validateTheme")
-                uploadStarted=(action "uploadStarted")
-                uploadFinished=(action "uploadFinished")
-                uploadSuccess=(action "uploadSuccess")
-                uploadFailed=(action "uploadFailed")
-                listenTo="themeUploader"}}
+            <GhFileUploader
+                @url={{this.uploadUrl}}
+                @paramName="file"
+                @accept={{this.accept}}
+                @labelText="Click to select or drag-and-drop your theme zip file here."
+                @validate={{action "validateTheme"}}
+                @uploadStarted={{action "uploadStarted"}}
+                @uploadFinished={{action "uploadFinished"}}
+                @uploadSuccess={{action "uploadSuccess"}}
+                @uploadFailed={{action "uploadFailed"}}
+                @listenTo="themeUploader" />
         {{/if}}
     </div>
 </div>

--- a/app/templates/components/modal-webhook-form.hbs
+++ b/app/templates/components/modal-webhook-form.hbs
@@ -7,81 +7,81 @@
 
 <div class="modal-body">
     <fieldset>
-        {{#gh-form-group errors=this.webhook.errors hasValidated=this.webhook.hasValidated property="name"}}
+        <GhFormGroup @errors={{this.webhook.errors}} @hasValidated={{this.webhook.hasValidated}} @property="name">
             <label for="webhook-name" class="fw6">Name</label>
-            {{gh-text-input
-                value=(readonly this.webhook.name)
-                input=(action (mut this.webhook.name) value="target.value")
-                focus-out=(action "validate" "name" target=this.webhook)
-                id="webhook-name"
-                name="name"
-                class="gh-input mt1"
-                placeholder="Webhook name..."
-                shouldFocus=true
-                autocapitalize="off"
-                autocorrect="off"
-                data-test-input="webhook-name"}}
+            <GhTextInput
+                @value={{readonly this.webhook.name}}
+                @input={{action (mut this.webhook.name) value="target.value"}}
+                @focus-out={{action "validate" "name" target=this.webhook}}
+                @id="webhook-name"
+                @name="name"
+                @class="gh-input mt1"
+                @placeholder="Webhook name..."
+                @shouldFocus={{true}}
+                @autocapitalize="off"
+                @autocorrect="off"
+                data-test-input="webhook-name" />
             <GhErrorMessage @errors={{this.webhook.errors}} @property="name" data-test-error="webhook-name" />
-        {{/gh-form-group}}
+        </GhFormGroup>
     </fieldset>
     <fieldset>
-        {{#gh-form-group errors=this.webhook.errors hasValidated=this.webhook.hasValidated property="event"}}
+        <GhFormGroup @errors={{this.webhook.errors}} @hasValidated={{this.webhook.hasValidated}} @property="event">
             <label for="webhook-event" class="fw6">Event</label>
             <span class="gh-select">
-                {{one-way-select this.webhook.event
-                    options=this.availableEvents
-                    optionValuePath="event"
-                    optionLabelPath="name"
-                    optionTargetPath="event"
-                    groupLabelPath="group"
-                    class="mt1"
-                    includeBlank=true
-                    prompt="Select an event"
-                    update=(action "selectEvent")
-                    id="webhook-event"
-                    name="event"
-                    data-test-select="webhook-event"}}
+                <OneWaySelect @value={{this.webhook.event}}
+                    @options={{this.availableEvents}}
+                    @optionValuePath="event"
+                    @optionLabelPath="name"
+                    @optionTargetPath="event"
+                    @groupLabelPath="group"
+                    @class="mt1"
+                    @includeBlank={{true}}
+                    @prompt="Select an event"
+                    @update={{action "selectEvent"}}
+                    @id="webhook-event"
+                    @name="event"
+                    data-test-select="webhook-event" />
                 {{svg-jar "arrow-down-small"}}
             </span>
             <GhErrorMessage @errors={{this.webhook.errors}} @property="event" data-test-error="webhook-event" />
-        {{/gh-form-group}}
+        </GhFormGroup>
     </fieldset>
     <fieldset>
-        {{#gh-form-group errors=this.webhook.errors hasValidated=this.webhook.hasValidated property="targetUrl"}}
+        <GhFormGroup @errors={{this.webhook.errors}} @hasValidated={{this.webhook.hasValidated}} @property="targetUrl">
             <label for="webhook-targetUrl" class="fw6">Target URL</label>
-            {{gh-text-input
-                value=(readonly this.webhook.targetUrl)
-                input=(action (mut this.webhook.targetUrl) value="target.value")
-                focus-out=(action "validate" "targetUrl" target=this.webhook)
-                id="webhook-targetUrl"
-                name="targetUrl"
-                class="gh-input mt1"
-                placeholder="Webhook target URL..."
-                shouldFocus=true
-                autocapitalize="off"
-                autocorrect="off"
-                data-test-input="webhook-targetUrl"}}
+            <GhTextInput
+                @value={{readonly this.webhook.targetUrl}}
+                @input={{action (mut this.webhook.targetUrl) value="target.value"}}
+                @focus-out={{action "validate" "targetUrl" target=this.webhook}}
+                @id="webhook-targetUrl"
+                @name="targetUrl"
+                @class="gh-input mt1"
+                @placeholder="Webhook target URL..."
+                @shouldFocus={{true}}
+                @autocapitalize="off"
+                @autocorrect="off"
+                data-test-input="webhook-targetUrl" />
             <GhErrorMessage @errors={{this.webhook.errors}} @property="targetUrl" data-test-error="webhook-targetUrl" />
-        {{/gh-form-group}}
+        </GhFormGroup>
     </fieldset>
     {{#if this.config.enableDeveloperExperiments}}
         <fieldset>
-            {{#gh-form-group errors=this.webhook.errors hasValidated=this.webhook.hasValidated property="secret"}}
+            <GhFormGroup @errors={{this.webhook.errors}} @hasValidated={{this.webhook.hasValidated}} @property="secret">
                 <label for="webhook-secret" class="fw6">Secret</label>
-                {{gh-text-input
-                    value=(readonly this.webhook.secret)
-                    oninput=(action (mut this.webhook.secret) value="target.value")
-                    focus-out=(action "validate" "secret" target=this.webhook)
-                    id="webhook-secret"
-                    name="secret"
-                    class="gh-input mt1"
-                    placeholder="Webhook secret..."
-                    shouldFocus=true
-                    autocapitalize="off"
-                    autocorrect="off"
-                    data-test-input="webhook-secret"}}
+                <GhTextInput
+                    @value={{readonly this.webhook.secret}}
+                    @oninput={{action (mut this.webhook.secret) value="target.value"}}
+                    @focus-out={{action "validate" "secret" target=this.webhook}}
+                    @id="webhook-secret"
+                    @name="secret"
+                    @class="gh-input mt1"
+                    @placeholder="Webhook secret..."
+                    @shouldFocus={{true}}
+                    @autocapitalize="off"
+                    @autocorrect="off"
+                    data-test-input="webhook-secret" />
                 <GhErrorMessage @errors={{this.webhook.errors}} @property="secret" data-test-error="webhook-secret" />
-            {{/gh-form-group}}
+            </GhFormGroup>
         </fieldset>
     {{/if}}
     {{#if this.error}}
@@ -99,9 +99,9 @@
     >
         <span>Cancel</span>
     </button>
-    {{gh-task-button this.buttonText
-        successText=this.successText
-        task=this.saveWebhook
-        class="gh-btn gh-btn-green gh-btn-icon"
-        data-test-button="save-webhook"}}
+    <GhTaskButton @buttonText={{this.buttonText}}
+        @successText={{this.successText}}
+        @task={{this.saveWebhook}}
+        @class="gh-btn gh-btn-green gh-btn-icon"
+        data-test-button="save-webhook" />
 </div>

--- a/app/templates/editor.hbs
+++ b/app/templates/editor.hbs
@@ -1,25 +1,25 @@
 {{#if this.post}}
-    {{#gh-editor
-        tagName="section"
-        class="gh-editor gh-view"
+    <GhEditor
+        @tagName="section"
+        @class="gh-editor gh-view"
         as |editor|
-    }}
+    >
         <header class="gh-editor-header br2 pe-none {{editor.headerClass}} {{if this.infoMessage "bg-white"}}">
             <div class="flex items-center pe-auto">
                 {{#if this.ui.isFullScreen}}
                     <div class="{{ui-text "ts"}} h9 br b--lightgrey pl3 pr4 flex items-center br2 br--left {{unless this.infoMessage "bg-white"}}">
-                        {{#link-to (pluralize this.post.displayName) classNames="blue link fw4 flex items-center" data-test-link=(pluralize this.post.displayName)}}
+                        <LinkTo @route={{pluralize this.post.displayName }} @classNames="blue link fw4 flex items-center" data-test-link={{pluralize this.post.displayName}}>
                             {{svg-jar "arrow-left" class="w3 fill-blue mr1 nudge-right--2"}}
                             {{capitalize (pluralize this.post.displayName)}}
-                        {{/link-to}}
+                        </LinkTo>
                     </div>
                 {{/if}}
                 <div class="flex items-center pl4 pr4 f8 nudge-left--1 h9 br2 br--right {{unless this.infoMessage "bg-white"}}">
                     <span class="fw4 midgrey-l2">
-                        {{gh-editor-post-status
-                            post=this.post
-                            isSaving=(or this.autosave.isRunning this.saveTasks.isRunning)
-                        }}
+                        <GhEditorPostStatus
+                            @post={{this.post}}
+                            @isSaving={{or this.autosave.isRunning this.saveTasks.isRunning}}
+                        />
                     </span>
                 </div>
             </div>
@@ -39,20 +39,20 @@
             <section class="view-actions br2 {{unless this.infoMessage "bg-white"}}" style="pointer-events: auto">
                 {{#unless this.post.isNew}}
                     {{#if this.session.user.isContributor}}
-                        {{gh-task-button "Save"
-                            task=this.save
-                            runningText="Saving"
-                            class="gh-btn gh-btn-blue gh-btn-icon contributor-save-button"
-                            data-test-contributor-save=true}}
+                        <GhTaskButton @buttonText="Save"
+                            @task={{this.save}}
+                            @runningText="Saving"
+                            @class="gh-btn gh-btn-blue gh-btn-icon contributor-save-button"
+                            data-test-contributor-save=true />
                     {{else}}
-                        {{gh-publishmenu
-                            post=this.post
-                            postStatus=this.post.status
-                            saveTask=this.save
-                            setSaveType=(action "setSaveType")
-                            onOpen=(action "cancelAutosave")
-                            backgroundTask=this.backgroundLoader
-                            memberCount=this.memberCount}}
+                        <GhPublishmenu
+                            @post={{this.post}}
+                            @postStatus={{this.post.status}}
+                            @saveTask={{this.save}}
+                            @setSaveType={{action "setSaveType"}}
+                            @onOpen={{action "cancelAutosave"}}
+                            @backgroundTask={{this.backgroundLoader}}
+                            @memberCount={{this.memberCount}} />
                     {{/if}}
                 {{/unless}}
 
@@ -66,22 +66,22 @@
             gh-koenig-editor acts as a wrapper around the title input and
             koenig editor canvas to support Ghost-specific editor behaviour
         --}}
-        {{gh-koenig-editor
-            title=(readonly this.post.titleScratch)
-            titlePlaceholder=(concat (capitalize this.post.displayName) " Title")
-            onTitleChange=(action "updateTitleScratch")
-            onTitleBlur=(action (perform this.saveTitle))
-            body=(readonly this.post.scratch)
-            bodyPlaceholder=(concat "Begin writing your " this.post.displayName "...")
-            bodyAutofocus=this.shouldFocusEditor
-            onBodyChange=(action "updateScratch")
-            headerOffset=editor.headerHeight
-            scrollContainerSelector=".gh-koenig-editor"
-            scrollOffsetTopSelector=".gh-editor-header-small"
-            scrollOffsetBottomSelector=".gh-mobile-nav-bar"
-            onEditorCreated=(action "setKoenigEditor")
-            onWordCountChange=(action "updateWordCount")
-        }}
+        <GhKoenigEditor
+            @title={{readonly this.post.titleScratch}}
+            @titlePlaceholder={{concat (capitalize this.post.displayName) " Title"}}
+            @onTitleChange={{action "updateTitleScratch"}}
+            @onTitleBlur={{action (perform this.saveTitle)}}
+            @body={{readonly this.post.scratch}}
+            @bodyPlaceholder={{concat "Begin writing your " this.post.displayName "..."}}
+            @bodyAutofocus={{this.shouldFocusEditor}}
+            @onBodyChange={{action "updateScratch"}}
+            @headerOffset={{editor.headerHeight}}
+            @scrollContainerSelector=".gh-koenig-editor"
+            @scrollOffsetTopSelector=".gh-editor-header-small"
+            @scrollOffsetBottomSelector=".gh-mobile-nav-bar"
+            @onEditorCreated={{action "setKoenigEditor"}}
+            @onWordCountChange={{action "updateWordCount"}}
+        />
 
         <div class="absolute flex items-center br3 bg-white {{if editor.headerClass "right-4 bottom-4" "right-6 bottom-6"}}">
             <div class="midgrey-l2 {{if editor.headerClass "f-supersmall pl2 pr2" "f8 pl4 pr3"}} fw4">
@@ -90,33 +90,33 @@
             <a href="https://ghost.org/faq/using-the-editor/" class="flex {{if editor.headerClass "pa2" "pa3"}}" target="_blank">{{svg-jar "help" class="w4 h4 stroke-midgrey-l2"}}</a>
         </div>
 
-    {{/gh-editor}}
+    </GhEditor>
 
     {{#if this.showDeletePostModal}}
-        {{gh-fullscreen-modal "delete-post"
-            model=(hash post=this.post onSuccess=(route-action 'redirectToContentScreen'))
-            close=(action "toggleDeletePostModal")
-            modifier="action wide"}}
+        <GhFullscreenModal @modal="delete-post"
+            @model={{hash post=this.post onSuccess=(route-action 'redirectToContentScreen')}}
+            @close={{action "toggleDeletePostModal"}}
+            @modifier="action wide" />
     {{/if}}
 
     {{#if this.showLeaveEditorModal}}
-        {{gh-fullscreen-modal "leave-editor"
-            confirm=(action "leaveEditor")
-            close=(action "toggleLeaveEditorModal")
-            modifier="action wide"}}
+        <GhFullscreenModal @modal="leave-editor"
+            @confirm={{action "leaveEditor"}}
+            @close={{action "toggleLeaveEditorModal"}}
+            @modifier="action wide" />
     {{/if}}
 
     {{#if this.showReAuthenticateModal}}
-        {{gh-fullscreen-modal "re-authenticate"
-            close=(action "toggleReAuthenticateModal")
-            modifier="action wide"}}
+        <GhFullscreenModal @modal="re-authenticate"
+            @close={{action "toggleReAuthenticateModal"}}
+            @modifier="action wide" />
     {{/if}}
 
     {{#if this.showEmailPreviewModal}}
-        {{gh-fullscreen-modal "post-email-preview"
-            model=this.post
-            close=(action "toggleEmailPreviewModal")
-            modifier="full-overlay email-preview"}}
+        <GhFullscreenModal @modal="post-email-preview"
+            @model={{this.post}}
+            @close={{action "toggleEmailPreviewModal"}}
+            @modifier="full-overlay email-preview" />
     {{/if}}
 
     {{#if this.showUpgradeModal}}
@@ -132,16 +132,16 @@
         />
     {{/if}}
 
-    {{#liquid-wormhole}}
-        {{gh-post-settings-menu
-            post=this.post
-            showSettingsMenu=this.ui.showSettingsMenu
-            toggleEmailPreviewModal=(action "toggleEmailPreviewModal")
-            deletePost=(action "toggleDeletePostModal")
-            updateSlug=this.updateSlug
-            savePost=this.savePost
-        }}
-    {{/liquid-wormhole}}
+    <LiquidWormhole>
+        <GhPostSettingsMenu
+            @post={{this.post}}
+            @showSettingsMenu={{this.ui.showSettingsMenu}}
+            @toggleEmailPreviewModal={{action "toggleEmailPreviewModal"}}
+            @deletePost={{action "toggleDeletePostModal"}}
+            @updateSlug={{this.updateSlug}}
+            @savePost={{this.savePost}}
+        />
+    </LiquidWormhole>
 {{/if}}
 
 {{outlet}}

--- a/app/templates/editor/edit-loading.hbs
+++ b/app/templates/editor/edit-loading.hbs
@@ -1,5 +1,5 @@
 <div class="gh-view" {{did-insert (action "setMainClass" "gh-main-white" target=this.ui)}}>
     <div class="gh-content">
-        {{gh-loading-spinner}}
+        <GhLoadingSpinner />
     </div>
 </div>

--- a/app/templates/members.hbs
+++ b/app/templates/members.hbs
@@ -47,7 +47,7 @@
         {{#if filteredMembers}}
             {{#unless this.searchText}}
                 <section>
-                    {{gh-members-chart members=members}}
+                    <GhMembersChart @members={{members}} />
                 </section>
             {{/unless}}
         {{/if}}

--- a/app/templates/members/import.hbs
+++ b/app/templates/members/import.hbs
@@ -1,4 +1,4 @@
-{{gh-fullscreen-modal "import-members"
-    close=(action "close")
-    confirm=(action "fetchNewMembers")
-    modifier="action wide"}}
+<GhFullscreenModal @modal="import-members"
+    @close={{action "close"}}
+    @confirm={{action "fetchNewMembers"}}
+    @modifier="action wide" />

--- a/app/templates/pages-loading.hbs
+++ b/app/templates/pages-loading.hbs
@@ -17,11 +17,11 @@
                 @onOrderChange={{action (mut k)}}
             />
 
-            {{#link-to "editor.new" "page" class="gh-btn gh-btn-green" data-test-new-page-button=true}}<span>New page</span>{{/link-to}}
+            <LinkTo @route="editor.new" @model="page" class="gh-btn gh-btn-green" data-test-new-page-button={{true}}><span>New page</span></LinkTo>
         </section>
     </header>
 
     <div class="gh-content">
-        {{gh-loading-list}}
+        <GhLoadingList />
     </div>
 </section>

--- a/app/templates/pages.hbs
+++ b/app/templates/pages.hbs
@@ -17,7 +17,7 @@
                 @onOrderChange={{action "changeOrder"}}
             />
 
-            {{#link-to "editor.new" "page" class="gh-btn gh-btn-green" data-test-new-page-button=true}}<span>New page</span>{{/link-to}}
+            <LinkTo @route="editor.new" @model="page" class="gh-btn gh-btn-green" data-test-new-page-button={{true}}><span>New page</span></LinkTo>
         </section>
     </GhCanvasHeader>
 
@@ -33,33 +33,33 @@
             {{/if}}
 
             {{#each this.postsInfinityModel as |page|}}
-                {{gh-posts-list-item
-                    post=page
-                    data-test-page-id=page.id}}
+                <GhPostsListItem
+                    @post={{page}}
+                    data-test-page-id={{page.id}} />
             {{else}}
                 <li class="no-posts-box">
                     <div class="no-posts">
                         {{#if this.showingAll}}
                             {{svg-jar "pages-placeholder" class="gh-pages-placeholder"}}
                             <h3>You haven't created any pages yet!</h3>
-                            {{#link-to "editor.new" "page" class="gh-btn gh-btn-green gh-btn-lg"}}
+                            <LinkTo @route="editor.new" @model="page" class="gh-btn gh-btn-green gh-btn-lg">
                                 <span>Create a new page</span>
-                            {{/link-to}}
+                            </LinkTo>
                         {{else}}
                             <h3>No pages match the current filter</h3>
-                            {{#link-to "pages" (query-params type=null author=null tag=null) class="gh-btn gh-btn-lg"}}
+                            <LinkTo @route="pages" @query={{hash type=null author=null tag=null}} class="gh-btn gh-btn-lg">
                                 <span>Show all pages</span>
-                            {{/link-to}}
+                            </LinkTo>
                         {{/if}}
                     </div>
                 </li>
             {{/each}}
         </ol>
 
-        {{gh-infinity-loader
-            infinityModel=this.postsInfinityModel
-            scrollable=".gh-main"
-            triggerOffset=1000}}
+        <GhInfinityLoader
+            @infinityModel={{this.postsInfinityModel}}
+            @scrollable=".gh-main"
+            @triggerOffset={{1000}} />
     </section>
 
     {{outlet}}

--- a/app/templates/posts-loading.hbs
+++ b/app/templates/posts-loading.hbs
@@ -17,11 +17,11 @@
                 @onOrderChange={{action (mut k)}}
             />
 
-            {{#link-to "editor.new" "post" class="gh-btn gh-btn-green" data-test-new-post-button=true}}<span>New post</span>{{/link-to}}
+            <LinkTo @route="editor.new" @model="post" class="gh-btn gh-btn-green" data-test-new-post-button={{true}}><span>New post</span></LinkTo>
         </section>
     </header>
 
     <div class="gh-content">
-        {{gh-loading-list}}
+        <GhLoadingList />
     </div>
 </section>

--- a/app/templates/posts.hbs
+++ b/app/templates/posts.hbs
@@ -17,7 +17,7 @@
                 @onOrderChange={{action "changeOrder"}}
             />
 
-            {{#link-to "editor.new" "post" class="gh-btn gh-btn-green" data-test-new-post-button=true}}<span>New post</span>{{/link-to}}
+            <LinkTo @route="editor.new" @model="post" class="gh-btn gh-btn-green" data-test-new-post-button={{true}}><span>New post</span></LinkTo>
         </section>
     </GhCanvasHeader>
 
@@ -33,33 +33,33 @@
             {{/if}}
 
             {{#each this.postsInfinityModel as |post|}}
-                {{gh-posts-list-item
-                    post=post
-                    data-test-post-id=post.id}}
+                <GhPostsListItem
+                    @post={{post}}
+                    data-test-post-id={{post.id}} />
             {{else}}
             <li class="no-posts-box">
                 <div class="no-posts">
                     {{#if this.showingAll}}
                         {{svg-jar "posts-placeholder" class="gh-posts-placeholder"}}
                         <h3>You haven't written any posts yet!</h3>
-                        {{#link-to "editor.new" "post" class="gh-btn gh-btn-green gh-btn-lg"}}
+                        <LinkTo @route="editor.new" @model="post" class="gh-btn gh-btn-green gh-btn-lg">
                             <span>Write a new post</span>
-                        {{/link-to}}
+                        </LinkTo>
                     {{else}}
                         <h3>No posts match the current filter</h3>
-                        {{#link-to "posts" (query-params type=null author=null tag=null) class="gh-btn gh-btn-lg"}}
+                        <LinkTo @route="posts" @query={{hash type=null author=null tag=null}} class="gh-btn gh-btn-lg">
                             <span>Show all posts</span>
-                        {{/link-to}}
+                        </LinkTo>
                     {{/if}}
                 </div>
             </li>
             {{/each}}
         </ol>
 
-        {{gh-infinity-loader
-            infinityModel=this.postsInfinityModel
-            scrollable=".gh-main"
-            triggerOffset=1000}}
+        <GhInfinityLoader
+            @infinityModel={{this.postsInfinityModel}}
+            @scrollable=".gh-main"
+            @triggerOffset={{1000}} />
     </section>
 
     {{outlet}}

--- a/app/templates/reset.hbs
+++ b/app/templates/reset.hbs
@@ -2,36 +2,36 @@
     <div class="gh-flow-content-wrap">
         <section class="gh-flow-content fade-in">
             <form id="reset" class="gh-signin" method="post" novalidate="novalidate" {{action "submit" on="submit"}}>
-                {{#gh-form-group errors=this.errors hasValidated=this.hasValidated property="newPassword"}}
+                <GhFormGroup @errors={{this.errors}} @hasValidated={{this.hasValidated}} @property="newPassword">
                     <span class="gh-input-icon gh-icon-lock">
                         {{svg-jar "lock"}}
-                        {{gh-text-input
-                            type="password"
-                            name="newpassword"
-                            placeholder="Password"
-                            class="password"
-                            autocorrect="off"
-                            shouldFocus=true
-                            value=(readonly this.newPassword)
-                            input=(action (mut this.newPassword) value="target.value")}}
+                        <GhTextInput
+                            @type="password"
+                            @name="newpassword"
+                            @placeholder="Password"
+                            @class="password"
+                            @autocorrect="off"
+                            @shouldFocus={{true}}
+                            @value={{readonly this.newPassword}}
+                            @input={{action (mut this.newPassword) value="target.value"}} />
                     </span>
-                {{/gh-form-group}}
-                {{#gh-form-group errors=this.errors hasValidated=this.hasValidated property="ne2Password"}}
+                </GhFormGroup>
+                <GhFormGroup @errors={{this.errors}} @hasValidated={{this.hasValidated}} @property="ne2Password">
                     <span class="gh-input-icon gh-icon-lock">
                         {{svg-jar "lock"}}
-                        {{gh-text-input
-                            type="password"
-                            name="ne2password"
-                            placeholder="Confirm Password"
-                            class="password"
-                            autocorrect="off"
-                            shouldFocus=true
-                            value=(readonly this.ne2Password)
-                            input=(action (mut this.ne2Password) value="target.value")}}
+                        <GhTextInput
+                            @type="password"
+                            @name="ne2password"
+                            @placeholder="Confirm Password"
+                            @class="password"
+                            @autocorrect="off"
+                            @shouldFocus={{true}}
+                            @value={{readonly this.ne2Password}}
+                            @input={{action (mut this.ne2Password) value="target.value"}} />
                     </span>
-                {{/gh-form-group}}
+                </GhFormGroup>
 
-                {{gh-task-button "Reset Password" task=this.resetPassword class="gh-btn gh-btn-blue gh-btn-block gh-btn-icon" type="submit" autoWidth="false"}}
+                <GhTaskButton @buttonText="Reset Password" @task={{this.resetPassword}} @class="gh-btn gh-btn-blue gh-btn-block gh-btn-icon" @type="submit" @autoWidth="false" />
             </form>
 
             <p class="main-error">{{this.flowErrors}}&nbsp;</p>

--- a/app/templates/settings/code-injection-loading.hbs
+++ b/app/templates/settings/code-injection-loading.hbs
@@ -4,11 +4,11 @@
             Code injection
         </h2>
         <section class="view-actions">
-            {{gh-task-button task=save class="gh-btn gh-btn-blue gh-btn-icon" disabled=true data-test-save-button=true}}
+            <GhTaskButton @task={{save}} @class="gh-btn gh-btn-blue gh-btn-icon" @disabled={{true}} data-test-save-button={{true}} />
         </section>
     </header>
 
     <section class="gh-content">
-        {{gh-loading-spinner}}
+        <GhLoadingSpinner />
     </section>
 </section>

--- a/app/templates/settings/code-injection.hbs
+++ b/app/templates/settings/code-injection.hbs
@@ -4,15 +4,15 @@
             Code injection
         </h2>
         <section class="view-actions">
-            {{gh-task-button task=this.save class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button=true}}
+            <GhTaskButton @task={{this.save}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button={{true}} />
         </section>
     </GhCanvasHeader>
 
     {{#if this.showLeaveSettingsModal}}
-        {{gh-fullscreen-modal "leave-settings"
-            confirm=(action "leaveSettings")
-            close=(action "toggleLeaveSettingsModal")
-            modifier="action wide"}}
+        <GhFullscreenModal @modal="leave-settings"
+            @confirm={{action "leaveSettings"}}
+            @close={{action "toggleLeaveSettingsModal"}}
+            @modifier="action wide" />
     {{/if}}
 
     <section class="view-container">
@@ -27,13 +27,13 @@
                     <div class="form-group settings-code">
                         <label for="ghost-head">Site Header</label>
                         <p>Code here will be injected into the <code>\{{ghost_head}}</code> tag on every page of the site</p>
-                        {{gh-cm-editor this.settings.codeinjectionHead id="ghost-head" class="gh-input settings-code-editor" name="codeInjection[ghost_head]" type="text" update=(action (mut this.settings.codeinjectionHead))}}
+                        <GhCmEditor @value={{this.settings.codeinjectionHead}} @id="ghost-head" @class="gh-input settings-code-editor" @name="codeInjection[ghost_head]" @type="text" @update={{action (mut this.settings.codeinjectionHead)}} />
                     </div>
 
                     <div class="form-group settings-code">
                         <label for="ghost-foot">Site Footer</label>
                         <p>Code here will be injected into the <code>\{{ghost_foot}}</code> tag on every page of the site</p>
-                        {{gh-cm-editor this.settings.codeinjectionFoot id="ghost-foot" class="gh-input settings-code-editor" name="codeInjection[ghost_foot]" type="text" update=(action (mut this.settings.codeinjectionFoot))}}
+                        <GhCmEditor @value={{this.settings.codeinjectionFoot}} @id="ghost-foot" @class="gh-input settings-code-editor" @name="codeInjection[ghost_foot]" @type="text" @update={{action (mut this.settings.codeinjectionFoot)}} />
                     </div>
                 </div>
             </fieldset>

--- a/app/templates/settings/design-loading.hbs
+++ b/app/templates/settings/design-loading.hbs
@@ -4,11 +4,11 @@
             Design
         </h2>
         <section class="view-actions">
-            {{gh-task-button task=save class="gh-btn gh-btn-blue gh-btn-icon" disabled=true}}
+            <GhTaskButton @task={{save}} @class="gh-btn gh-btn-blue gh-btn-icon" @disabled={{true}} />
         </section>
     </header>
 
     <section class="gh-content">
-        {{gh-loading-spinner}}
+        <GhLoadingSpinner />
     </section>
 </section>

--- a/app/templates/settings/design.hbs
+++ b/app/templates/settings/design.hbs
@@ -4,67 +4,67 @@
             Design
         </h2>
         <section class="view-actions">
-            {{gh-task-button task=this.save class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button=true}}
+            <GhTaskButton @task={{this.save}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button={{true}} />
         </section>
     </GhCanvasHeader>
 
     {{#if this.showLeaveSettingsModal}}
-        {{gh-fullscreen-modal "leave-settings"
-            confirm=(action "leaveSettings")
-            close=(action "toggleLeaveSettingsModal")
-            modifier="action wide"}}
+        <GhFullscreenModal @modal="leave-settings"
+            @confirm={{action "leaveSettings"}}
+            @close={{action "toggleLeaveSettingsModal"}}
+            @modifier="action wide" />
     {{/if}}
 
     <section class="view-container">
         <div class="gh-setting-header gh-first-header">Navigation</div>
         <div class="gh-blognav-container pa5 pt6 bg-grouped-table shadow-1 br3">
             <form id="settings-navigation" class="gh-blognav" novalidate="novalidate">
-                {{#sortable-objects sortableObjectList=this.settings.navigation useSwap=false}}
+                <SortableObjects @sortableObjectList={{this.settings.navigation}} @useSwap={{false}}>
                     {{#each this.settings.navigation as |navItem index|}}
-                        {{#draggable-object content=navItem dragHandle=".gh-blognav-grab" isSortable=true}}
-                            {{gh-navitem
-                                navItem=navItem
-                                baseUrl=this.blogUrl
-                                addItem=(action "addNavItem")
-                                deleteItem=(action "deleteNavItem")
-                                updateUrl=(action "updateUrl")
-                                updateLabel=(action "updateLabel")
-                                data-test-navitem=index}}
-                        {{/draggable-object}}
+                        <DraggableObject @content={{navItem}} @dragHandle=".gh-blognav-grab" @isSortable={{true}}>
+                            <GhNavitem
+                                @navItem={{navItem}}
+                                @baseUrl={{this.blogUrl}}
+                                @addItem={{action "addNavItem"}}
+                                @deleteItem={{action "deleteNavItem"}}
+                                @updateUrl={{action "updateUrl"}}
+                                @updateLabel={{action "updateLabel"}}
+                                data-test-navitem={{index}} />
+                        </DraggableObject>
                     {{/each}}
-                {{/sortable-objects}}
-                {{gh-navitem
-                    navItem=this.newNavItem
-                    baseUrl=this.blogUrl
-                    addItem=(action "addNavItem")
-                    updateUrl=(action "updateUrl")
-                    data-test-navitem="new"}}
+                </SortableObjects>
+                <GhNavitem
+                    @navItem={{this.newNavItem}}
+                    @baseUrl={{this.blogUrl}}
+                    @addItem={{action "addNavItem"}}
+                    @updateUrl={{action "updateUrl"}}
+                    data-test-navitem="new" />
             </form>
         </div>
 
         <div class="gh-setting-header">Secondary Navigation</div>
         <div class="gh-blognav-container pa5 pt6 bg-grouped-table shadow-1 br3">
             <form id="secondary-navigation" class="gh-blognav" novalidate="novalidate">
-                {{#sortable-objects sortableObjectList=this.settings.secondaryNavigation useSwap=false}}
+                <SortableObjects @sortableObjectList={{this.settings.secondaryNavigation}} @useSwap={{false}}>
                     {{#each this.settings.secondaryNavigation as |navItem index|}}
-                        {{#draggable-object content=navItem dragHandle=".gh-blognav-grab" isSortable=true}}
-                            {{gh-navitem
-                                navItem=navItem
-                                baseUrl=this.blogUrl
-                                addItem=(action "addNavItem")
-                                deleteItem=(action "deleteNavItem")
-                                updateUrl=(action "updateUrl")
-                                updateLabel=(action "updateLabel")
-                                data-test-navitem=index}}
-                        {{/draggable-object}}
+                        <DraggableObject @content={{navItem}} @dragHandle=".gh-blognav-grab" @isSortable={{true}}>
+                            <GhNavitem
+                                @navItem={{navItem}}
+                                @baseUrl={{this.blogUrl}}
+                                @addItem={{action "addNavItem"}}
+                                @deleteItem={{action "deleteNavItem"}}
+                                @updateUrl={{action "updateUrl"}}
+                                @updateLabel={{action "updateLabel"}}
+                                data-test-navitem={{index}} />
+                        </DraggableObject>
                     {{/each}}
-                {{/sortable-objects}}
-                {{gh-navitem
-                    navItem=this.newSecondaryNavItem
-                    baseUrl=this.blogUrl
-                    addItem=(action "addNavItem")
-                    updateUrl=(action "updateUrl")
-                    data-test-navitem="new"}}
+                </SortableObjects>
+                <GhNavitem
+                    @navItem={{this.newSecondaryNavItem}}
+                    @baseUrl={{this.blogUrl}}
+                    @addItem={{action "addNavItem"}}
+                    @updateUrl={{action "updateUrl"}}
+                    data-test-navitem="new" />
             </form>
         </div>
 
@@ -152,50 +152,50 @@
         <div class="gh-setting-header">Installed Themes</div>
         <div class="gh-themes-container">
 
-            {{gh-theme-table
-                themes=this.themes
-                activateTheme=(action "activateTheme")
-                downloadTheme=(action "downloadTheme")
-                deleteTheme=(action "deleteTheme")}}
+            <GhThemeTable
+                @themes={{this.themes}}
+                @activateTheme={{action "activateTheme"}}
+                @downloadTheme={{action "downloadTheme"}}
+                @deleteTheme={{action "deleteTheme"}} />
 
-            {{#link-to "settings.design.uploadtheme" class="gh-btn gh-btn-green gh-themes-uploadbtn" data-test-upload-theme-button=true}}
+            <LinkTo @route="settings.design.uploadtheme" class="gh-btn gh-btn-green gh-themes-uploadbtn" data-test-upload-theme-button={{true}}>
                 <span>Upload a theme</span>
-            {{/link-to}}
+            </LinkTo>
 
 
             {{#if this.showDeleteThemeModal}}
-                {{gh-fullscreen-modal "delete-theme"
-                    model=(hash
+                <GhFullscreenModal @modal="delete-theme"
+                    @model={{hash
                         theme=this.themeToDelete
                         download=(action "downloadTheme" this.themeToDelete)
-                    )
-                    close=(action "hideDeleteThemeModal")
-                    confirm=(action "deleteTheme")
-                    modifier="action wide"}}
+                    }}
+                    @close={{action "hideDeleteThemeModal"}}
+                    @confirm={{action "deleteTheme"}}
+                    @modifier="action wide" />
             {{/if}}
 
             {{#if this.showThemeWarningsModal}}
-                {{gh-fullscreen-modal "theme-warnings"
-                    model=(hash
+                <GhFullscreenModal @modal="theme-warnings"
+                    @model={{hash
                         title="Activation successful"
                         warnings=this.themeWarnings
                         errors=this.themeErrors
                         canActivate=true
-                    )
-                    close=(action "hideThemeWarningsModal")
-                    modifier="action wide"}}
+                    }}
+                    @close={{action "hideThemeWarningsModal"}}
+                    @modifier="action wide" />
             {{/if}}
 
             {{#if this.showThemeErrorsModal}}
-                {{gh-fullscreen-modal "theme-warnings"
-                    model=(hash
+                <GhFullscreenModal @modal="theme-warnings"
+                    @model={{hash
                         title="Activation failed"
                         errors=this.themeErrors
                         fatalErrors=this.themeFatalErrors
                         canActivate=false
-                    )
-                    close=(action "hideThemeWarningsModal")
-                    modifier="action wide"}}
+                    }}
+                    @close={{action "hideThemeWarningsModal"}}
+                    @modifier="action wide" />
             {{/if}}
         </div>
 
@@ -204,8 +204,8 @@
 
 {{outlet}}
 
-{{gh-tour-item "upload-a-theme"
-    target=".gh-themes-uploadbtn"
-    throbberAttachment="top middle"
-    popoverTriangleClass="bottom"
-}}
+<GhTourItem @throbberId="upload-a-theme"
+    @target=".gh-themes-uploadbtn"
+    @throbberAttachment="top middle"
+    @popoverTriangleClass="bottom"
+/>

--- a/app/templates/settings/design/uploadtheme.hbs
+++ b/app/templates/settings/design/uploadtheme.hbs
@@ -1,7 +1,7 @@
-{{gh-fullscreen-modal "upload-theme"
-    model=(hash
+<GhFullscreenModal @modal="upload-theme"
+    @model={{hash
         themes=themes
         activate=(route-action 'activateTheme')
-    )
-    close=(route-action "cancel")
-    modifier="action wide"}}
+    }}
+    @close={{route-action "cancel"}}
+    @modifier="action wide" />

--- a/app/templates/settings/general-loading.hbs
+++ b/app/templates/settings/general-loading.hbs
@@ -4,11 +4,11 @@
             General settings
         </h2>
         <section class="view-actions">
-            {{gh-task-button "Save settings" task=save class="gh-btn gh-btn-blue gh-btn-icon" disabled=true data-test-save-button=true}}
+            <GhTaskButton @buttonText="Save settings" @task={{this.save}} @class="gh-btn gh-btn-blue gh-btn-icon" @disabled={{true}} data-test-save-button="true" />
         </section>
     </header>
 
     <section class="gh-content">
-        {{gh-loading-spinner}}
+        <GhLoadingSpinner />
     </section>
 </section>

--- a/app/templates/settings/general.hbs
+++ b/app/templates/settings/general.hbs
@@ -5,15 +5,15 @@
             General settings
         </h2>
         <section class="view-actions">
-            {{gh-task-button "Save settings" task=this.save class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button=true}}
+            <GhTaskButton @buttonText="Save settings" @task={{this.save}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button="true" />
         </section>
     </GhCanvasHeader>
 
     {{#if this.showLeaveSettingsModal}}
-        {{gh-fullscreen-modal "leave-settings"
-            confirm=(action "leaveSettings")
-            close=(action "toggleLeaveSettingsModal")
-            modifier="action wide"}}
+        <GhFullscreenModal @modal="leave-settings"
+            @confirm={{action "leaveSettings"}}
+            @close={{action "toggleLeaveSettingsModal"}}
+            @modifier="action wide" />
     {{/if}}
 
     <section class="view-container">
@@ -26,27 +26,27 @@
                     <div class="gh-setting-desc">The details used to identify your publication around the web</div>
                     {{#liquid-if this.pubInfoOpen}}
                     <div class="gh-setting-content-extended">
-                        {{#gh-form-group errors=this.settings.errors hasValidated=this.settings.hasValidated property="title"}}
-                            {{gh-text-input
-                                value=(readonly this.settings.title)
-                                input=(action (mut this.settings.title) value="target.value")
-                                focus-out=(action "validate" "title" target=this.settings)
-                                data-test-title-input=true
-                            }}
+                        <GhFormGroup @errors={{this.settings.errors}} @hasValidated={{this.settings.hasValidated}} @property="title">
+                            <GhTextInput
+                                @value={{readonly this.settings.title}}
+                                @input={{action (mut this.settings.title) value="target.value"}}
+                                @focus-out={{action "validate" "title" target=this.settings}}
+                                data-test-title-input={{true}}
+                            />
                             <GhErrorMessage @errors={{this.settings.errors}} @property="title" />
                             <p>The name of your site</p>
-                        {{/gh-form-group}}
+                        </GhFormGroup>
 
-                        {{#gh-form-group errors=this.settings.errors hasValidated=this.settings.hasValidated property="description" class="description-container"}}
-                            {{gh-text-input
-                                value=(readonly this.settings.description)
-                                input=(action (mut this.settings.description) value="target.value")
-                                focus-out=(action "validate" "description" target=this.settings)
-                                data-test-description-input=true
-                            }}
-                            <GhErrorMessage @errors={{this.settings.errors}} @property="description" />
+                        <GhFormGroup @errors={{this.settings.errors}} @hasValidated={{this.settings.hasValidated}} @property="description" @class="description-container">
+                            <GhTextInput
+                                @value={{readonly this.settings.description}}
+                                @input={{action (mut this.settings.description) value="target.value"}}
+                                @focus-out={{action "validate" "description" target=this.settings}}
+                                data-test-description-input={{true}}
+                            />
+                            <GhErrorMessage @errors={{this.settings.errors}} @property="description"/>
                             <p>Used in your theme, meta data and search results</p>
-                        {{/gh-form-group}}
+                        </GhFormGroup>
                     </div>
                     {{/liquid-if}}
                 </div>
@@ -61,10 +61,10 @@
                     <div class="gh-setting-desc">Set the time and date of your publication, used for all published posts</div>
                     {{#liquid-if this.timezoneOpen}}
                     <div class="gh-setting-content-extended">
-                        {{gh-timezone-select
-                                activeTimezone=this.settings.activeTimezone
-                                availableTimezones=this.availableTimezones
-                                update=(action "setTimezone")}}
+                        <GhTimezoneSelect
+                            @activeTimezone={{this.settings.activeTimezone}}
+                            @availableTimezones={{this.availableTimezones}}
+                            @update={{action "setTimezone"}} />
                     </div>
                     {{/liquid-if}}
                 </div>
@@ -78,16 +78,16 @@
                     <div class="gh-setting-desc">Set the language/locale which is used on your site</div>
                     {{#liquid-if this.defaultLocaleOpen}}
                     <div class="gh-setting-content-extended">
-                        {{#gh-form-group errors=this.settings.errors hasValidated=this.settings.hasValidated property="defaultLocale"}}
-                            {{gh-text-input
-                                value=(readonly this.settings.defaultLocale)
-                                input=(action (mut this.settings.defaultLocale) value="target.value")
-                                focus-out=(action "validate" "defaultLocale" target=this.settings)
-                                data-test-default-locale-input=true
-                            }}
+                        <GhFormGroup @errors={{this.settings.errors}} @hasValidated={{this.settings.hasValidated}} @property="defaultLocale">
+                            <GhTextInput
+                                @value={{readonly this.settings.defaultLocale}}
+                                @input={{action (mut this.settings.defaultLocale) value="target.value"}}
+                                @focus-out={{action "validate" "defaultLocale" target=this.settings}}
+                                data-test-default-locale-input={{true}}
+                            />
                             <GhErrorMessage @errors={{this.settings.errors}} @property="defaultLocale" />
                             <p>Default: English (<strong>en</strong>); you can add translation files to your theme for <a href="https://ghost.org/docs/api/handlebars-themes/helpers/translate/" target="_blank" rel="noopener">any language</a></p>
-                        {{/gh-form-group}}
+                        </GhFormGroup>
                     </div>
                     {{/liquid-if}}
                 </div>
@@ -100,12 +100,12 @@
         <div class="gh-setting-header">Publication identity</div>
         <div class="flex flex-column br3 shadow-1 bg-grouped-table pa5">
             <div class="gh-setting-first" data-test-setting="icon">
-                {{#gh-uploader
-                    extensions=this.iconExtensions
-                    paramsHash=(hash purpose="icon")
-                    onComplete=(action "imageUploaded" "icon")
+                <GhUploader
+                    @extensions={{this.iconExtensions}}
+                    @paramsHash={{hash purpose="icon"}}
+                    @onComplete={{action "imageUploaded" "icon"}}
                     as |uploader|
-                }}
+                >
                 <div class="gh-setting-content">
                     <div class="gh-setting-title">Publication icon</div>
                     <div class="gh-setting-desc">A square, social icon used in the UI of your publication, at least 60x60px</div>
@@ -127,17 +127,17 @@
                         </button>
                     {{/if}}
                     <div style="display:none">
-                        {{gh-file-input multiple=false action=uploader.setFiles accept=this.iconMimeTypes data-test-file-input="icon"}}
+                        <GhFileInput @multiple={{false}} @action={{uploader.setFiles}} @accept={{this.iconMimeTypes}} data-test-file-input="icon" />
                     </div>
                 </div>
-                {{/gh-uploader}}
+                </GhUploader>
             </div>
             <div class="gh-setting" data-test-setting="logo">
-                {{#gh-uploader
-                    extensions=this.imageExtensions
-                    onComplete=(action "imageUploaded" "logo")
+                <GhUploader
+                    @extensions={{this.imageExtensions}}
+                    @onComplete={{action "imageUploaded" "logo"}}
                     as |uploader|
-                }}
+                >
                 <div class="gh-setting-content">
                     <div class="gh-setting-title">Publication logo</div>
                     <div class="gh-setting-desc">The primary logo for your brand displayed across your theme, should be transparent and at least 600px x 72px</div>
@@ -159,10 +159,10 @@
                         </button>
                     {{/if}}
                     <div style="display:none">
-                        {{gh-file-input multiple=false action=uploader.setFiles accept=this.imageMimeTypes data-test-file-input="logo"}}
+                        <GhFileInput @multiple={{false}} @action={{uploader.setFiles}} @accept={{this.imageMimeTypes}} data-test-file-input="logo" />
                     </div>
                 </div>
-                {{/gh-uploader}}
+                </GhUploader>
             </div>
             {{#if this.config.enableDeveloperExperiments}}
                 <div class="gh-setting" data-test-setting="brand-color">
@@ -171,30 +171,30 @@
                         <div class="gh-setting-desc">Primary color used in your publication theme</div>
                     </div>
                     <div class="gh-setting-action">
-                        {{#gh-form-group errors=settings.errors hasValidated=settings.hasValidated property="brandColor" class="input-color-form-group"}}
+                        <GhFormGroup @errors={{settings.errors}} @hasValidated={{settings.hasValidated}} @property="brandColor" @class="input-color-form-group">
                             <div class="input-color">
-                                {{gh-text-input
-                                    name="brand-color"
-                                    placeholder="abcdef"
-                                    autocorrect="off"
-                                    maxlength="6"
-                                    focus-out=(action "validateBrandColor")
-                                    value=brandColor
-                                    data-test-brand-color-input=true
-                                }}
+                                <GhTextInput
+                                    @name="brand-color"
+                                    @placeholder="abcdef"
+                                    @autocorrect="off"
+                                    @maxlength="6"
+                                    @focus-out={{action "validateBrandColor"}}
+                                    @value={{brandColor}}
+                                    data-test-brand-color-input={{true}}
+                                />
                                 <div class="color-box" style={{this.backgroundStyle}}></div>
                             </div>
-                            {{gh-error-message errors=settings.errors property="brandColor" data-test-brandColor-error=true}}
-                        {{/gh-form-group}}
+                            <GhErrorMessage @errors={{settings.errors}} @property="brandColor" data-test-brandColor-error={{true}} />
+                        </GhFormGroup>
                     </div>
                 </div>
             {{/if}}
             <div class="gh-setting-last" data-test-setting="coverImage">
-                {{#gh-uploader
-                    extensions=this.imageExtensions
-                    onComplete=(action "imageUploaded" "coverImage")
+                <GhUploader
+                    @extensions={{this.imageExtensions}}
+                    @onComplete={{action "imageUploaded" "coverImage"}}
                     as |uploader|
-                }}
+                >
                 <div class="gh-setting-content">
                     <div class="gh-setting-title">Publication cover</div>
                     <div class="gh-setting-desc">An optional large background image for your site</div>
@@ -216,10 +216,10 @@
                         </button>
                     {{/if}}
                     <div style="display:none">
-                        {{gh-file-input multiple=false action=uploader.setFiles accept=this.imageMimeTypes data-test-file-input="coverImage"}}
+                        <GhFileInput @multiple={{false}} @action={{uploader.setFiles}} @accept={{this.imageMimeTypes}} data-test-file-input="coverImage" />
                     </div>
                 </div>
-                {{/gh-uploader}}
+                </GhUploader>
             </div>
         </div>
 
@@ -239,32 +239,32 @@
                     <div class="gh-setting-content-extended">
                         <div class="flex flex-column flex-row-ns">
                             <div class="flex-basis-1-2-m flex-basis-2-3-l mr5">
-                                {{#gh-form-group errors=this.settings.errors hasValidated=this.settings.hasValidated property="metaTitle"}}
+                                <GhFormGroup @errors={{this.settings.errors}} @hasValidated={{this.settings.hasValidated}} @property="metaTitle">
                                     <label for="metaTitle">Meta title</label>
-                                    {{gh-text-input
-                                        id="metaTitle"
-                                        type="text"
-                                        placeholder=(truncate this.settings.title 70)
-                                        value=(readonly this.settings.metaTitle)
-                                        input=(action (mut this.settings.metaTitle) value="target.value")
+                                    <GhTextInput
+                                        @id="metaTitle"
+                                        @type="text"
+                                        @placeholder={{truncate this.settings.title 70}}
+                                        @value={{readonly this.settings.metaTitle}}
+                                        @input={{action (mut this.settings.metaTitle) value="target.value"}}
                                         data-test-input="metaTitle"
-                                    }}
+                                    />
                                     <GhErrorMessage @errors={{this.settings.errors}} @property="metaTitle" data-test-error="metaTitle" />
                                     <p>Recommended: <b>70</b> characters. You’ve used <b>{{gh-count-down-characters this.settings.metaTitle 70}}</b></p>
-                                {{/gh-form-group}}
-                                {{#gh-form-group errors=this.settings.errors hasValidated=this.settings.hasValidated property="metaDescription"}}
+                                </GhFormGroup>
+                                <GhFormGroup @errors={{this.settings.errors}} @hasValidated={{this.settings.hasValidated}} @property="metaDescription">
                                     <label for="metaDescription">Meta description</label>
-                                    {{gh-textarea
-                                        id="metaDescription"
-                                        type="text"
-                                        placeholder=(truncate this.settings.description 300)
-                                        value=(readonly this.settings.metaDescription)
-                                        input=(action (mut this.settings.metaDescription) value="target.value")
+                                    <GhTextarea
+                                        @id="metaDescription"
+                                        @type="text"
+                                        @placeholder={{truncate this.settings.description 300}}
+                                        @value={{readonly this.settings.metaDescription}}
+                                        @input={{action (mut this.settings.metaDescription) value="target.value"}}
                                         data-test-input="metaDescription"
-                                    }}
+                                    />
                                     <GhErrorMessage @errors={{this.settings.errors}} @property="metaDescription" data-test-error="metaDescription" />
                                     <p>Recommended: <b>156</b> characters. You’ve used <b>{{gh-count-down-characters this.settings.metaDescription 156}}</b></p>
-                                {{/gh-form-group}}
+                                </GhFormGroup>
                             </div>
                             <div class="flex-basis-1-2-m flex-basis-1-3-l">
                                 <label>Search engine result preview</label>
@@ -292,38 +292,38 @@
                     <div class="gh-setting-content-extended">
                         <div class="flex flex-column flex-row-ns">
                             <div class="flex-basis-1-2-m flex-basis-2-3-l mr5 nudge-top--7">
-                                {{#gh-form-group}}
-                                    {{gh-image-uploader-with-preview
-                                        image=this.settings.twitterImage
-                                        text="Add Twitter image"
-                                        allowUnsplash=true
-                                        update=(action (mut this.settings.twitterImage))
-                                        remove=(action (mut this.settings.twitterImage ""))
-                                    }}
-                                {{/gh-form-group}}
-                                {{#gh-form-group errors=this.settings.errors hasValidated=this.settings.hasValidated property="twitterTitle"}}
+                                <GhFormGroup>
+                                    <GhImageUploaderWithPreview
+                                        @image={{this.settings.twitterImage}}
+                                        @text="Add Twitter image"
+                                        @allowUnsplash={{true}}
+                                        @update={{action (mut this.settings.twitterImage)}}
+                                        @remove={{action (mut this.settings.twitterImage "")}}
+                                    />
+                                </GhFormGroup>
+                                <GhFormGroup @errors={{this.settings.errors}} @hasValidated={{this.settings.hasValidated}} @property="twitterTitle">
                                     <label for="twitterTitle">Twitter title</label>
-                                    {{gh-text-input
-                                        id="twitterTitle"
-                                        type="text"
-                                        placeholder=(truncate this.settings.title 70)
-                                        value=(readonly this.settings.twitterTitle)
-                                        input=(action (mut this.settings.twitterTitle) value="target.value")
+                                    <GhTextInput
+                                        @id="twitterTitle"
+                                        @type="text"
+                                        @placeholder={{truncate this.settings.title 70}}
+                                        @value={{readonly this.settings.twitterTitle}}
+                                        @input={{action (mut this.settings.twitterTitle) value="target.value"}}
                                         data-test-input="twitterTitle"
-                                    }}
+                                    />
                                     <GhErrorMessage @errors={{this.settings.errors}} @property="twitterTitle" data-test-error="twitterTitle" />
-                                {{/gh-form-group}}
-                                {{#gh-form-group errors=this.settings.errors hasValidated=this.settings.hasValidated property="twitterDescription"}}
+                                </GhFormGroup>
+                                <GhFormGroup @errors={{this.settings.errors}} @hasValidated={{this.settings.hasValidated}} @property="twitterDescription">
                                     <label for="twitterDescription">Twitter description</label>
-                                    {{gh-textarea
-                                        id="twitterDescription"
-                                        placeholder=(truncate this.settings.description 300)
-                                        value=(readonly this.settings.twitterDescription)
-                                        input=(action (mut this.settings.twitterDescription) value="target.value")
+                                    <GhTextarea
+                                        @id="twitterDescription"
+                                        @placeholder={{truncate this.settings.description 300}}
+                                        @value={{readonly this.settings.twitterDescription}}
+                                        @input={{action (mut this.settings.twitterDescription) value="target.value"}}
                                         data-test-input="twitterDescription"
-                                    }}
+                                    />
                                     <GhErrorMessage @errors={{this.settings.errors}} @property="twitterDescription" data-test-error="twitterDescription" />
-                                {{/gh-form-group}}
+                                </GhFormGroup>
                             </div>
                             <div class="flex-basis-1-2-m flex-basis-1-3-l nt4-ns">
                                 <label>Preview</label>
@@ -362,38 +362,38 @@
                     <div class="gh-setting-content-extended">
                         <div class="flex flex-column flex-row-ns">
                             <div class="flex-basis-1-2-m flex-basis-2-3-l mr5 nudge-top--7">
-                                {{#gh-form-group}}
-                                    {{gh-image-uploader-with-preview
-                                        image=this.settings.ogImage
-                                        text="Add Facebook image"
-                                        allowUnsplash=true
-                                        update=(action (mut this.settings.ogImage))
-                                        remove=(action (mut this.settings.ogImage ""))
-                                    }}
-                                {{/gh-form-group}}
-                                {{#gh-form-group errors=this.settings.errors hasValidated=this.settings.hasValidated property="ogTitle"}}
+                                <GhFormGroup>
+                                    <GhImageUploaderWithPreview
+                                        @image={{this.settings.ogImage}}
+                                        @text="Add Facebook image"
+                                        @allowUnsplash={{true}}
+                                        @update={{action (mut this.settings.ogImage)}}
+                                        @remove={{action (mut this.settings.ogImage "")}}
+                                    />
+                                </GhFormGroup>
+                                <GhFormGroup @errors={{this.settings.errors}} @hasValidated={{this.settings.hasValidated}} @property="ogTitle">
                                     <label for="ogTitle">Facebook title</label>
-                                    {{gh-text-input
-                                        id="ogTitle"
-                                        type="text"
-                                        placeholder=(truncate this.settings.title 70)
-                                        value=(readonly this.settings.ogTitle)
-                                        input=(action (mut this.settings.ogTitle) value="target.value")
+                                    <GhTextInput
+                                        @id="ogTitle"
+                                        @type="text"
+                                        @placeholder={{truncate this.settings.title 70}}
+                                        @value={{readonly this.settings.ogTitle}}
+                                        @input={{action (mut this.settings.ogTitle) value="target.value"}}
                                         data-test-input="ogTitle"
-                                    }}
+                                    />
                                     <GhErrorMessage @errors={{this.settings.errors}} @property="ogTitle" data-test-error="ogTitle" />
-                                {{/gh-form-group}}
-                                {{#gh-form-group errors=this.settings.errors hasValidated=this.settings.hasValidated property="ogDescription"}}
+                                </GhFormGroup>
+                                <GhFormGroup @errors={{this.settings.errors}} @hasValidated={{this.settings.hasValidated}} @property="ogDescription">
                                     <label for="ogDescription">Facebook description</label>
-                                    {{gh-textarea
-                                        id="ogDescription"
-                                        placeholder=(truncate this.settings.description 300)
-                                        value=(readonly this.settings.ogDescription)
-                                        input=(action (mut this.settings.ogDescription) value="target.value")
+                                    <GhTextarea
+                                        @id="ogDescription"
+                                        @placeholder={{truncate this.settings.description 300}}
+                                        @value={{readonly this.settings.ogDescription}}
+                                        @input={{action (mut this.settings.ogDescription) value="target.value"}}
                                         data-test-input="ogDescription"
-                                    }}
+                                    />
                                     <GhErrorMessage @errors={{this.settings.errors}} @property="ogDescription" data-test-error="ogDescription" />
-                                {{/gh-form-group}}
+                                </GhFormGroup>
                             </div>
                             <div class="flex-basis-1-2-m flex-basis-1-3-l nt4-ns">
                                 <label>Preview</label>
@@ -427,32 +427,32 @@
                     <div class="gh-setting-desc">Link your social accounts for full structured data and rich card support</div>
                     {{#liquid-if this.socialOpen}}
                     <div class="gh-setting-content-extended">
-                        {{#gh-form-group errors=this.settings.errors hasValidated=this.settings.hasValidated property="facebook"}}
-                            {{gh-text-input
-                                type="url"
-                                placeholder="https://www.facebook.com/ghost"
-                                autocorrect="off"
-                                value=(readonly this.settings.facebook)
-                                input=(action (mut this._scratchFacebook) value="target.value")
-                                focus-out=(action "validateFacebookUrl")
-                                data-test-facebook-input=true
-                            }}
+                        <GhFormGroup @errors={{this.settings.errors}} @hasValidated={{this.settings.hasValidated}} @property="facebook">
+                            <GhTextInput
+                                @type="url"
+                                @placeholder="https://www.facebook.com/ghost"
+                                @autocorrect="off"
+                                @value={{readonly this.settings.facebook}}
+                                @input={{action (mut this._scratchFacebook) value="target.value"}}
+                                @focus-out={{action "validateFacebookUrl"}}
+                                data-test-facebook-input={{true}}
+                            />
                             <GhErrorMessage @errors={{this.settings.errors}} @property="facebook" data-test-facebook-error=true />
                             <p>URL of your publication's Facebook Page</p>
-                        {{/gh-form-group}}
-                        {{#gh-form-group errors=this.settings.errors hasValidated=this.settings.hasValidated property="twitter"}}
-                            {{gh-text-input
-                                type="url"
-                                placeholder="https://twitter.com/ghost"
-                                autocorrect="off"
-                                value=(readonly this.settings.twitter)
-                                input=(action (mut this._scratchTwitter) value="target.value")
-                                focus-out=(action "validateTwitterUrl")
-                                data-test-twitter-input=true
-                            }}
+                        </GhFormGroup>
+                        <GhFormGroup @errors={{this.settings.errors}} @hasValidated={{this.settings.hasValidated}} @property="twitter">
+                            <GhTextInput
+                                @type="url"
+                                @placeholder="https://twitter.com/ghost"
+                                @autocorrect="off"
+                                @value={{readonly this.settings.twitter}}
+                                @input={{action (mut this._scratchTwitter) value="target.value"}}
+                                @focus-out={{action "validateTwitterUrl"}}
+                                data-test-twitter-input={{true}}
+                            />
                             <GhErrorMessage @errors={{this.settings.errors}} @property="twitter" data-test-twitter-error=true />
                             <p>URL of your publication's Twitter profile</p>
-                        {{/gh-form-group}}
+                        </GhFormGroup>
                     </div>
                     {{/liquid-if}}
                 </div>
@@ -481,17 +481,17 @@
 
                     {{#if this.settings.isPrivate}}
                         <div class="gh-setting-content-extended">
-                            {{#gh-form-group errors=this.settings.errors hasValidated=this.settings.hasValidated property="password"}}
-                                {{gh-text-input
-                                    value=(readonly this.settings.password)
-                                    name="general[password]"
-                                    focus-out=(action "validate" "password" target=this.settings)
-                                    input=(action (mut this.settings.password) value="target.value")
-                                    data-test-password-input=true
-                                }}
+                            <GhFormGroup @errors={{this.settings.errors}} @hasValidated={{this.settings.hasValidated}} @property="password">
+                                <GhTextInput
+                                    @value={{readonly this.settings.password}}
+                                    @name="general[password]"
+                                    @focus-out={{action "validate" "password" target=this.settings}}
+                                    @input={{action (mut this.settings.password) value="target.value"}}
+                                    data-test-password-input={{true}}
+                                />
                                 <GhErrorMessage @errors={{this.settings.errors}} @property="password" data-test-password-error=true />
                                 <p>Set the password for this site</p>
-                            {{/gh-form-group}}
+                            </GhFormGroup>
                         </div>
                     {{/if}}
                 </div>

--- a/app/templates/settings/integration-loading.hbs
+++ b/app/templates/settings/integration-loading.hbs
@@ -6,6 +6,6 @@
     </header>
 
     <div class="gh-content">
-        {{gh-loading-spinner}}
+        <GhLoadingSpinner />
     </div>
 </section>

--- a/app/templates/settings/integration.hbs
+++ b/app/templates/settings/integration.hbs
@@ -2,12 +2,12 @@
     <form class="mb15" {{action (perform "save") on="submit"}}>
         <GhCanvasHeader class="gh-canvas-header">
             <h2 class="gh-canvas-title" data-test-screen-title>
-                {{#link-to "settings.integrations" data-test-link="integrations-back"}}Integrations{{/link-to}}
+                <LinkTo @route="settings.integrations" data-test-link="integrations-back">Integrations</LinkTo>
                 <span>{{svg-jar "arrow-right"}}</span>
                 {{this.integration.name}}
             </h2>
             <section class="view-actions">
-                {{gh-task-button task=this.save class="gh-btn gh-btn-blue gh-btn-icon" data-test-button="save"}}
+                <GhTaskButton @task={{this.save}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-button="save" />
             </section>
         </GhCanvasHeader>
 
@@ -17,17 +17,17 @@
                 <div class="flex flex-column items-start">
                     <label class="mb1">Icon</label>
                     <figure class="relative flex items-center h-100 ma0 br4 hide-child ba b--whitegrey-d2 pa8 bg-white" style={{this.iconImageStyle}}>
-                        {{#aspect-ratio-box class="flex items-center h-100" ratio="1/1" base="height"}}
+                        <AspectRatioBox @class="flex items-center h-100" @ratio="1/1" @base="height">
                             {{#unless this.integration.iconImage}}
                                 {{svg-jar "integration" class="w11 h11"}}
                             {{/unless}}
-                        {{/aspect-ratio-box}}
+                        </AspectRatioBox>
 
-                        {{#gh-uploader
-                            extensions=this.imageExtensions
-                            onComplete=(action "setIconImage")
+                        <GhUploader
+                            @extensions={{this.imageExtensions}}
+                            @onComplete={{action "setIconImage"}}
                             as |uploader|
-                        }}
+                        >
                             {{#if uploader.isUploading}}
                                 <div class="absolute top-0 left-0 w-100 h-100 br4 bg-black-70 flex items-center">
                                     {{uploader.progressBar}}
@@ -42,54 +42,53 @@
                                 </button>
                             {{/if}}
                             <div style="display:none">
-                                {{gh-file-input
-                                    name="iconImage"
-                                    multiple=false
-                                    action=uploader.setFiles
-                                    accept=this.imageMimeTypes
-                                    data-test-file-input="icon"}}
+                                <GhFileInput
+                                    @name="iconImage"
+                                    @multiple={{false}}
+                                    @action={{uploader.setFiles}}
+                                    @accept={{this.imageMimeTypes}} data-test-file-input="icon" />
                             </div>
-                        {{/gh-uploader}}
+                        </GhUploader>
                     </figure>
                 </div>
                 <div class="flex-auto ml12">
-                    {{#gh-validation-status-container
-                        class="flex flex-column w-100 mr3"
-                        errors=this.integration.errors
-                        hasValidated=this.integration.hasValidated
-                        property="name"
-                    }}
+                    <GhValidationStatusContainer
+                        @class="flex flex-column w-100 mr3"
+                        @errors={{this.integration.errors}}
+                        @hasValidated={{this.integration.hasValidated}}
+                        @property="name"
+                    >
                         <label for="integration_name">Name</label>
-                        {{gh-text-input
-                            id="integration_name"
-                            class="gh-input mt1 mb1"
-                            type="text"
-                            value=(readonly this.integration.name)
-                            input=(action (mut this.integration.name) value="target.value")
-                            focus-out=(action "validate" "name" target=this.integration)
+                        <GhTextInput
+                            @id="integration_name"
+                            @class="gh-input mt1 mb1"
+                            @type="text"
+                            @value={{readonly this.integration.name}}
+                            @input={{action (mut this.integration.name) value="target.value"}}
+                            @focus-out={{action "validate" "name" target=this.integration}}
                             data-test-input="name"
-                        }}
+                        />
                         <GhErrorMessage @errors={{this.integration.errors}} @property="name" data-test-error="name" class="ma0" />
-                    {{/gh-validation-status-container}}
+                    </GhValidationStatusContainer>
 
-                    {{#gh-validation-status-container
-                        class="flex flex-column w-100 mr3"
-                        errors=this.integration.errors
-                        hasValidated=this.integration.hasValidated
-                        property="decription"
-                    }}
+                    <GhValidationStatusContainer
+                        @class="flex flex-column w-100 mr3"
+                        @errors={{this.integration.errors}}
+                        @hasValidated={{this.integration.hasValidated}}
+                        @property="decription"
+                    >
                         <label for="integration_description" class="mt3">Description</label>
-                        {{gh-text-input
-                            id="integration_description"
-                            class="gh-input mt1"
-                            type="text"
-                            value=(readonly this.integration.description)
-                            input=(action (mut this.integration.description) value="target.value")
-                            focus-out=(action "validate" "description" target=this.integration)
+                        <GhTextInput
+                            @id="integration_description"
+                            @class="gh-input mt1"
+                            @type="text"
+                            @value={{readonly this.integration.description}}
+                            @input={{action (mut this.integration.description) value="target.value"}}
+                            @focus-out={{action "validate" "description" target=this.integration}}
                             data-test-input="description"
-                        }}
+                        />
                         <GhErrorMessage @errors={{this.integration.errors}} @property="description" data-test-error="description" class="ma0" />
-                    {{/gh-validation-status-container}}
+                    </GhValidationStatusContainer>
                 </div>
             </div>
             <table class="ma0 mt5" style="table-layout: fixed">
@@ -183,9 +182,9 @@
                         <td class="pa2 pl3" data-test-text="last-triggered">{{or webhook.lastTriggeredAtUTC "Not triggered"}}</td>
                         <td class="w1 pa2 pl3 nowrap">
                             <div class="child flex items-center">
-                                {{#link-to "settings.integration.webhooks.edit" this.integration webhook data-test-link="edit-webhook"}}
+                                <LinkTo @route="settings.integration.webhooks.edit" @models={{array this.integration webhook}} data-test-link="edit-webhook">
                                     {{svg-jar "pen" class="w6 h6 fill-midgrey pa1 mr1"}}
-                                {{/link-to}}
+                                </LinkTo>
                                 <button {{action "confirmWebhookDeletion" webhook}} data-test-button="delete-webhook">
                                     {{svg-jar "trash" class="w6 fill-red pa1"}}
                                 </button>
@@ -199,13 +198,12 @@
                             <p class="ma0 pa0 tc midgrey lh-title mt2">
                                 No webhooks configured
                             </p>
-                            {{#link-to "settings.integration.webhooks.new" this.integration classNames="flex items-center"
-                            data-test-link="add-webhook"}}
+                            <LinkTo @route="settings.integration.webhooks.new" @model={{this.integration}} @classNames="flex items-center" data-test-link="add-webhook">
                             <div class="flex items-center pa2 pt1">
                                 {{svg-jar "add" class="w3 h3 fill-blue-d1"}}
                                 <span class="ml1 blue">Add webhook</span>
                             </div>
-                            {{/link-to}}
+                            </LinkTo>
                         </div>
                     </td>
                 </tr>
@@ -215,13 +213,12 @@
             <tfoot class="bt b--lightgrey">
                 <tr class="new-webhook-cell">
                     <td colspan="5">
-                        {{#link-to "settings.integration.webhooks.new" this.integration classNames="flex items-center"
-                        data-test-link="add-webhook"}}
+                        <LinkTo @route="settings.integration.webhooks.new" @model={{this.integration}} @classNames="flex items-center" data-test-link="add-webhook">
                         <div class="pa3 f7">
                             {{svg-jar "add" class="w3 h3 fill-blue-d1"}}
                             <span class="ml1 blue">Add webhook</span>
                         </div>
-                        {{/link-to}}
+                        </LinkTo>
                     </td>
                 </tr>
             </tfoot>
@@ -234,24 +231,24 @@
 </section>
 
 {{#if this.showUnsavedChangesModal}}
-    {{gh-fullscreen-modal "leave-settings"
-        confirm=(action "leaveScreen")
-        close=(action "toggleUnsavedChangesModal")
-        modifier="action wide"}}
+    <GhFullscreenModal @modal="leave-settings"
+        @confirm={{action "leaveScreen"}}
+        @close={{action "toggleUnsavedChangesModal"}}
+        @modifier="action wide" />
 {{/if}}
 
 {{#if this.showDeleteIntegrationModal}}
-    {{gh-fullscreen-modal "delete-integration"
-        confirm=(action "deleteIntegration")
-        close=(action "cancelIntegrationDeletion")
-        modifier="action wide"}}
+    <GhFullscreenModal @modal="delete-integration"
+        @confirm={{action "deleteIntegration"}}
+        @close={{action "cancelIntegrationDeletion"}}
+        @modifier="action wide" />
 {{/if}}
 
 {{#if this.webhookToDelete}}
-    {{gh-fullscreen-modal "delete-webhook"
-        confirm=(action "deleteWebhook")
-        close=(action "cancelWebhookDeletion")
-        modifier="action wide"}}
+    <GhFullscreenModal @modal="delete-webhook"
+        @confirm={{action "deleteWebhook"}}
+        @close={{action "cancelWebhookDeletion"}}
+        @modifier="action wide" />
 {{/if}}
 
 {{outlet}}

--- a/app/templates/settings/integration/webhooks/edit.hbs
+++ b/app/templates/settings/integration/webhooks/edit.hbs
@@ -1,5 +1,5 @@
-{{gh-fullscreen-modal "webhook-form"
-    model=this.webhook
-    confirm=(action "save")
-    close=(action "cancel")
-    modifier="action wide"}}
+<GhFullscreenModal @modal="webhook-form"
+    @model={{this.webhook}}
+    @confirm={{action "save"}}
+    @close={{action "cancel"}}
+    @modifier="action wide" />

--- a/app/templates/settings/integration/webhooks/new.hbs
+++ b/app/templates/settings/integration/webhooks/new.hbs
@@ -1,5 +1,5 @@
-{{gh-fullscreen-modal "webhook-form"
-    model=this.webhook
-    confirm=(action "save")
-    close=(action "cancel")
-    modifier="action wide"}}
+<GhFullscreenModal @modal="webhook-form"
+    @model={{this.webhook}}
+    @confirm={{action "save"}}
+    @close={{action "cancel"}}
+    @modifier="action wide" />

--- a/app/templates/settings/integrations.hbs
+++ b/app/templates/settings/integrations.hbs
@@ -62,7 +62,7 @@
         <span class="apps-grid-title pb1">Built-in integrations</span>
         <div class="apps-grid">
             <div class="apps-grid-cell" data-test-app="zapier">
-                {{#link-to "settings.integrations.zapier" data-test-link="zapier"}}
+                <LinkTo @route="settings.integrations.zapier" data-test-link="zapier">
                 <article class="apps-card-app">
                     <div class="apps-card-left">
                         <figure class="apps-card-app-icon" style="background-image:url(assets/img/zapiericon.png);background-size:36px;"></figure>
@@ -78,11 +78,11 @@
                         </div>
                     </div>
                 </article>
-                {{/link-to}}
+                </LinkTo>
             </div>
 
             <div class="apps-grid-cell" data-test-app="slack">
-                {{#link-to "settings.integrations.slack" data-test-link="slack"}}
+                <LinkTo @route="settings.integrations.slack" data-test-link="slack">
                 <article class="apps-card-app">
                     <div class="apps-card-left">
                         <figure class="apps-card-app-icon" style="background-image:url(assets/img/slackicon.png); background-size: 36px;"></figure>
@@ -102,11 +102,11 @@
                         </div>
                     </div>
                 </article>
-                {{/link-to}}
+                </LinkTo>
             </div>
 
             <div class="apps-grid-cell" data-test-app="amp">
-                {{#link-to "settings.integrations.amp" data-test-link="amp"}}
+                <LinkTo @route="settings.integrations.amp" data-test-link="amp">
                 <article class="apps-card-app">
                     <div class="apps-card-left">
                         <figure class="apps-card-app-icon" style="background-image:url(assets/img/ampicon.png); background-size: 36px;"></figure>
@@ -126,11 +126,11 @@
                         </div>
                     </div>
                 </article>
-                {{/link-to}}
+                </LinkTo>
             </div>
 
             <div class="apps-grid-cell" data-test-app="unsplash">
-                {{#link-to "settings.integrations.unsplash" data-test-link="unsplash"}}
+                <LinkTo @route="settings.integrations.unsplash" data-test-link="unsplash">
                 <article class="apps-card-app">
                     <div class="apps-card-left">
                         <figure class="apps-card-app-icon" style="background-image:url(assets/icons/unsplash.svg); background-size:30px;"></figure>
@@ -150,7 +150,7 @@
                         </div>
                     </div>
                 </article>
-                {{/link-to}}
+                </LinkTo>
             </div>
 
 
@@ -163,7 +163,7 @@
         <div class="apps-grid">
             {{#each this.integrations as |integration|}}
                 <div class="apps-grid-cell" data-test-custom-integration>
-                    {{#link-to "settings.integration" integration data-test-integration=integration.id}}
+                    <LinkTo @route="settings.integration" @model={{integration}} data-test-integration={{integration.id}}>
                         <article class="apps-card-app">
                             <div class="apps-card-left">
                                 <figure class="apps-card-app-icon flex items-center" style={{integration-icon-style integration}}>
@@ -187,7 +187,7 @@
                                 </div>
                             </div>
                         </article>
-                    {{/link-to}}
+                    </LinkTo>
                 </div>
             {{else}}
                 <div class="flex flex-column justify-center items-center mih30 miw-100" data-test-blank="custom-integrations">
@@ -198,12 +198,12 @@
                             <p class="ma0 pa0 tc midgrey lh-title mt2">
                                 Create your own custom Ghost integrations with dedicated API keys & webhooks
                             </p>
-                            {{#link-to "settings.integrations.new" class="" data-test-button="new-integration"}}
+                            <LinkTo @route="settings.integrations.new" class="" data-test-button="new-integration">
                                 <div class="flex items-center pa2 pt1">
                                     {{svg-jar "add" class="w3 h3 fill-blue-d1"}}
                                     <span class="db ml1 blue nudge-bottom--1">Add custom integration</span>
                                 </div>
-                            {{/link-to}}
+                            </LinkTo>
                         </div>
                     {{/if}}
                 </div>
@@ -211,14 +211,14 @@
 
             {{#if this.integrations}}
             <div class="apps-grid-cell new-integration-cell">
-                {{#link-to "settings.integrations.new" class="" data-test-button="new-integration"}}
+                <LinkTo @route="settings.integrations.new" class="" data-test-button="new-integration">
                 <article class="apps-card-app">
                     <div class="flex items-center">
                         {{svg-jar "add" class="w3 h3 fill-blue-d1"}}
                         <span class="db ml1 blue nudge-bottom--1 fw4">Add custom integration</span>
                     </div>
                 </article>
-                {{/link-to}}
+                </LinkTo>
             </div>
             {{/if}}
         </div>

--- a/app/templates/settings/integrations/amp-loading.hbs
+++ b/app/templates/settings/integrations/amp-loading.hbs
@@ -1,13 +1,13 @@
 <div class="gh-canvas">
     <header class="gh-canvas-header">
         <h2 class="gh-canvas-title" data-test-screen-title>
-            {{#link-to "settings.integrations"}}Integrations{{/link-to}}
+            <LinkTo @route="settings.integrations">Integrations</LinkTo>
             <span>{{svg-jar "arrow-right"}}</span>
             AMP
         </h2>
     </header>
 
     <div class="gh-content">
-        {{gh-loading-spinner}}
+        <GhLoadingSpinner />
     </div>
 </div>

--- a/app/templates/settings/integrations/amp.hbs
+++ b/app/templates/settings/integrations/amp.hbs
@@ -1,20 +1,20 @@
 <section class="gh-canvas">
     <GhCanvasHeader class="gh-canvas-header">
         <h2 class="gh-canvas-title" data-test-screen-title>
-            {{#link-to "settings.integrations" data-test-link="integrations-back"}}Integrations{{/link-to}}
+            <LinkTo @route="settings.integrations" data-test-link="integrations-back">Integrations</LinkTo>
             <span>{{svg-jar "arrow-right"}}</span>
             AMP
         </h2>
         <section class="view-actions">
-            {{gh-task-button task=this.save class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button=true}}
+            <GhTaskButton @task={{this.save}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button={{true}} />
         </section>
     </GhCanvasHeader>
 
     {{#if this.showLeaveSettingsModal}}
-        {{gh-fullscreen-modal "leave-settings"
-            confirm=(action "leaveSettings")
-            close=(action "toggleLeaveSettingsModal")
-            modifier="action wide"}}
+        <GhFullscreenModal @modal="leave-settings"
+            @confirm={{action "leaveSettings"}}
+            @close={{action "toggleLeaveSettingsModal"}}
+            @modifier="action wide" />
     {{/if}}
 
     <section class="view-container bt b--lightgrey-d1 pt5">

--- a/app/templates/settings/integrations/new.hbs
+++ b/app/templates/settings/integrations/new.hbs
@@ -1,5 +1,5 @@
-{{gh-fullscreen-modal "new-integration"
-    model=this.integration
-    confirm=(action "save")
-    close=(action "cancel")
-    modifier="action wide"}}
+<GhFullscreenModal @modal="new-integration"
+    @model={{this.integration}}
+    @confirm={{action "save"}}
+    @close={{action "cancel"}}
+    @modifier="action wide" />

--- a/app/templates/settings/integrations/slack-loading.hbs
+++ b/app/templates/settings/integrations/slack-loading.hbs
@@ -1,13 +1,13 @@
 <div class="gh-canvas">
     <header class="gh-canvas-header">
         <h2 class="gh-canvas-title" data-test-screen-title>
-            {{#link-to "settings.integrations"}}Integrations{{/link-to}}
+            <LinkTo @route="settings.integrations">Integrations</LinkTo>
             <span>{{svg-jar "arrow-right"}}</span>
             Slack
         </h2>
     </header>
 
     <div class="gh-content">
-        {{gh-loading-spinner}}
+        <GhLoadingSpinner />
     </div>
 </div>

--- a/app/templates/settings/integrations/slack.hbs
+++ b/app/templates/settings/integrations/slack.hbs
@@ -1,20 +1,20 @@
 <section class="gh-canvas">
     <GhCanvasHeader class="gh-canvas-header">
         <h2 class="gh-canvas-title" data-test-screen-title>
-            {{#link-to "settings.integrations" data-test-link="integrations-back"}}Integrations{{/link-to}}
+            <LinkTo @route="settings.integrations" data-test-link="integrations-back">Integrations</LinkTo>
             <span>{{svg-jar "arrow-right"}}</span>
             Slack
         </h2>
         <section class="view-actions">
-            {{gh-task-button task=this.save class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button=true}}
+            <GhTaskButton @task={{this.save}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button={{true}} />
         </section>
     </GhCanvasHeader>
 
     {{#if this.showLeaveSettingsModal}}
-        {{gh-fullscreen-modal "leave-settings"
-            confirm=(action "leaveSettings")
-            close=(action "toggleLeaveSettingsModal")
-            modifier="action wide"}}
+        <GhFullscreenModal @modal="leave-settings"
+            @confirm={{action "leaveSettings"}}
+            @close={{action "toggleLeaveSettingsModal"}}
+            @modifier="action wide" />
     {{/if}}
 
     <section class="view-container bt b--lightgrey-d1 pt5">
@@ -39,24 +39,24 @@
                         <div class="gh-setting-title">Webhook URL</div>
                         <div class="gh-setting-desc">Automatically send newly published posts to a channel in Slack or any Slack-compatible service like Discord or Mattermost.</div>
                         <div class="gh-setting-content-extended">
-                            {{#gh-form-group errors=this.slackSettings.errors hasValidated=this.slackSettings.hasValidated property="url"}}
-                                {{gh-text-input
-                                    placeholder="https://hooks.slack.com/services/..."
-                                    name="slack[url]"
-                                    value=(readonly this.slackSettings.url)
-                                    input=(action "updateURL" value="target.value")
-                                    keyEvents=(hash
+                            <GhFormGroup @errors={{this.slackSettings.errors}} @hasValidated={{this.slackSettings.hasValidated}} @property="url">
+                                <GhTextInput
+                                    @placeholder="https://hooks.slack.com/services/..."
+                                    @name="slack[url]"
+                                    @value={{readonly this.slackSettings.url}}
+                                    @input={{action "updateURL" value="target.value"}}
+                                    @keyEvents={{hash
                                         Enter=(action "save")
-                                    )
-                                    focus-out=(action "triggerDirtyState")
-                                    data-test-slack-url-input=true
-                                }}
+                                    }}
+                                    @focus-out={{action "triggerDirtyState"}}
+                                    data-test-slack-url-input={{true}}
+                                />
                                 {{#unless this.slackSettings.errors.url}}
                                     <p>Set up a new incoming webhook <a href="https://my.slack.com/apps/new/A0F7XDUAZ-incoming-webhooks" target="_blank">here</a>, and grab the URL.</p>
                                 {{else}}
                                     <GhErrorMessage @errors={{this.slackSettings.errors}} @property="url" data-test-error="slack-url" />
                                 {{/unless}}
-                            {{/gh-form-group}}
+                            </GhFormGroup>
                         </div>
                     </div>
                 </div>
@@ -65,24 +65,24 @@
                         <div class="gh-setting-title">Username</div>
                         <div class="gh-setting-desc">The username to display messages from</div>
                         <div class="gh-setting-content-extended">
-                            {{#gh-form-group errors=this.slackSettings.errors hasValidated=this.slackSettings.hasValidated property="username"}}
-                                {{gh-text-input
-                                    placeholder="Ghost"
-                                    name="slack[username]"
-                                    value=(readonly this.slackSettings.username)
-                                    input=(action "updateUsername" value="target.value")
-                                    keyEvents=(hash
+                            <GhFormGroup @errors={{this.slackSettings.errors}} @hasValidated={{this.slackSettings.hasValidated}} @property="username">
+                                <GhTextInput
+                                    @placeholder="Ghost"
+                                    @name="slack[username]"
+                                    @value={{readonly this.slackSettings.username}}
+                                    @input={{action "updateUsername" value="target.value"}}
+                                    @keyEvents={{hash
                                         Enter=(action "save")
-                                    )
-                                    focus-out=(action "triggerDirtyState")
-                                    data-test-slack-username-input=true
-                                }}
+                                    }}
+                                    @focus-out={{action "triggerDirtyState"}}
+                                    data-test-slack-username-input={{true}}
+                                />
                                 {{#if this.slackSettings.errors.username}}
                                     <GhErrorMessage @errors={{this.slackSettings.errors}} @property="username" />
                                 {{/if}}
-                            {{/gh-form-group}}
+                            </GhFormGroup>
                         </div>
-                        {{gh-task-button "Send test notification" task=this.sendTestNotification successText="Sent" class="gh-btn gh-btn-green gh-btn-icon" disabled=this.testNotificationDisabled data-test-send-notification-button=true}}
+                        <GhTaskButton @buttonText="Send test notification" @task={{this.sendTestNotification}} @successText="Sent" @class="gh-btn gh-btn-green gh-btn-icon" @disabled={{this.testNotificationDisabled}} data-test-send-notification-button="true" />
                     </div>
                 </div>
             </div>

--- a/app/templates/settings/integrations/unsplash-loading.hbs
+++ b/app/templates/settings/integrations/unsplash-loading.hbs
@@ -1,13 +1,13 @@
 <div class="gh-canvas">
     <header class="gh-canvas-header">
         <h2 class="gh-canvas-title" data-test-screen-title>
-            {{#link-to "settings.integrations"}}Integrations{{/link-to}}
+            <LinkTo @route="settings.integrations">Integrations</LinkTo>
             <span>{{svg-jar "arrow-right"}}</span>
             Unsplash
         </h2>
     </header>
 
     <div class="gh-content">
-        {{gh-loading-spinner}}
+        <GhLoadingSpinner />
     </div>
 </div>

--- a/app/templates/settings/integrations/unsplash.hbs
+++ b/app/templates/settings/integrations/unsplash.hbs
@@ -1,20 +1,20 @@
 <section class="gh-canvas">
     <GhCanvasHeader class="gh-canvas-header">
         <h2 class="gh-canvas-title" data-test-screen-title>
-            {{#link-to "settings.integrations" data-test-link="integrations-back"}}Integrations{{/link-to}}
+            <LinkTo @route="settings.integrations" data-test-link="integrations-back">Integrations</LinkTo>
             <span>{{svg-jar "arrow-right"}}</span>
             Unsplash
         </h2>
         <section class="view-actions">
-            {{gh-task-button task=this.save class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button=true}}
+            <GhTaskButton @task={{this.save}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button={{true}} />
         </section>
     </GhCanvasHeader>
 
     {{#if this.showLeaveSettingsModal}}
-        {{gh-fullscreen-modal "leave-settings"
-            confirm=(action "leaveSettings")
-            close=(action "toggleLeaveSettingsModal")
-            modifier="action wide"}}
+        <GhFullscreenModal @modal="leave-settings"
+            @confirm={{action "leaveSettings"}}
+            @close={{action "toggleLeaveSettingsModal"}}
+            @modifier="action wide" />
     {{/if}}
 
     <section class="view-container bt b--lightgrey-d1 pt5">

--- a/app/templates/settings/integrations/zapier.hbs
+++ b/app/templates/settings/integrations/zapier.hbs
@@ -1,7 +1,7 @@
 <section class="gh-canvas">
     <GhCanvasHeader class="gh-canvas-header">
         <h2 class="gh-canvas-title" data-test-screen-title>
-            {{#link-to "settings.integrations" data-test-link="integrations-back"}}Integrations{{/link-to}}
+            <LinkTo @route="settings.integrations" data-test-link="integrations-back">Integrations</LinkTo>
             <span>{{svg-jar "arrow-right"}}</span>
             Zapier
         </h2>

--- a/app/templates/settings/labs-loading.hbs
+++ b/app/templates/settings/labs-loading.hbs
@@ -6,6 +6,6 @@
     </header>
 
     <div class="gh-content">
-        {{gh-loading-spinner}}
+        <GhLoadingSpinner />
     </div>
 </section>

--- a/app/templates/settings/labs.hbs
+++ b/app/templates/settings/labs.hbs
@@ -19,23 +19,23 @@
                             <div class="gh-setting-desc pl5 pb5">Create registered members and take subscription payments — <a href="https://ghost.org/docs/members/" target="_blank" rel="noopener">Find out more</a></div>
                         </div>
                         <div class="gh-setting-action">
-                            <div class="for-switch pa5">{{gh-feature-flag "members"}}</div>
+                            <div class="for-switch pa5"><GhFeatureFlag @flag="members" /></div>
                         </div>
                     </div>
                     {{#liquid-if this.feature.labs.members}}
-                    {{gh-members-lab-setting
-                        settings=this.settings
-                        setDefaultContentVisibility=(action "setDefaultContentVisibility")
-                        setMembersSubscriptionSettings=(action "setMembersSubscriptionSettings")
-                        setBulkEmailSettings=(action "setBulkEmailSettings")
-                    }}
+                    <GhMembersLabSetting
+                        @settings={{this.settings}}
+                        @setDefaultContentVisibility={{action "setDefaultContentVisibility"}}
+                        @setMembersSubscriptionSettings={{action "setMembersSubscriptionSettings"}}
+                        @setBulkEmailSettings={{action "setBulkEmailSettings"}}
+                    />
                     <div class="mt5 pl5 pr5 pb5">
-                        {{gh-task-button "Save members settings"
-                            task=this.saveSettings
-                            successText="Saved"
-                            runningText="Saving"
-                            class="gh-btn gh-btn-blue gh-btn-icon"
-                        }}
+                        <GhTaskButton @buttonText="Save members settings"
+                            @task={{this.saveSettings}}
+                            @successText="Saved"
+                            @runningText="Saving"
+                            @class="gh-btn gh-btn-blue gh-btn-icon"
+                        />
                     </div>
                     {{/liquid-if}}
                 </div>
@@ -51,13 +51,14 @@
                 </div>
                 <div class="gh-setting-action">
                     <form id="settings-import" enctype="multipart/form-data">
-                        {{gh-file-upload
-                            id="importfile"
-                            classNames="flex"
-                            uploadButtonText=this.uploadButtonText
-                            onUpload=(action "onUpload")
-                            acceptEncoding=this.importMimeType
-                            data-test-file-input="import"}}
+                        <GhFileUpload
+                            @id="importfile"
+                            @classNames="flex"
+                            @uploadButtonText={{this.uploadButtonText}}
+                            @onUpload={{action "onUpload"}}
+                            @acceptEncoding={{this.importMimeType}}
+                            data-test-file-input="import"
+                        />
                     </form>
                 </div>
             </div>
@@ -116,18 +117,18 @@
                     <div class="gh-setting-desc">Swap Ghost admin's colours to a dark background which is easy on the eyes</div>
                 </div>
                 <div class="gh-setting-action">
-                    <div class="for-switch">{{gh-feature-flag "nightShift"}}</div>
+                    <div class="for-switch"><GhFeatureFlag @flag="nightShift" /></div>
                 </div>
             </div>
             <div class="gh-setting">
-                {{#gh-uploader
-                    extensions=this.jsonExtension
-                    uploadUrl="/redirects/json/"
-                    paramName="redirects"
-                    onUploadSuccess=(perform this.redirectUploadResult true)
-                    onUploadFailure=(perform this.redirectUploadResult false)
+                <GhUploader
+                    @extensions={{this.jsonExtension}}
+                    @uploadUrl="/redirects/json/"
+                    @paramName="redirects"
+                    @onUploadSuccess={{perform this.redirectUploadResult true}}
+                    @onUploadFailure={{perform this.redirectUploadResult false}}
                     as |uploader|
-                }}
+                >
                 <div class="gh-setting-content">
                     <div class="gh-setting-title">Redirects</div>
                     <div class="gh-setting-desc">Configure redirects for old or moved content, more info in <a href="https://ghost.org/tutorials/implementing-redirects/">the docs</a></div>
@@ -159,20 +160,20 @@
                     {{/if}}
 
                     <div style="display:none">
-                        {{gh-file-input multiple=false action=uploader.setFiles accept=this.jsonMimeType data-test-file-input="redirects"}}
+                        <GhFileInput @multiple={{false}} @action={{uploader.setFiles}} @accept={{this.jsonMimeType}} data-test-file-input="redirects" />
                     </div>
                 </div>
-                {{/gh-uploader}}
+                </GhUploader>
             </div>
             <div class="gh-setting-last">
-                {{#gh-uploader
-                    extensions=this.yamlExtension
-                    uploadUrl="/settings/routes/yaml/"
-                    paramName="routes"
-                    onUploadSuccess=(perform this.routesUploadResult true)
-                    onUploadFailure=(perform this.routesUploadResult false)
+                <GhUploader
+                    @extensions={{this.yamlExtension}}
+                    @uploadUrl="/settings/routes/yaml/"
+                    @paramName="routes"
+                    @onUploadSuccess={{perform this.routesUploadResult true}}
+                    @onUploadFailure={{perform this.routesUploadResult false}}
                     as |uploader|
-                }}
+                >
                 <div class="gh-setting-content">
                     <div class="gh-setting-title">Routes</div>
                     <div class="gh-setting-desc">Configure dynamic routing by modifying the routes.yaml file</div>
@@ -204,10 +205,10 @@
                     {{/if}}
 
                     <div style="display:none">
-                        {{gh-file-input multiple=false action=uploader.setFiles accept=this.yamlMimeType data-test-file-input="routes"}}
+                        <GhFileInput @multiple={{false}} @action={{uploader.setFiles}} @accept={{this.yamlMimeType}} data-test-file-input="routes" />
                     </div>
                 </div>
-                {{/gh-uploader}}
+                </GhUploader>
             </div>
         </div>
 
@@ -219,7 +220,7 @@
                     <div class="gh-setting-desc">Send yourself a test email to make sure everything is working</div>
                 </div>
                 <div class="gh-setting-action">
-                    {{gh-task-button "Send" successText="Sent" task=this.sendTestEmail class="gh-btn gh-btn-hover-blue gh-btn-icon"}}
+                    <GhTaskButton @buttonText="Send" @successText="Sent" @task={{this.sendTestEmail}} @class="gh-btn gh-btn-hover-blue gh-btn-icon" />
                 </div>
             </div>
         </div>
@@ -228,7 +229,7 @@
 </section>
 
 {{#if this.showDeleteAllModal}}
-    {{gh-fullscreen-modal "delete-all"
-                          close=(action "toggleDeleteAllModal")
-                          modifier="action wide"}}
+    <GhFullscreenModal @modal="delete-all"
+        @close={{action "toggleDeleteAllModal"}}
+        @modifier="action wide" />
 {{/if}}

--- a/app/templates/setup.hbs
+++ b/app/templates/setup.hbs
@@ -2,20 +2,20 @@
     <header class="gh-flow-head">
         <nav class="gh-flow-nav">
             {{#if this.showBackLink}}
-                {{#link-to this.backRoute classNames="gh-flow-back"}}{{svg-jar "arrow-left-small"}} Back{{/link-to}}
+                <LinkTo @route={{this.backRoute}} @classNames="gh-flow-back">{{svg-jar "arrow-left-small"}} Back</LinkTo>
             {{/if}}
             <ol>
-                {{#gh-activating-list-item route="setup.one" linkClasses="step"}}
+                <GhActivatingListItem @route="setup.one" @linkClasses="step">
                     {{svg-jar "check-circle"}}<span class="num">1</span>
-                {{/gh-activating-list-item}}
+                </GhActivatingListItem>
                 <li class="divider"></li>
-                {{#gh-activating-list-item route="setup.two" linkClasses="step"}}
+                <GhActivatingListItem @route="setup.two" @linkClasses="step">
                     {{svg-jar "check-circle"}}<span class="num">2</span>
-                {{/gh-activating-list-item}}
+                </GhActivatingListItem>
                 <li class="divider"></li>
-                {{#gh-activating-list-item route="setup.three" linkClasses="step"}}
+                <GhActivatingListItem @route="setup.three" @linkClasses="step">
                     {{svg-jar "check-circle"}}<span class="num">3</span>
-                {{/gh-activating-list-item}}
+                </GhActivatingListItem>
             </ol>
         </nav>
     </header>

--- a/app/templates/setup/one.hbs
+++ b/app/templates/setup/one.hbs
@@ -1,12 +1,12 @@
 <header>
     <h1>Welcome to <strong>Ghost</strong>!</h1>
-    <p>All over the world, people have started <em>{{gh-download-count}}</em> incredible sites with Ghost. Today, we’re starting yours.</p>
+    <p>All over the world, people have started <em><GhDownloadCount /></em> incredible sites with Ghost. Today, we’re starting yours.</p>
 </header>
 
 <figure class="gh-flow-screenshot">
     <img src="assets/img/install-welcome.png" alt="Ghost screenshot" />
 </figure>
 
-{{#link-to "setup.two" classNames="gh-btn gh-btn-green gh-btn-lg gh-btn-icon gh-btn-icon-right"}}
+<LinkTo @route="setup.two" @classNames="gh-btn gh-btn-green gh-btn-lg gh-btn-icon gh-btn-icon-right">
     <span>Create your account {{svg-jar "arrow-right-small"}}</span>
-{{/link-to}}
+</LinkTo>

--- a/app/templates/setup/three.hbs
+++ b/app/templates/setup/three.hbs
@@ -6,25 +6,25 @@
 <div><img class="gh-flow-faces" src="assets/img/users.png" alt="" /></div>
 
 <form class="gh-flow-invite" {{action "invite" on="submit"}}>
-    {{#gh-form-group errors=this.errors hasValidated=this.hasValidated property="users"}}
+    <GhFormGroup @errors={{this.errors}} @hasValidated={{this.hasValidated}} @property="users">
         <label for="users">Enter one email address per line, we’ll handle the rest! {{svg-jar "email"}}</label>
-        {{gh-textarea
-            name="users"
-            required="required"
-            value=(readonly this.users)
-            input=(action (mut this.users) value="target.value")
-            focus-out=(action "validate")
-        }}
-    {{/gh-form-group}}
+        <GhTextarea
+            @name="users"
+            @required="required"
+            @value={{readonly this.users}}
+            @input={{action (mut this.users) value="target.value"}}
+            @focus-out={{action "validate"}}
+        />
+    </GhFormGroup>
 
-    {{#gh-task-button
-        task=this.invite
-        type="submit"
-        classNameBindings=":gh-btn :gh-btn-default :gh-btn-lg :gh-btn-block buttonClass"
-        successClass=""
-        failureClass=""
+    <GhTaskButton
+        @task={{this.invite}}
+        @type="submit"
+        @class="gh-btn gh-btn-default gh-btn-lg gh-btn-block {{this.buttonClass}}"
+        @successClass=""
+        @failureClass=""
         as |task|
-    }}
+    >
         <span>
             {{#if task.isRunning}}
                 {{svg-jar "spinner" class="no-margin"}}
@@ -32,7 +32,7 @@
                 {{this.buttonText}}
             {{/if}}
         </span>
-    {{/gh-task-button}}
+    </GhTaskButton>
 </form>
 
 <button class="gh-flow-skip" {{action "skipInvite"}}>

--- a/app/templates/setup/two.hbs
+++ b/app/templates/setup/two.hbs
@@ -3,99 +3,93 @@
 </header>
 
 <form id="setup" class="gh-flow-create">
-    {{gh-profile-image email=this.email setImage=(action "setImage")}}
+    <GhProfileImage @email={{this.email}} @setImage={{action "setImage"}} />
 
-    {{#gh-form-group errors=this.errors hasValidated=this.hasValidated property="blogTitle"}}
+    <GhFormGroup @errors={{this.errors}} @hasValidated={{this.hasValidated}} @property="blogTitle">
         <label for="blog-title">Site title</label>
         <span class="gh-input-icon gh-icon-content">
             {{svg-jar "content"}}
-            {{gh-trim-focus-input
-                tabindex="1"
-                type="text"
-                id="blog-title"
-                name="blog-title"
-                placeholder="Eg. The Daily Awesome"
-                autocorrect="off"
-                value=(readonly this.blogTitle)
-                input=(action (mut this.blogTitle) value="target.value")
-                focus-out=(action "preValidate" "blogTitle")
-                data-test-blog-title-input=true}}
+            <GhTrimFocusInput
+                @tabindex="1"
+                @type="text"
+                @id="blog-title"
+                @name="blog-title"
+                @placeholder="Eg. The Daily Awesome"
+                @autocorrect="off"
+                @value={{readonly this.blogTitle}}
+                @input={{action (mut this.blogTitle) value="target.value"}}
+                @focus-out={{action "preValidate" "blogTitle"}}
+                data-test-blog-title-input={{true}} />
         </span>
         <GhErrorMessage @errors={{this.errors}} @property="blogTitle" />
-    {{/gh-form-group}}
+    </GhFormGroup>
 
-    {{#gh-form-group errors=this.errors hasValidated=this.hasValidated property="name"}}
+    <GhFormGroup @errors={{this.errors}} @hasValidated={{this.hasValidated}} @property="name">
         <label for="name">Full name</label>
         <span class="gh-input-icon gh-icon-user">
             {{svg-jar "user-circle"}}
-            {{gh-text-input
-                tabindex="2"
-                id="name"
-                name="name"
-                placeholder="Eg. John H. Watson"
-                autocorrect="off"
-                autocomplete="name"
-                value=(readonly this.name)
-                input=(action (mut this.name) value="target.value")
-                focus-out=(action "preValidate" "name")
-                data-test-name-input=true}}
+            <GhTextInput
+                @tabindex="2"
+                @id="name"
+                @name="name"
+                @placeholder="Eg. John H. Watson"
+                @autocorrect="off"
+                @autocomplete="name"
+                @value={{readonly this.name}}
+                @input={{action (mut this.name) value="target.value"}}
+                @focus-out={{action "preValidate" "name"}}
+                data-test-name-input={{true}} />
         </span>
         <GhErrorMessage @errors={{this.errors}} @property="name" />
-    {{/gh-form-group}}
+    </GhFormGroup>
 
-    {{#gh-form-group errors=this.errors hasValidated=this.hasValidated property="email"}}
+    <GhFormGroup @errors={{this.errors}} @hasValidated={{this.hasValidated}} @property="email">
         <label for="email">Email address</label>
         <span class="gh-input-icon gh-icon-mail">
             {{svg-jar "email"}}
-            {{gh-text-input
-                tabindex="3"
-                type="email"
-                id="email"
-                name="email"
-                placeholder="Eg. john@example.com"
-                autocorrect="off"
-                autocomplete="username email"
-                value=(readonly this.email)
-                input=(action (mut this.email) value="target.value")
-                focus-out=(action "preValidate" "email")
-                data-test-email-input=true}}
+            <GhTextInput
+                @tabindex="3"
+                @type="email"
+                @id="email"
+                @name="email"
+                @placeholder="Eg. john@example.com"
+                @autocorrect="off"
+                @autocomplete="username email"
+                @value={{readonly this.email}}
+                @input={{action (mut this.email) value="target.value"}}
+                @focus-out={{action "preValidate" "email"}}
+                data-test-email-input={{true}} />
         </span>
         <GhErrorMessage @errors={{this.errors}} @property="email" />
-    {{/gh-form-group}}
+    </GhFormGroup>
 
-    {{#gh-form-group errors=this.errors hasValidated=this.hasValidated property="password"}}
+    <GhFormGroup @errors={{this.errors}} @hasValidated={{this.hasValidated}} @property="password">
         <label for="password">Password</label>
         <span class="gh-input-icon gh-icon-lock">
             {{svg-jar "lock"}}
-            {{gh-text-input
-                tabindex="4"
-                type="password"
-                id="password"
-                name="password"
-                placeholder="At least 10 characters"
-                autocorrect="off"
-                autocomplete="new-password"
-                value=(readonly this.password)
-                input=(action (mut this.password) value="target.value")
-                focus-out=(action "preValidate" "password")
-                data-test-password-input=true}}
+            <GhTextInput
+                @tabindex="4"
+                @type="password"
+                @id="password"
+                @name="password"
+                @placeholder="At least 10 characters"
+                @autocorrect="off"
+                @autocomplete="new-password"
+                @value={{readonly this.password}}
+                @input={{action (mut this.password) value="target.value"}}
+                @focus-out={{action "preValidate" "password"}}
+                data-test-password-input={{true}} />
         </span>
         <GhErrorMessage @errors={{this.errors}} @property="password" />
-    {{/gh-form-group}}
+    </GhFormGroup>
 
-    {{#gh-task-button
-        task=this.setup
-        type="submit"
-        tabindex="5"
-        class="gh-btn gh-btn-green gh-btn-lg gh-btn-block gh-btn-icon"
-        as |task|
-    }}
+    <GhTaskButton @task={{this.setup}} @type="submit" @tabindex="5" @class="gh-btn gh-btn-green gh-btn-lg gh-btn-block gh-btn-icon" as |task|>
         {{#if task.isRunning}}
             <span>{{svg-jar "spinner" class="gh-icon-spinner gh-btn-icon-no-margin"}}</span>
         {{else}}
             <span>Last step: Invite staff users {{svg-jar "arrow-right-small" class="gh-btn-icon-right"}}</span>
         {{/if}}
-    {{/gh-task-button}}
+    </GhTaskButton>
 </form>
 
 <p class="main-error">{{this.flowErrors}}&nbsp;</p>

--- a/app/templates/signin.hbs
+++ b/app/templates/signin.hbs
@@ -2,58 +2,58 @@
     <div class="gh-flow-content-wrap">
         <section class="gh-flow-content">
             <form id="login" method="post" class="gh-signin" novalidate="novalidate" {{action "authenticate" on="submit"}}>
-                {{#gh-form-group errors=this.signin.errors hasValidated=this.hasValidated property="identification"}}
+                <GhFormGroup @errors={{this.signin.errors}} @hasValidated={{this.hasValidated}} @property="identification">
                     <span class="gh-input-icon gh-icon-mail">
                         {{svg-jar "email"}}
-                        {{gh-trim-focus-input
-                            class="email"
-                            type="email"
-                            placeholder="Email Address"
-                            name="identification"
-                            autocapitalize="off"
-                            autocorrect="off"
-                            autocomplete="username"
-                            tabindex="1"
-                            value=(readonly this.signin.identification)
-                            input=(action (mut this.signin.identification) value="target.value")
-                            focus-out=(action "validate" "identification")
-                        }}
+                        <GhTrimFocusInput
+                            @class="email"
+                            @type="email"
+                            @placeholder="Email Address"
+                            @name="identification"
+                            @autocapitalize="off"
+                            @autocorrect="off"
+                            @autocomplete="username"
+                            @tabindex="1"
+                            @value={{readonly this.signin.identification}}
+                            @input={{action (mut this.signin.identification) value="target.value"}}
+                            @focus-out={{action "validate" "identification"}}
+                        />
                     </span>
-                {{/gh-form-group}}
-                {{#gh-form-group errors=this.signin.errors hasValidated=this.hasValidated property="password"}}
+                </GhFormGroup>
+                <GhFormGroup @errors={{this.signin.errors}} @hasValidated={{this.hasValidated}} @property="password">
                     <span class="gh-input-icon gh-icon-lock forgotten-wrap">
                         {{svg-jar "lock"}}
-                        {{gh-text-input
-                            class="password"
-                            type="password"
-                            placeholder="Password"
-                            name="password"
-                            tabindex="2"
-                            autocomplete="current-password"
-                            autocorrect="off"
-                            value=(readonly this.signin.password)
-                            input=(action (mut this.signin.password) value="target.value")}}
+                        <GhTextInput
+                            @class="password"
+                            @type="password"
+                            @placeholder="Password"
+                            @name="password"
+                            @tabindex="2"
+                            @autocomplete="current-password"
+                            @autocorrect="off"
+                            @value={{readonly this.signin.password}}
+                            @input={{action (mut this.signin.password) value="target.value"}} />
 
-                        {{#gh-task-button
-                            task=this.forgotten
-                            class="forgotten-link gh-btn gh-btn-link gh-btn-icon"
-                            tabindex="4"
-                            type="button"
-                            successClass=""
-                            failureClass=""
+                        <GhTaskButton
+                            @task={{this.forgotten}}
+                            @class="forgotten-link gh-btn gh-btn-link gh-btn-icon"
+                            @tabindex="4"
+                            @type="button"
+                            @successClass=""
+                            @failureClass=""
                             as |task|
-                        }}
+                        >
                             <span>{{#if task.isRunning}}{{svg-jar "spinner" class="gh-spinner"}}{{else}}Forgot?{{/if}}</span>
-                        {{/gh-task-button}}
+                        </GhTaskButton>
                     </span>
-                {{/gh-form-group}}
+                </GhFormGroup>
 
-                {{gh-task-button "Sign in"
-                    task=this.validateAndAuthenticate
-                    showSuccess=false
-                    class="login gh-btn gh-btn-blue gh-btn-block gh-btn-icon"
-                    type="submit"
-                    tabindex="3"}}
+                <GhTaskButton @buttonText="Sign in"
+                    @task={{this.validateAndAuthenticate}}
+                    @showSuccess={{false}}
+                    @class="login gh-btn gh-btn-blue gh-btn-block gh-btn-icon"
+                    @type="submit"
+                    @tabindex="3" />
             </form>
 
             <p class="main-error">{{if this.flowErrors this.flowErrors}}&nbsp;</p>

--- a/app/templates/signup.hbs
+++ b/app/templates/signup.hbs
@@ -7,80 +7,80 @@
             </header>
 
             <form id="signup" class="gh-flow-create" method="post" novalidate="novalidate" onsubmit={{action "submit"}}>
-                {{gh-profile-image email=this.signupDetails.email setImage=(action "setImage")}}
+                <GhProfileImage @email={{this.signupDetails.email}} @setImage={{action "setImage"}} />
 
-                {{#gh-form-group errors=this.signupDetails.errors hasValidated=this.signupDetails.hasValidated property="name"}}
+                <GhFormGroup @errors={{this.signupDetails.errors}} @hasValidated={{this.signupDetails.hasValidated}} @property="name">
                     <label for="name">Full name</label>
                     <span class="gh-input-icon gh-icon-user">
                         {{svg-jar "user-circle"}}
-                        {{gh-trim-focus-input
-                            tabindex="1"
-                            type="text"
-                            id="display-name"
-                            name="display-name"
-                            placeholder="Eg. John H. Watson"
-                            autocorrect="off"
-                            autocomplete="name"
-                            value=(readonly this.signupDetails.name)
-                            input=(action (mut this.signupDetails.name) value="target.value")
-                            focus-out=(action "validate" "name")
+                        <GhTrimFocusInput
+                            @tabindex="1"
+                            @type="text"
+                            @id="display-name"
+                            @name="display-name"
+                            @placeholder="Eg. John H. Watson"
+                            @autocorrect="off"
+                            @autocomplete="name"
+                            @value={{readonly this.signupDetails.name}}
+                            @input={{action (mut this.signupDetails.name) value="target.value"}}
+                            @focus-out={{action "validate" "name"}}
                             data-test-input="name"
-                        }}
+                        />
                     </span>
                     <GhErrorMessage @errors={{this.signupDetails.errors}} @property="name" />
-                {{/gh-form-group}}
+                </GhFormGroup>
 
-                {{#gh-form-group errors=this.signupDetails.errors hasValidated=this.signupDetails.hasValidated property="email"}}
+                <GhFormGroup @errors={{this.signupDetails.errors}} @hasValidated={{this.signupDetails.hasValidated}} @property="email">
                     <label for="email">Email address</label>
                     <span class="gh-input-icon gh-icon-mail">
                         {{svg-jar "email"}}
-                        {{gh-text-input
-                            tabindex="2"
-                            type="text"
-                            id="username"
-                            name="username"
-                            placeholder="Eg. john@example.com"
-                            autocorrect="off"
-                            autocomplete="username email"
-                            value=(readonly this.signupDetails.email)
-                            input=(action (mut this.signupDetails.email) value="target.value")
-                            focus-out=(action "validate" "email")
+                        <GhTextInput
+                            @tabindex="2"
+                            @type="text"
+                            @id="username"
+                            @name="username"
+                            @placeholder="Eg. john@example.com"
+                            @autocorrect="off"
+                            @autocomplete="username email"
+                            @value={{readonly this.signupDetails.email}}
+                            @input={{action (mut this.signupDetails.email) value="target.value"}}
+                            @focus-out={{action "validate" "email"}}
                             data-test-input="email"
-                        }}
+                        />
                     </span>
                     <GhErrorMessage @errors={{this.signupDetails.errors}} @property="email" />
-                {{/gh-form-group}}
+                </GhFormGroup>
 
-                {{#gh-form-group errors=this.signupDetails.errors hasValidated=this.signupDetails.hasValidated property="password"}}
+                <GhFormGroup @errors={{this.signupDetails.errors}} @hasValidated={{this.signupDetails.hasValidated}} @property="password">
                     <label for="password">Password</label>
                     <span class="gh-input-icon gh-icon-lock">
                         {{svg-jar "lock"}}
-                        {{gh-text-input
-                            tabindex="3"
-                            type="password"
-                            id="password"
-                            name="password"
-                            placeholder="At least 10 characters"
-                            autocorrect="off"
-                            autocomplete="new-password"
-                            value=(readonly this.signupDetails.password)
-                            input=(action (mut this.signupDetails.password) value="target.value")
-                            focus-out=(action "validate" "password")
+                        <GhTextInput
+                            @tabindex="3"
+                            @type="password"
+                            @id="password"
+                            @name="password"
+                            @placeholder="At least 10 characters"
+                            @autocorrect="off"
+                            @autocomplete="new-password"
+                            @value={{readonly this.signupDetails.password}}
+                            @input={{action (mut this.signupDetails.password) value="target.value"}}
+                            @focus-out={{action "validate" "password"}}
                             data-test-input="password"
-                        }}
+                        />
                     </span>
                     <GhErrorMessage @errors={{this.signupDetails.errors}} @property="password" />
-                {{/gh-form-group}}
+                </GhFormGroup>
             </form>
 
-            {{gh-task-button "Create Account"
-                type="submit"
-                form="signup"
-                defaultClick=true
-                runningText="Creating"
-                task=this.signup
-                class="gh-btn gh-btn-green gh-btn-lg gh-btn-block gh-btn-icon"
-                tabindex="3"}}
+            <GhTaskButton @buttonText="Create Account"
+                @type="submit"
+                @form="signup"
+                @defaultClick={{true}}
+                @runningText="Creating"
+                @task={{this.signup}}
+                @class="gh-btn gh-btn-green gh-btn-lg gh-btn-block gh-btn-icon"
+                @tabindex="3" />
 
             <p class="main-error">{{if this.flowErrors this.flowErrors}}&nbsp;</p>
         </section>

--- a/app/templates/staff/index.hbs
+++ b/app/templates/staff/index.hbs
@@ -10,9 +10,9 @@
     </GhCanvasHeader>
 
     {{#if this.showInviteUserModal}}
-        {{gh-fullscreen-modal "invite-new-user"
-                              close=(action "toggleInviteUserModal")
-                              modifier="action wide"}}
+        <GhFullscreenModal @modal="invite-new-user"
+            @close={{action "toggleInviteUserModal"}}
+            @modifier="action wide" />
     {{/if}}
 
     <section class="view-container gh-team">
@@ -24,7 +24,7 @@
             <div class="apps-grid">
 
                 {{#each this.sortedInvites as |invite|}}
-                    {{#gh-user-invited invite=invite reload=(route-action "reload") as |component|}}
+                    <GhUserInvited @invite={{invite}} @reload={{route-action "reload"}} as |component|>
                         <div class="apps-grid-cell" data-test-invite-id="{{invite.id}}">
                             <article class="apps-card-app">
                                 <div class="apps-card-left">
@@ -63,7 +63,7 @@
                                 </div>
                             </article>
                         </div>
-                    {{/gh-user-invited}}
+                    </GhUserInvited>
                 {{/each}}
 
             </div>
@@ -76,9 +76,9 @@
         <div class="apps-grid">
             {{!-- For authors/contributors, only show their own user --}}
             {{#if this.currentUser.isAuthorOrContributor}}
-                {{#gh-user-active user=this.currentUser as |component|}}
-                    {{gh-user-list-item user=this.currentUser component=component}}
-                {{/gh-user-active}}
+                <GhUserActive @user={{this.currentUser}} as |component|>
+                    <GhUserListItem @user={{this.currentUser}} @component={{component}} />
+                </GhUserActive>
             {{else}}
                 {{#vertical-collection this.sortedActiveUsers
                     key="id"
@@ -86,9 +86,9 @@
                     estimateHeight=75
                     as |user|
                 }}
-                    {{#gh-user-active user=user as |component|}}
-                        {{gh-user-list-item user=user component=component}}
-                    {{/gh-user-active}}
+                    <GhUserActive @user={{user}} as |component|>
+                        <GhUserListItem @user={{user}} @component={{component}} />
+                    </GhUserActive>
                 {{/vertical-collection}}
             {{/if}}
         </div>
@@ -101,9 +101,9 @@
         <span class="apps-grid-title">Suspended users</span>
         <div class="apps-grid">
             {{#each this.sortedSuspendedUsers key="id" as |user|}}
-                {{#gh-user-active user=user as |component|}}
-                    {{gh-user-list-item user=user component=component}}
-                {{/gh-user-active}}
+                <GhUserActive @user={{user}} as |component|>
+                    <GhUserListItem @user={{user}} @component={{component}} />
+                </GhUserActive>
             {{/each}}
         </div>
     </section>

--- a/app/templates/staff/user-loading.hbs
+++ b/app/templates/staff/user-loading.hbs
@@ -1,7 +1,7 @@
 <section class="gh-canvas">
     <header class="gh-canvas-header">
         <h2 class="gh-canvas-title" data-test-screen-title>
-            {{link-to "Staff" "staff" data-test-staff-link=true}}
+            <LinkTo @route="staff" data-test-staff-link={{true}}>Staff</LinkTo>
             <span>{{svg-jar "arrow-right"}}</span>
             {{user.name}}
         </h2>
@@ -12,6 +12,6 @@
     </header>
 
     <div class="gh-content">
-        {{gh-loading-spinner}}
+        <GhLoadingSpinner />
     </div>
 </section>

--- a/app/templates/staff/user.hbs
+++ b/app/templates/staff/user.hbs
@@ -1,7 +1,7 @@
 <section class="gh-canvas">
     <GhCanvasHeader class="gh-canvas-header">
         <h2 class="gh-canvas-title" data-test-screen-title>
-            {{link-to "Staff" "staff" data-test-staff-link=true}}
+            <LinkTo @route="staff" data-test-staff-link={{true}}>Staff</LinkTo>
             <span>{{svg-jar "arrow-right"}}</span>
             {{this.user.name}}
 
@@ -11,32 +11,32 @@
         </h2>
 
         {{#if this.showLeaveSettingsModal}}
-            {{gh-fullscreen-modal "leave-settings"
-                confirm=(action "leaveSettings")
-                close=(action "toggleLeaveSettingsModal")
-                modifier="action wide"}}
+            <GhFullscreenModal @modal="leave-settings"
+                @confirm={{action "leaveSettings"}}
+                @close={{action "toggleLeaveSettingsModal"}}
+                @modifier="action wide" />
         {{/if}}
 
         <section class="view-actions">
             {{#if this.userActionsAreVisible}}
                 <span class="dropdown">
-                    {{#gh-dropdown-button dropdownName="user-actions-menu" classNames="gh-btn gh-btn-white gh-btn-icon only-has-icon user-actions-cog" title="User Actions" data-test-user-actions=true}}
+                    <GhDropdownButton @dropdownName="user-actions-menu" @classNames="gh-btn gh-btn-white gh-btn-icon only-has-icon user-actions-cog" @title="User Actions" data-test-user-actions={{true}}>
                         <span>
                             {{svg-jar "settings"}}
                             <span class="hidden">User Settings</span>
                         </span>
-                    {{/gh-dropdown-button}}
-                    {{#gh-dropdown name="user-actions-menu" tagName="ul" classNames="user-actions-menu dropdown-menu dropdown-triangle-top-right"}}
+                    </GhDropdownButton>
+                    <GhDropdown @name="user-actions-menu" @tagName="ul" @classNames="user-actions-menu dropdown-menu dropdown-triangle-top-right">
                         {{#if this.canMakeOwner}}
                             <li>
                                 <button {{action "toggleTransferOwnerModal"}}>
                                     Make Owner
                                 </button>
                                 {{#if this.showTransferOwnerModal}}
-                                    {{gh-fullscreen-modal "transfer-owner"
-                                                          confirm=(action "transferOwnership")
-                                                          close=(action "toggleTransferOwnerModal")
-                                                          modifier="action wide"}}
+                                    <GhFullscreenModal @modal="transfer-owner"
+                                        @confirm={{action "transferOwnership"}}
+                                        @close={{action "toggleTransferOwnerModal"}}
+                                        @modifier="action wide" />
                                 {{/if}}
                             </li>
                         {{/if}}
@@ -61,34 +61,34 @@
                                 </li>
                             {{/if}}
                         {{/if}}
-                    {{/gh-dropdown}}
+                    </GhDropdown>
                 </span>
             {{/if}}
 
-            {{gh-task-button class="gh-btn gh-btn-blue gh-btn-icon" task=this.save data-test-save-button=true}}
+            <GhTaskButton @class="gh-btn gh-btn-blue gh-btn-icon" @task={{this.save}} data-test-save-button={{true}} />
 
             {{#if this.showDeleteUserModal}}
-                {{gh-fullscreen-modal "delete-user"
-                                      model=this.user
-                                      confirm=(action "deleteUser")
-                                      close=(action "toggleDeleteUserModal")
-                                      modifier="action wide"}}
+                <GhFullscreenModal @modal="delete-user"
+                    @model={{this.user}}
+                    @confirm={{action "deleteUser"}}
+                    @close={{action "toggleDeleteUserModal"}}
+                    @modifier="action wide" />
             {{/if}}
 
             {{#if this.showSuspendUserModal}}
-                {{gh-fullscreen-modal "suspend-user"
-                                      model=this.user
-                                      confirm=(action "suspendUser")
-                                      close=(action "toggleSuspendUserModal")
-                                      modifier="action wide"}}
+                <GhFullscreenModal @modal="suspend-user"
+                    @model={{this.user}}
+                    @confirm={{action "suspendUser"}}
+                    @close={{action "toggleSuspendUserModal"}}
+                    @modifier="action wide" />
             {{/if}}
 
             {{#if this.showUnsuspendUserModal}}
-                {{gh-fullscreen-modal "unsuspend-user"
-                                      model=this.user
-                                      confirm=(action "unsuspendUser")
-                                      close=(action "toggleUnsuspendUserModal")
-                                      modifier="action wide"}}
+                <GhFullscreenModal @modal="unsuspend-user"
+                    @model={{this.user}}
+                    @confirm={{action "unsuspendUser"}}
+                    @close={{action "toggleUnsuspendUserModal"}}
+                    @modifier="action wide" />
             {{/if}}
         </section>
     </GhCanvasHeader>
@@ -101,10 +101,10 @@
                 <figure class="user-cover" style={{background-image-style this.user.coverImageUrl}}>
                     <button type="button" class="gh-btn gh-btn-default user-cover-edit" {{action "toggleUploadCoverModal"}}><span>Change Cover</span></button>
                     {{#if this.showUploadCoverModal}}
-                        {{gh-fullscreen-modal "upload-image"
-                                                model=(hash model=this.user imageProperty="coverImage")
-                                                close=(action "toggleUploadCoverModal")
-                                                modifier="action wide"}}
+                        <GhFullscreenModal @modal="upload-image"
+                            @model={{hash model=this.user imageProperty="coverImage"}}
+                            @close={{action "toggleUploadCoverModal"}}
+                            @modifier="action wide" />
                     {{/if}}
                 </figure>
 
@@ -112,170 +112,171 @@
                     <div id="user-image" class="img" style={{background-image-style this.user.profileImageUrl}}><span class="hidden">{{this.user.name}}"s Picture</span></div>
                     <button type="button" {{action "toggleUploadImageModal"}} class="edit-user-image">Edit Picture</button>
                     {{#if this.showUploadImageModal}}
-                        {{gh-fullscreen-modal "upload-image"
-                                                model=(hash model=this.user imageProperty="profileImage" paramsHash=(hash purpose="profile_image"))
-                                                close=(action "toggleUploadImageModal")
-                                                modifier="action wide"}}
+                        <GhFullscreenModal @modal="upload-image"
+                            @model={{hash model=this.user imageProperty="profileImage" paramsHash=(hash purpose="profile_image")}}
+                            @close={{action "toggleUploadImageModal"}}
+                            @modifier="action wide" />
                     {{/if}}
                 </figure>
 
                 <div class="pa5">
                     <fieldset class="user-details-bottom">
 
-                        {{#gh-form-group errors=this.user.errors hasValidated=this.user.hasValidated property="name" class="first-form-group"}}
+                        <GhFormGroup @errors={{this.user.errors}} @hasValidated={{this.user.hasValidated}} @property="name" @class="first-form-group">
                             <label for="user-name">Full Name</label>
-                            {{gh-text-input
-                                id="user-name"
-                                class="user-name"
-                                placeholder="Full Name"
-                                autocorrect="off"
-                                value=(readonly this.user.name)
-                                input=(action (mut this.user.name) value="target.value")
-                                focus-out=(action "validate" "name" target=this.user)
-                                data-test-name-input=true
-                            }}
+                            <GhTextInput
+                                @id="user-name"
+                                @class="user-name"
+                                @placeholder="Full Name"
+                                @autocorrect="off"
+                                @value={{readonly this.user.name}}
+                                @input={{action (mut this.user.name) value="target.value"}}
+                                @focus-out={{action "validate" "name" target=this.user}}
+                                data-test-name-input={{true}}
+                            />
                             {{#if this.user.errors.name}}
                                 <GhErrorMessage @errors={{this.user.errors}} @property="name" data-test-error="user-name" />
                             {{else}}
                                 <p>Use your real name so people can recognise you</p>
                             {{/if}}
-                        {{/gh-form-group}}
+                        </GhFormGroup>
 
-                        {{#gh-form-group errors=this.user.errors hasValidated=this.user.hasValidated property="slug"}}
+                        <GhFormGroup @errors={{this.user.errors}} @hasValidated={{this.user.hasValidated}} @property="slug">
                             <label for="user-slug">Slug</label>
-                            {{gh-text-input
-                                class="user-name"
-                                id="user-slug"
-                                name="user"
-                                placeholder="Slug"
-                                selectOnClick="true"
-                                autocorrect="off"
-                                value=(readonly this.slugValue)
-                                input=(action (mut this.slugValue) value="target.value")
-                                focus-out=(action (perform this.updateSlug this.slugValue))
-                                data-test-slug-input=true
-                            }}
-                            <p>{{gh-blog-url}}/author/{{this.slugValue}}</p>
+                            <GhTextInput
+                                @class="user-name"
+                                @id="user-slug"
+                                @name="user"
+                                @placeholder="Slug"
+                                @selectOnClick="true"
+                                @autocorrect="off"
+                                @value={{readonly this.slugValue}}
+                                @input={{action (mut this.slugValue) value="target.value"}}
+                                @focus-out={{action (perform this.updateSlug this.slugValue)}}
+                                data-test-slug-input={{true}}
+                            />
+                            <p><GhBlogUrl />/author/{{this.slugValue}}</p>
                             <GhErrorMessage @errors={{this.user.errors}} @property="slug" data-test-error="user-slug" />
-                        {{/gh-form-group}}
+                        </GhFormGroup>
 
-                        {{#gh-form-group errors=this.user.errors hasValidated=this.user.hasValidated property="email"}}
+                        <GhFormGroup @errors={{this.user.errors}} @hasValidated={{this.user.hasValidated}} @property="email">
                             <label for="user-email">Email</label>
                             {{!-- Administrators only see text of Owner's email address but not input --}}
                             {{#if this.canChangeEmail}}
-                                {{gh-text-input
-                                    type="email"
-                                    id="user-email"
-                                    name="email"
-                                    placeholder="Email Address"
-                                    autocapitalize="off"
-                                    autocorrect="off"
-                                    autocomplete="off"
-                                    value=(readonly this.user.email)
-                                    input=(action (mut this.user.email) value="target.value")
-                                    focus-out=(action "validate" "email" target=this.user)
-                                    data-test-email-input=true}}
+                                <GhTextInput
+                                    @type="email"
+                                    @id="user-email"
+                                    @name="email"
+                                    @placeholder="Email Address"
+                                    @autocapitalize="off"
+                                    @autocorrect="off"
+                                    @autocomplete="off"
+                                    @value={{readonly this.user.email}}
+                                    @input={{action (mut this.user.email) value="target.value"}}
+                                    @focus-out={{action "validate" "email" target=this.user}}
+                                    data-test-email-input={{true}}
+                                />
                                 <GhErrorMessage @errors={{this.user.errors}} @property="email" data-test-error="user-email" />
                             {{else}}
                                 <span>{{this.user.email}}</span>
                             {{/if}}
                             <p>Used for notifications</p>
-                        {{/gh-form-group}}
+                        </GhFormGroup>
 
                         {{#if this.rolesDropdownIsVisible}}
                             <div class="form-group">
                                 <label for="user-role">Role</label>
                                 <span class="gh-select" tabindex="0">
-                                    {{one-way-select
-                                        id="new-user-role"
-                                        options=this.roles
-                                        optionValuePath="id"
-                                        optionLabelPath="name"
-                                        value=this.user.role
-                                        update=(action "changeRole")
-                                    }}
+                                    <OneWaySelect
+                                        @id="new-user-role"
+                                        @options={{this.roles}}
+                                        @optionValuePath="id"
+                                        @optionLabelPath="name"
+                                        @value={{this.user.role}}
+                                        @update={{action "changeRole"}}
+                                    />
                                 </span>
                                 <p>What permissions should this user have?</p>
                             </div>
                         {{/if}}
 
-                        {{#gh-form-group errors=this.user.errors hasValidated=this.user.hasValidated property="location"}}
+                        <GhFormGroup @errors={{this.user.errors}} @hasValidated={{this.user.hasValidated}} @property="location">
                             <label for="user-location">Location</label>
-                            {{gh-text-input
-                                id="user-location"
-                                value=(readonly this.user.location)
-                                input=(action (mut this.user.location) value="target.value")
-                                focus-out=(action "validate" "location" target=this.user)
-                                data-test-location-input=true}}
+                            <GhTextInput
+                                @id="user-location"
+                                @value={{readonly this.user.location}}
+                                @input={{action (mut this.user.location) value="target.value"}}
+                                @focus-out={{action "validate" "location" target=this.user}}
+                                data-test-location-input={{true}} />
                             <GhErrorMessage @errors={{this.user.errors}} @property="location" data-test-error="user-location" />
                             <p>Where in the world do you live?</p>
-                        {{/gh-form-group}}
+                        </GhFormGroup>
 
-                        {{#gh-form-group errors=this.user.errors hasValidated=this.user.hasValidated property="website"}}
+                        <GhFormGroup @errors={{this.user.errors}} @hasValidated={{this.user.hasValidated}} @property="website">
                             <label for="user-website">Website</label>
-                            {{gh-text-input
-                                type="url"
-                                id="user-website"
-                                autocapitalize="off"
-                                autocorrect="off"
-                                autocomplete="off"
-                                value=(readonly this.user.website)
-                                input=(action (mut this.user.website) value="target.value")
-                                focus-out=(action "validate" "website" target=this.user)
-                                data-test-website-input=true}}
+                            <GhTextInput
+                                @type="url"
+                                @id="user-website"
+                                @autocapitalize="off"
+                                @autocorrect="off"
+                                @autocomplete="off"
+                                @value={{readonly this.user.website}}
+                                @input={{action (mut this.user.website) value="target.value"}}
+                                @focus-out={{action "validate" "website" target=this.user}}
+                                data-test-website-input={{true}} />
                             <GhErrorMessage @errors={{this.user.errors}} @property="website" data-test-error="user-website" />
                             <p>Have a website or blog other than this one? Link it!</p>
-                        {{/gh-form-group}}
+                        </GhFormGroup>
 
-                        {{#gh-form-group errors=this.user.errors hasValidated=this.user.hasValidated property="facebook"}}
+                        <GhFormGroup @errors={{this.user.errors}} @hasValidated={{this.user.hasValidated}} @property="facebook">
                             <label for="user-facebook">Facebook Profile</label>
-                            {{gh-text-input
-                                type="url"
-                                placeholder="https://www.facebook.com/username"
-                                autocorrect="off"
-                                id="user-facebook"
-                                name="user[facebook]"
-                                value=(readonly this.user.facebook)
-                                input=(action (mut this._scratchFacebook) value="target.value")
-                                focus-out=(action "validateFacebookUrl")
-                                data-test-facebook-input=true
-                            }}
+                            <GhTextInput
+                                @type="url"
+                                @placeholder="https://www.facebook.com/username"
+                                @autocorrect="off"
+                                @id="user-facebook"
+                                @name="user[facebook]"
+                                @value={{readonly this.user.facebook}}
+                                @input={{action (mut this._scratchFacebook) value="target.value"}}
+                                @focus-out={{action "validateFacebookUrl"}}
+                                data-test-facebook-input={{true}}
+                            />
                             <GhErrorMessage @errors={{this.user.errors}} @property="facebook" data-test-error="user-facebook" />
                             <p>URL of your personal Facebook Profile</p>
-                        {{/gh-form-group}}
+                        </GhFormGroup>
 
-                        {{#gh-form-group errors=this.user.errors hasValidated=this.user.hasValidated property="twitter"}}
+                        <GhFormGroup @errors={{this.user.errors}} @hasValidated={{this.user.hasValidated}} @property="twitter">
                             <label for="user-twitter">Twitter Profile</label>
-                            {{gh-text-input
-                                type="url"
-                                placeholder="https://twitter.com/username"
-                                autocorrect="off"
-                                id="user-twitter"
-                                name="user[twitter]"
-                                value=(readonly this.user.twitter)
-                                input=(action (mut this._scratchTwitter) value="target.value")
-                                focus-out=(action "validateTwitterUrl")
-                                data-test-twitter-input=true
-                            }}
+                            <GhTextInput
+                                @type="url"
+                                @placeholder="https://twitter.com/username"
+                                @autocorrect="off"
+                                @id="user-twitter"
+                                @name="user[twitter]"
+                                @value={{readonly this.user.twitter}}
+                                @input={{action (mut this._scratchTwitter) value="target.value"}}
+                                @focus-out={{action "validateTwitterUrl"}}
+                                data-test-twitter-input={{true}}
+                            />
                             <GhErrorMessage @errors={{this.user.errors}} @property="twitter" data-test-error="user-twitter" />
                             <p>URL of your personal Twitter profile</p>
-                        {{/gh-form-group}}
+                        </GhFormGroup>
 
-                        {{#gh-form-group errors=this.user.errors hasValidated=this.user.hasValidated property="bio" class="bio-container"}}
+                        <GhFormGroup @errors={{this.user.errors}} @hasValidated={{this.user.hasValidated}} @property="bio" @class="bio-container">
                             <label for="user-bio">Bio</label>
-                            {{gh-textarea
-                                id="user-bio"
-                                value=(readonly this.user.bio)
-                                input=(action (mut this.user.bio) value="target.value")
-                                focus-out=(action "validate" "bio" target=this.user)
-                                data-test-bio-input=true
-                            }}
+                            <GhTextarea
+                                @id="user-bio"
+                                @value={{readonly this.user.bio}}
+                                @input={{action (mut this.user.bio) value="target.value"}}
+                                @focus-out={{action "validate" "bio" target=this.user}}
+                                data-test-bio-input={{true}}
+                            />
                             <GhErrorMessage @errors={{this.user.errors}} @property="bio" data-test-error="user-bio" />
                             <p>
                                 Write about you, in 200 characters or less.
                                 {{gh-count-characters this.user.bio}}
                             </p>
-                        {{/gh-form-group}}
+                        </GhFormGroup>
 
                     </fieldset>
                 </div>
@@ -288,56 +289,56 @@
                     <div class="pa5">
                         <fieldset class="user-details-password">
                             {{#if this.isOwnProfile}}
-                                {{#gh-form-group errors=this.user.errors hasValidated=this.user.hasValidated property="password"}}
+                                <GhFormGroup @errors={{this.user.errors}} @hasValidated={{this.user.hasValidated}} @property="password">
                                     <label for="user-password-old">Old Password</label>
-                                    {{gh-text-input
-                                        type="password"
-                                        id="user-password-old"
-                                        autocomplete="current-password"
-                                        value=(readonly this.user.password)
-                                        input=(action "updatePassword" value="target.value")
-                                        keyEvents=(hash
+                                    <GhTextInput
+                                        @type="password"
+                                        @id="user-password-old"
+                                        @autocomplete="current-password"
+                                        @value={{readonly this.user.password}}
+                                        @input={{action "updatePassword" value="target.value"}}
+                                        @keyEvents={{hash
                                             Enter=(action (perform this.user.saveNewPassword))
-                                        )
-                                        data-test-old-pass-input=true
-                                    }}
+                                        }}
+                                        data-test-old-pass-input={{true}}
+                                    />
                                     <GhErrorMessage @errors={{this.user.errors}} @property="password" data-test-error="user-old-pass" />
-                                {{/gh-form-group}}
+                                </GhFormGroup>
                             {{/if}}
 
-                            {{#gh-form-group errors=this.user.errors hasValidated=this.user.hasValidated property="newPassword"}}
+                            <GhFormGroup @errors={{this.user.errors}} @hasValidated={{this.user.hasValidated}} @property="newPassword">
                                 <label for="user-password-new">New Password</label>
-                                {{gh-text-input
-                                    value=(readonly this.user.newPassword)
-                                    type="password"
-                                    autocomplete="new-password"
-                                    id="user-password-new"
-                                    input=(action "updateNewPassword" value="target.value")
-                                    keyEvents=(hash
+                                <GhTextInput
+                                    @value={{readonly this.user.newPassword}}
+                                    @type="password"
+                                    @autocomplete="new-password"
+                                    @id="user-password-new"
+                                    @input={{action "updateNewPassword" value="target.value"}}
+                                    @keyEvents={{hash
                                         Enter=(action (perform this.user.saveNewPassword))
-                                    )
-                                    data-test-new-pass-input=true
-                                }}
+                                    }}
+                                    data-test-new-pass-input={{true}}
+                                />
                                 <GhErrorMessage @errors={{this.user.errors}} @property="newPassword" data-test-error="user-new-pass" />
-                            {{/gh-form-group}}
+                            </GhFormGroup>
 
-                            {{#gh-form-group errors=this.user.errors hasValidated=this.user.hasValidated property="ne2Password"}}
+                            <GhFormGroup @errors={{this.user.errors}} @hasValidated={{this.user.hasValidated}} @property="ne2Password">
                                 <label for="user-new-password-verification">Verify Password</label>
-                                {{gh-text-input
-                                    value=(readonly this.user.ne2Password)
-                                    type="password"
-                                    id="user-new-password-verification"
-                                    input=(action "updateNe2Password" value="target.value")
-                                    keyEvents=(hash
+                                <GhTextInput
+                                    @value={{readonly this.user.ne2Password}}
+                                    @type="password"
+                                    @id="user-new-password-verification"
+                                    @input={{action "updateNe2Password" value="target.value"}}
+                                    @keyEvents={{hash
                                         Enter=(action (perform this.user.saveNewPassword))
-                                    )
-                                    data-test-ne2-pass-input=true
-                                }}
+                                    }}
+                                    data-test-ne2-pass-input={{true}}
+                                />
                                 <GhErrorMessage @errors={{this.user.errors}} @property="ne2Password" data-test-error="user-ne2-pass" />
-                            {{/gh-form-group}}
+                            </GhFormGroup>
 
                             <div class="form-group">
-                                {{gh-task-button "Change Password" class="gh-btn gh-btn-red gh-btn-icon button-change-password" task=this.user.saveNewPassword data-test-save-pw-button=true}}
+                                <GhTaskButton @buttonText="Change Password" @class="gh-btn gh-btn-red gh-btn-icon button-change-password" @task={{this.user.saveNewPassword}} data-test-save-pw-button="true" />
                             </div>
                         </fieldset>
                     </div>

--- a/app/templates/tags-loading.hbs
+++ b/app/templates/tags-loading.hbs
@@ -2,11 +2,11 @@
     <header class="gh-canvas-header">
         <h2 class="gh-canvas-title" data-test-screen-title>Tags</h2>
         <section class="view-actions">
-            {{#link-to "tag.new" class="gh-btn gh-btn-green"}}<span>New tag</span>{{/link-to}}
+            <LinkTo @route="tag.new" class="gh-btn gh-btn-green"><span>New tag</span></LinkTo>
         </section>
     </header>
 
     <div class="gh-content">
-        {{gh-loading-spinner}}
+        <GhLoadingSpinner />
     </div>
 </section>

--- a/lib/koenig-editor/addon/templates/components/koenig-basic-html-input.hbs
+++ b/lib/koenig-editor/addon/templates/components/koenig-basic-html-input.hbs
@@ -4,34 +4,34 @@
         data-gramm="false"
         data-kg="editor"
         data-kg-allow-clickthrough
-        data-placeholder={{placeholder}}
+        data-placeholder={{this.placeholder}}
     ></div>
 </div>
 
-{{koenig-toolbar
-    basicOnly=true
-    editor=editor
-    editorRange=selectedRange
-    activeMarkupTagNames=activeMarkupTagNames
-    toggleMarkup=(action "toggleMarkup")
-    editLink=(action "editLink")
-}}
+<KoenigToolbar
+    @basicOnly={{true}}
+    @editor={{this.editor}}
+    @editorRange={{this.selectedRange}}
+    @activeMarkupTagNames={{this.activeMarkupTagNames}}
+    @toggleMarkup={{action "toggleMarkup"}}
+    @editLink={{action "editLink"}}
+/>
 
 {{!-- pop-up link hover toolbar --}}
-{{koenig-link-toolbar
-    editor=editor
-    container=element
-    linkRange=linkRange
-    selectedRange=selectedRange
-    editLink=(action "editLink")
-}}
+<KoenigLinkToolbar
+    @editor={{this.editor}}
+    @container={{this.element}}
+    @linkRange={{this.linkRange}}
+    @selectedRange={{this.selectedRange}}
+    @editLink={{action "editLink"}}
+/>
 
 {{!-- pop-up link editing toolbar --}}
-{{#if linkRange}}
-    {{koenig-link-input
-        editor=editor
-        linkRange=linkRange
-        selectedRange=selectedRange
-        cancel=(action "cancelEditLink")
-    }}
+{{#if this.linkRange}}
+    <KoenigLinkInput
+        @editor={{this.editor}}
+        @linkRange={{this.linkRange}}
+        @selectedRange={{this.selectedRange}}
+        @cancel={{action "cancelEditLink"}}
+    />
 {{/if}}

--- a/lib/koenig-editor/addon/templates/components/koenig-caption-input.hbs
+++ b/lib/koenig-editor/addon/templates/components/koenig-caption-input.hbs
@@ -1,11 +1,11 @@
-{{koenig-basic-html-input
-    html=caption
-    placeholder=(if isFocused "" placeholder)
-    class="miw-100 tc bn form-text bg-transparent"
-    name="caption"
-    onChange=(action update)
-    onFocus=(action (mut isFocused) true)
-    onBlur=(action (mut isFocused) false)
-    onNewline=(action "handleEnter")
-    didCreateEditor=(action "registerEditor")
-}}
+<KoenigBasicHtmlInput
+    @html={{this.caption}}
+    @placeholder={{if this.isFocused "" this.placeholder}}
+    @class="miw-100 tc bn form-text bg-transparent"
+    @name="caption"
+    @onChange={{action this.update}}
+    @onFocus={{action (mut this.isFocused) true}}
+    @onBlur={{action (mut this.isFocused) false}}
+    @onNewline={{action "handleEnter"}}
+    @didCreateEditor={{action "registerEditor"}}
+/>

--- a/lib/koenig-editor/addon/templates/components/koenig-card-bookmark.hbs
+++ b/lib/koenig-editor/addon/templates/components/koenig-card-bookmark.hbs
@@ -1,44 +1,44 @@
-{{#koenig-card
-    class="flex flex-column"
-    isSelected=isSelected
-    isEditing=isEditing
-    selectCard=(action selectCard)
-    deselectCard=(action deselectCard)
-    onDeselect=(action "onDeselect")
-    editCard=(action editCard)
-    toolbar=toolbar
-    hasEditMode=false
-    showSelectedOutline=payload.metadata
-    addParagraphAfterCard=addParagraphAfterCard
-    moveCursorToPrevSection=moveCursorToPrevSection
-    moveCursorToNextSection=moveCursorToNextSection
-    editor=editor
+<KoenigCard
+    @class="flex flex-column"
+    @isSelected={{this.isSelected}}
+    @isEditing={{this.isEditing}}
+    @selectCard={{action this.selectCard}}
+    @deselectCard={{action this.deselectCard}}
+    @onDeselect={{action "onDeselect"}}
+    @editCard={{action this.editCard}}
+    @toolbar={{this.toolbar}}
+    @hasEditMode={{false}}
+    @showSelectedOutline={{this.payload.metadata}}
+    @addParagraphAfterCard={{this.addParagraphAfterCard}}
+    @moveCursorToPrevSection={{this.moveCursorToPrevSection}}
+    @moveCursorToNextSection={{this.moveCursorToNextSection}}
+    @editor={{this.editor}}
     as |card|
-}}
-    {{#if payload.metadata}}
+>
+    {{#if this.payload.metadata}}
         <div class="kg-card-hover">
-            <div class="koenig-embed-{{payload.type}} flex justify-center relative" data-kg-embed>
+            <div class="koenig-embed-{{this.payload.type}} flex justify-center relative" data-kg-embed>
                 {{!-- <iframe class="bn miw-100" scrolling="no"></iframe> --}}
                 <figure class="kg-card kg-bookmark-card also-new-tag">
-                    <a href={{payload.metadata.url}} class="kg-bookmark-container">
+                    <a href={{this.payload.metadata.url}} class="kg-bookmark-container">
                         <div class="kg-bookmark-content">
-                            <div class="kg-bookmark-title">{{payload.metadata.title}}</div>
-                            <div class="kg-bookmark-description">{{payload.metadata.description}}</div>
+                            <div class="kg-bookmark-title">{{this.payload.metadata.title}}</div>
+                            <div class="kg-bookmark-description">{{this.payload.metadata.description}}</div>
                             <div class="kg-bookmark-metadata">
-                                {{#if payload.metadata.icon}}
-                                    <img src={{payload.metadata.icon}} class="kg-bookmark-icon">
+                                {{#if this.payload.metadata.icon}}
+                                    <img src={{this.payload.metadata.icon}} class="kg-bookmark-icon">
                                 {{/if}}
-                                {{#if payload.metadata.author}}
-                                    <span class="kg-bookmark-author">{{payload.metadata.author}}</span>
+                                {{#if this.payload.metadata.author}}
+                                    <span class="kg-bookmark-author">{{this.payload.metadata.author}}</span>
                                 {{/if}}
-                                {{#if payload.metadata.publisher}}
-                                    <span class="kg-bookmark-publisher">{{payload.metadata.publisher}}</span>
+                                {{#if this.payload.metadata.publisher}}
+                                    <span class="kg-bookmark-publisher">{{this.payload.metadata.publisher}}</span>
                                 {{/if}}
                             </div>
                         </div>
-                        {{#if payload.metadata.thumbnail}}
+                        {{#if this.payload.metadata.thumbnail}}
                             <div class="kg-bookmark-thumbnail">
-                                <img src={{payload.metadata.thumbnail}} >
+                                <img src={{this.payload.metadata.thumbnail}} >
                             </div>
                         {{/if}}
                     </a>
@@ -46,32 +46,31 @@
                 <div class="koenig-card-click-overlay ba b--transparent" data-kg-overlay></div>
             </div>
 
-            {{#if (or isSelected (clean-basic-html payload.caption))}}
-                {{card.captionInput
-                    caption=payload.caption
-                    update=(action "updateCaption")
-                    placeholder="Type caption for bookmark (optional)"
-                }}
+            {{#if (or this.isSelected (clean-basic-html this.payload.caption))}}
+                <card.CaptionInput
+                    @caption={{this.payload.caption}}
+                    @update={{action "updateCaption"}}
+                    @placeholder="Type caption for bookmark (optional)" />
             {{/if}}
         </div>
     {{else}}
-        {{#if convertUrl.isRunning}}
+        {{#if this.convertUrl.isRunning}}
             <div class="miw-100 pa2 ba br2 b--lightgrey-d1 flex items-center justify-center bg-whitegrey-l2 f6 lh-title h10">
                 &nbsp;<div class="ghost-spinner spinner-blue"></div>&nbsp;
             </div>
-        {{else if hasError}}
+        {{else if this.hasError}}
             <div class="miw-100 flex flex-row pa2 pl3 ba br2 b--red-l3 red bg-error-red f7 fw4 lh-title h10 items-center">
                 <span class="mr3">There was an error when parsing the URL.</span>
                 <button type="button" class="red-d2 mr3 fw6 hover-red" {{action "retry"}}><span class="underline">Retry</span></button>
                 <button type="button" class="red-d2 mr-auto fw6 underline hover-red" {{action "insertAsLink"}}><span class="underline">Paste URL as link</span></button>
-                <button type="button" {{action deleteCard}} class="nudge-right--2">
+                <button type="button" {{action this.deleteCard}} class="nudge-right--2">
                     {{svg-jar "close" class="w3 stroke-red-l3"}}
                 </button>
             </div>
         {{else}}
             <input
                 type="text"
-                value={{payload.url}}
+                value={{this.payload.url}}
                 name="url"
                 placeholder="Paste URL to add bookmark content..."
                 class="miw-100 pa2 ba br2 b--lightgrey-d2 f7 form-text lh-title tracked-2 h10 nl2 nr2"
@@ -79,4 +78,4 @@
                 onkeydown={{action "urlKeydown"}}>
         {{/if}}
     {{/if}}
-{{/koenig-card}}
+</KoenigCard>

--- a/lib/koenig-editor/addon/templates/components/koenig-card-code.hbs
+++ b/lib/koenig-editor/addon/templates/components/koenig-card-code.hbs
@@ -1,58 +1,58 @@
-{{#koenig-card
-    class=(concat "ba b--white relative kg-card-hover miw-100 relative" (if isEditing " bw2 pt1 pb1 pl2 nl6 pr6 nr6"))
-    style=cardStyle
-    headerOffset=headerOffset
-    toolbar=toolbar
-    payload=payload
-    isSelected=isSelected
-    isEditing=isEditing
-    selectCard=(action selectCard)
-    deselectCard=(action deselectCard)
-    editCard=(action editCard)
-    saveCard=(action saveCard)
-    onEnterEdit=(action "enterEditMode")
-    onLeaveEdit=(action "leaveEditMode")
-    addParagraphAfterCard=addParagraphAfterCard
-    moveCursorToPrevSection=moveCursorToPrevSection
-    moveCursorToNextSection=moveCursorToNextSection
-    editor=editor
+<KoenigCard
+    @class={{concat "ba b--white relative kg-card-hover miw-100 relative" (if this.isEditing " bw2 pt1 pb1 pl2 nl6 pr6 nr6")}}
+    @style={{this.cardStyle}}
+    @headerOffset={{this.headerOffset}}
+    @toolbar={{this.toolbar}}
+    @payload={{this.payload}}
+    @isSelected={{this.isSelected}}
+    @isEditing={{this.isEditing}}
+    @selectCard={{action this.selectCard}}
+    @deselectCard={{action this.deselectCard}}
+    @editCard={{action this.editCard}}
+    @saveCard={{action this.saveCard}}
+    @onEnterEdit={{action "enterEditMode"}}
+    @onLeaveEdit={{action "leaveEditMode"}}
+    @addParagraphAfterCard={{this.addParagraphAfterCard}}
+    @moveCursorToPrevSection={{this.moveCursorToPrevSection}}
+    @moveCursorToNextSection={{this.moveCursorToNextSection}}
+    @editor={{this.editor}}
     as |card|
-}}
-    {{#if isEditing}}
-        {{gh-cm-editor payload.code
-            class="koenig-card-code--editor koenig-card-html--editor"
-            textareaClass="o-0"
-            autofocus=true
-            lineWrapping=true
-            update=(action "updateCode")
-            mode=cmMode
-        }}
+>
+    {{#if this.isEditing}}
+        <GhCmEditor @value={{this.payload.code}}
+            @class="koenig-card-code--editor koenig-card-html--editor"
+            @textareaClass="o-0"
+            @autofocus={{true}}
+            @lineWrapping={{true}}
+            @update={{action "updateCode"}}
+            @mode={{this.cmMode}}
+        />
         <input
             type="text"
-            value={{readonly payload.language}}
-            onblur={{action (mut payload.language) value="target.value"}}
+            value={{readonly this.payload.language}}
+            onblur={{action (mut this.payload.language) value="target.value"}}
             placeholder="Language..."
             class="absolute w-20 pa1 ba b--lightgrey br2 f8 tracked-2 fw4 z-999 outline-0 anim-normal"
-            style={{languageInputStyle}}
+            style={{this.languageInputStyle}}
         />
     {{else}}
         <div class="koenig-card-html-rendered">
-            <pre><code class="line-numbers {{if payload.language (concat "language-" payload.language)}}">{{escapedCode}}</code></pre>
+            <pre><code class="line-numbers {{if this.payload.language (concat "language-" this.payload.language)}}">{{this.escapedCode}}</code></pre>
         </div>
-        {{#if payload.language}}
+        {{#if this.payload.language}}
             <div class="absolute top-2 right-2 flex justify-center items-center pa2">
-                <span class="db nudge-top--2 fw5 f8 midlightgrey">{{payload.language}}</span>
+                <span class="db nudge-top--2 fw5 f8 midlightgrey">{{this.payload.language}}</span>
             </div>
         {{/if}}
         <div class="koenig-card-click-overlay"></div>
     {{/if}}
 
-    {{#if (and (not isEditing) (or isSelected (clean-basic-html payload.caption)))}}
-        {{card.captionInput
-            class="z-999"
-            caption=payload.caption
-            update=(action "updateCaption")
-            placeholder="Type caption for code block (optional)"
-        }}
+    {{#if (and (not this.isEditing) (or this.isSelected (clean-basic-html this.payload.caption)))}}
+        <card.CaptionInput
+            @class="z-999"
+            @caption={{this.payload.caption}}
+            @update={{action "updateCaption"}}
+            @placeholder="Type caption for code block (optional)"
+        />
     {{/if}}
-{{/koenig-card}}
+</KoenigCard>

--- a/lib/koenig-editor/addon/templates/components/koenig-card-embed.hbs
+++ b/lib/koenig-editor/addon/templates/components/koenig-card-embed.hbs
@@ -1,53 +1,53 @@
-{{#koenig-card
-    class="flex flex-column"
-    isSelected=isSelected
-    isEditing=isEditing
-    selectCard=(action selectCard)
-    deselectCard=(action deselectCard)
-    onDeselect=(action "onDeselect")
-    editCard=(action editCard)
-    toolbar=toolbar
-    hasEditMode=false
-    showSelectedOutline=payload.html
-    addParagraphAfterCard=addParagraphAfterCard
-    moveCursorToPrevSection=moveCursorToPrevSection
-    moveCursorToNextSection=moveCursorToNextSection
-    editor=editor
+<KoenigCard
+    @class="flex flex-column"
+    @isSelected={{this.isSelected}}
+    @isEditing={{this.isEditing}}
+    @selectCard={{action this.selectCard}}
+    @deselectCard={{action this.deselectCard}}
+    @onDeselect={{action "onDeselect"}}
+    @editCard={{action this.editCard}}
+    @toolbar={{this.toolbar}}
+    @hasEditMode={{false}}
+    @showSelectedOutline={{this.payload.html}}
+    @addParagraphAfterCard={{this.addParagraphAfterCard}}
+    @moveCursorToPrevSection={{this.moveCursorToPrevSection}}
+    @moveCursorToNextSection={{this.moveCursorToNextSection}}
+    @editor={{this.editor}}
     as |card|
-}}
-    {{#if payload.html}}
+>
+    {{#if this.payload.html}}
         <div class="kg-card-hover">
-            <div class="koenig-embed-{{payload.type}} flex justify-center relative" data-kg-embed>
+            <div class="koenig-embed-{{this.payload.type}} flex justify-center relative" data-kg-embed>
                 <iframe class="bn miw-100" scrolling="no"></iframe>
                 <div class="koenig-card-click-overlay ba b--transparent" data-kg-overlay></div>
             </div>
 
-            {{#if (or isSelected (clean-basic-html payload.caption))}}
-                {{card.captionInput
-                    caption=payload.caption
-                    update=(action "updateCaption")
-                    placeholder="Type caption for embed (optional)"
-                }}
+            {{#if (or this.isSelected (clean-basic-html this.payload.caption))}}
+                <card.CaptionInput
+                    @caption={{this.payload.caption}}
+                    @update={{action "updateCaption"}}
+                    @placeholder="Type caption for embed (optional)"
+                />
             {{/if}}
         </div>
     {{else}}
-        {{#if convertUrl.isRunning}}
+        {{#if this.convertUrl.isRunning}}
             <div class="miw-100 pa2 ba br2 b--lightgrey-d1 flex items-center justify-center bg-whitegrey-l2 f6 lh-title h10">
                 &nbsp;<div class="ghost-spinner spinner-blue"></div>&nbsp;
             </div>
-        {{else if hasError}}
+        {{else if this.hasError}}
             <div class="miw-100 flex flex-row pa2 pl3 ba br2 b--red-l3 red bg-error-red f7 fw4 lh-title h10 items-center">
                 <span class="mr3">There was an error when parsing the URL.</span>
                 <button type="button" class="red-d2 mr3 fw6 hover-red" {{action "retry"}}><span class="underline">Retry</span></button>
                 <button type="button" class="red-d2 mr-auto fw6 underline hover-red" {{action "insertAsLink"}}><span class="underline">Paste URL as link</span></button>
-                <button type="button" {{action deleteCard}} class="nudge-right--2">
+                <button type="button" {{action this.deleteCard}} class="nudge-right--2">
                     {{svg-jar "close" class="w3 stroke-red-l3"}}
                 </button>
             </div>
         {{else}}
             <input
                 type="text"
-                value={{payload.url}}
+                value={{this.payload.url}}
                 name="url"
                 placeholder="Paste URL to add embedded content..."
                 class="miw-100 pa2 ba br2 b--lightgrey-d2 f7 form-text lh-title tracked-2 h10 nl2 nr2"
@@ -55,4 +55,4 @@
                 onkeydown={{action "urlKeydown"}}>
         {{/if}}
     {{/if}}
-{{/koenig-card}}
+</KoenigCard>

--- a/lib/koenig-editor/addon/templates/components/koenig-card-gallery.hbs
+++ b/lib/koenig-editor/addon/templates/components/koenig-card-gallery.hbs
@@ -1,35 +1,35 @@
-{{#koenig-card
-    tagName="figure"
-    class=(concat (kg-style "media-card") " " (kg-style "breakout" size="wide") " flex flex-column")
-    isSelected=isSelected
-    isEditing=isEditing
-    selectCard=(action selectCard)
-    deselectCard=(action deselectCard)
-    editCard=(action editCard)
-    toolbar=toolbar
-    hasEditMode=false
-    addParagraphAfterCard=addParagraphAfterCard
-    moveCursorToPrevSection=moveCursorToPrevSection
-    moveCursorToNextSection=moveCursorToNextSection
-    editor=editor
-    onSelect=(action "didSelect")
-    onDeselect=(action "didDeselect")
+<KoenigCard
+    @tagName="figure"
+    @class={{concat (kg-style "media-card") " " (kg-style "breakout" size="wide") " flex flex-column"}}
+    @isSelected={{this.isSelected}}
+    @isEditing={{this.isEditing}}
+    @selectCard={{action this.selectCard}}
+    @deselectCard={{action this.deselectCard}}
+    @editCard={{action this.editCard}}
+    @toolbar={{this.toolbar}}
+    @hasEditMode={{false}}
+    @addParagraphAfterCard={{this.addParagraphAfterCard}}
+    @moveCursorToPrevSection={{this.moveCursorToPrevSection}}
+    @moveCursorToNextSection={{this.moveCursorToNextSection}}
+    @editor={{this.editor}}
+    @onSelect={{action "didSelect"}}
+    @onDeselect={{action "didDeselect"}}
     as |card|
-}}
-    {{#gh-uploader
-        files=files
-        accept=imageMimeTypes
-        extensions=imageExtensions
-        onUploadStart=(action "addImage")
-        onUploadSuccess=(action "setImageSrc")
-        onUploadFailure=(action "uploadFailed")
-        onFailed=(action "handleErrors")
+>
+    <GhUploader
+        @files={{this.files}}
+        @accept={{this.imageMimeTypes}}
+        @extensions={{this.imageExtensions}}
+        @onUploadStart={{action "addImage"}}
+        @onUploadSuccess={{action "setImageSrc"}}
+        @onUploadFailure={{action "uploadFailed"}}
+        @onFailed={{action "handleErrors"}}
         as |uploader|
-    }}
-        <div class="relative{{unless images " bg-whitegrey-l2"}}">
-            {{#if imageRows}}
+    >
+        <div class="relative{{unless this.images " bg-whitegrey-l2"}}">
+            {{#if this.imageRows}}
                 <div class="flex flex-column" data-gallery>
-                    {{#each imageRows as |row index|}}
+                    {{#each this.imageRows as |row index|}}
                         <div class="flex flex-row justify-center" data-row="{{index}}">
                             {{#each row as |image|}}
                                 <div
@@ -43,7 +43,7 @@
                                         height={{image.height}}
                                         class="w-100 h-100 db pe-none"
                                     >
-                                    {{#unless koenigDragDropHandler.isDragging}}
+                                    {{#unless this.koenigDragDropHandler.isDragging}}
                                         <div class="bg-image-overlay-top child pe-none {{image.overlayClasses}}">
                                             <div class="flex flex-row-reverse">
                                                 <button class="bg-white-90 pl3 pr3 br3 pe-auto" {{action "deleteImage" image}}>
@@ -59,22 +59,22 @@
                 </div>
             {{/if}}
 
-            {{#if (or uploader.isUploading (is-empty imageRows))}}
-                <div class="relative miw-100 flex items-center {{if (is-empty imageRows) "kg-media-placeholder ba b--whitegrey" "absolute absolute--fill bg-white-50"}}">
-                    {{#if isDraggedOver}}
+            {{#if (or uploader.isUploading (is-empty this.imageRows))}}
+                <div class="relative miw-100 flex items-center {{if (is-empty this.imageRows) "kg-media-placeholder ba b--whitegrey" "absolute absolute--fill bg-white-50"}}">
+                    {{#if this.isDraggedOver}}
                         <span class="db center sans-serif fw7 f7 middarkgrey">
                             Drop 'em like it's hot 🔥
                         </span>
                     {{else if uploader.isUploading}}
                         {{uploader.progressBar}}
-                    {{else if (is-empty imageRows)}}
+                    {{else if (is-empty this.imageRows)}}
                         <button class="flex flex-column items-center center sans-serif fw4 f7 middarkgrey pa8 pt6 pb6 kg-image-button" onclick={{action "triggerFileDialog"}}>
                             {{svg-jar "gallery-placeholder" class="kg-placeholder-gallery nudge-bottom--10"}}
                             <span class="mt2 midgrey">Click to select up to 9 images</span>
                         </button>
                     {{/if}}
                 </div>
-            {{else if isDraggedOver}}
+            {{else if this.isDraggedOver}}
                 <div class="absolute absolute--fill flex items-center bg-black-60 pe-none">
                     <span class="db center sans-serif fw7 f7 white">
                         Drop to add up to 9 images
@@ -82,10 +82,10 @@
                 </div>
             {{/if}}
 
-            {{#if (and errorMessage (not isDraggedOver))}}
+            {{#if (and this.errorMessage (not this.isDraggedOver))}}
                 <div class="absolute absolute--fill flex items-center bg-black-60">
                     <span class="db center sans-serif fw7 f7 pl2 pr2 bg-red white">
-                        {{errorMessage}}.
+                        {{this.errorMessage}}.
                         <button onclick={{action "clearErrorMessage"}} style="text-decoration: underline !important">
                             Dismiss
                         </button>
@@ -95,15 +95,15 @@
         </div>
 
         <div style="display:none">
-            {{gh-file-input multiple=true action=(action "setFiles") accept=imageMimeTypes}}
+            <GhFileInput @multiple={{true}} @action={{action "setFiles"}} @accept={{this.imageMimeTypes}} />
         </div>
-    {{/gh-uploader}}
+    </GhUploader>
 
-    {{#if (or isSelected (clean-basic-html payload.caption))}}
-        {{card.captionInput
-            caption=payload.caption
-            update=(action "updateCaption")
-            placeholder="Type caption for gallery (optional)"
-        }}
+    {{#if (or this.isSelected (clean-basic-html this.payload.caption))}}
+        <card.CaptionInput
+            @caption={{this.payload.caption}}
+            @update={{action "updateCaption"}}
+            @placeholder="Type caption for gallery (optional)"
+        />
     {{/if}}
-{{/koenig-card}}
+</KoenigCard>

--- a/lib/koenig-editor/addon/templates/components/koenig-card-hr.hbs
+++ b/lib/koenig-editor/addon/templates/components/koenig-card-hr.hbs
@@ -1,12 +1,12 @@
-{{#koenig-card
-    class="kg-card-hover"
-    isSelected=isSelected
-    isEditing=isEditing
-    selectCard=(action selectCard)
-    deselectCard=(action deselectCard)
-    editCard=(action editCard)
-    hasEditMode=false
-    editor=editor
-}}
+<KoenigCard
+    @class="kg-card-hover"
+    @isSelected={{this.isSelected}}
+    @isEditing={{this.isEditing}}
+    @selectCard={{action this.selectCard}}
+    @deselectCard={{action this.deselectCard}}
+    @editCard={{action this.editCard}}
+    @hasEditMode={{false}}
+    @editor={{this.editor}}
+>
     <hr>
-{{/koenig-card}}
+</KoenigCard>

--- a/lib/koenig-editor/addon/templates/components/koenig-card-html.hbs
+++ b/lib/koenig-editor/addon/templates/components/koenig-card-html.hbs
@@ -1,27 +1,27 @@
-{{#koenig-card
-    icon="koenig/card-indicator-html"
-    class=(concat (kg-style "container-card") " mih10 miw-100 relative")
-    headerOffset=headerOffset
-    toolbar=toolbar
-    payload=payload
-    isSelected=isSelected
-    isEditing=isEditing
-    selectCard=(action selectCard)
-    deselectCard=(action deselectCard)
-    editCard=(action editCard)
-    saveCard=(action saveCard)
-    onLeaveEdit=(action "leaveEditMode")
-    editor=editor
-}}
-    {{#if isEditing}}
-        {{gh-cm-editor payload.html
-            class="koenig-card-html--editor"
-            autofocus=true
-            lineWrapping=true
-            update=(action "updateHtml")
-        }}
+<KoenigCard
+    @icon="koenig/card-indicator-html"
+    @class={{concat (kg-style "container-card") " mih10 miw-100 relative"}}
+    @headerOffset={{this.headerOffset}}
+    @toolbar={{this.toolbar}}
+    @payload={{this.payload}}
+    @isSelected={{this.isSelected}}
+    @isEditing={{this.isEditing}}
+    @selectCard={{action this.selectCard}}
+    @deselectCard={{action this.deselectCard}}
+    @editCard={{action this.editCard}}
+    @saveCard={{action this.saveCard}}
+    @onLeaveEdit={{action "leaveEditMode"}}
+    @editor={{this.editor}}
+>
+    {{#if this.isEditing}}
+        <GhCmEditor @value={{this.payload.html}}
+            @class="koenig-card-html--editor"
+            @autofocus=true
+            @lineWrapping=true
+            @update={{action "updateHtml"}}
+        />
     {{else}}
-        <div class="koenig-card-html-rendered">{{{sanitize-html payload.html}}}</div>
+        <div class="koenig-card-html-rendered">{{{sanitize-html this.payload.html}}}</div>
         <div class="koenig-card-click-overlay"></div>
     {{/if}}
-{{/koenig-card}}
+</KoenigCard>

--- a/lib/koenig-editor/addon/templates/components/koenig-card-image.hbs
+++ b/lib/koenig-editor/addon/templates/components/koenig-card-image.hbs
@@ -1,32 +1,32 @@
-{{#koenig-card
-    tagName="figure"
-    class=(concat (kg-style "media-card") " " (kg-style "breakout" size=payload.cardWidth) " flex flex-column")
-    isSelected=isSelected
-    isEditing=isEditing
-    selectCard=(action selectCard)
-    deselectCard=(action deselectCard)
-    editCard=(action editCard)
-    toolbar=toolbar
-    hasEditMode=false
-    addParagraphAfterCard=addParagraphAfterCard
-    moveCursorToPrevSection=moveCursorToPrevSection
-    moveCursorToNextSection=moveCursorToNextSection
-    editor=editor
+<KoenigCard
+    @tagName="figure"
+    @class={{concat (kg-style "media-card") " " (kg-style "breakout" size=this.payload.cardWidth) " flex flex-column"}}
+    @isSelected={{this.isSelected}}
+    @isEditing={{this.isEditing}}
+    @selectCard={{action this.selectCard}}
+    @deselectCard={{action this.deselectCard}}
+    @editCard={{action this.editCard}}
+    @toolbar={{this.toolbar}}
+    @hasEditMode={{false}}
+    @addParagraphAfterCard={{this.addParagraphAfterCard}}
+    @moveCursorToPrevSection={{this.moveCursorToPrevSection}}
+    @moveCursorToNextSection={{this.moveCursorToNextSection}}
+    @editor={{this.editor}}
     as |card|
-}}
-    {{#gh-uploader
-        files=files
-        accept=imageMimeTypes
-        extensions=imageExtensions
-        onStart=(action "setPreviewSrc")
-        onComplete=(action "updateSrc")
-        onFailed=(action "resetSrcs")
+>
+    <GhUploader
+        @files={{this.files}}
+        @accept={{this.imageMimeTypes}}
+        @extensions={{this.imageExtensions}}
+        @onStart={{action "setPreviewSrc"}}
+        @onComplete={{action "updateSrc"}}
+        @onFailed={{action "resetSrcs"}}
         as |uploader|
-    }}
-        <div class="relative{{unless (or previewSrc payload.src) " bg-whitegrey-l2"}}">
-            {{#if (or previewSrc payload.src)}}
-                <img src={{or previewSrc payload.src}} class="{{kg-style kgImgStyle sidebar=ui.hasSideNav}}" alt={{payload.alt}}>
-                {{#if isDraggedOver}}
+    >
+        <div class="relative{{unless (or this.previewSrc this.payload.src) " bg-whitegrey-l2"}}">
+            {{#if (or this.previewSrc this.payload.src)}}
+                <img src={{or this.previewSrc this.payload.src}} class="{{kg-style this.kgImgStyle sidebar=this.ui.hasSideNav}}" alt={{this.payload.alt}}>
+                {{#if this.isDraggedOver}}
                     <div class="absolute absolute--fill flex items-center bg-black-60 pe-none">
                         <span class="db center sans-serif fw7 f7 white">
                             Drop to replace image
@@ -35,21 +35,21 @@
                 {{/if}}
             {{/if}}
 
-            {{#if (or uploader.errors uploader.isUploading (not payload.src))}}
-                <div class="relative miw-100 flex items-center {{if (not previewSrc payload.src) "kg-media-placeholder ba b--whitegrey" "absolute absolute--fill bg-white-50"}}">
+            {{#if (or uploader.errors uploader.isUploading (not this.payload.src))}}
+                <div class="relative miw-100 flex items-center {{if (not this.previewSrc this.payload.src) "kg-media-placeholder ba b--whitegrey" "absolute absolute--fill bg-white-50"}}">
                     {{#if uploader.errors}}
                         <span class="db absolute top-0 right-0 left-0 pl2 pr2 bg-red white sans-serif f7">
                             {{uploader.errors.firstObject.message}}
                         </span>
                     {{/if}}
 
-                    {{#if isDraggedOver}}
+                    {{#if this.isDraggedOver}}
                         <span class="db center sans-serif fw7 f7 middarkgrey">
                             Drop it like it's hot 🔥
                         </span>
                     {{else if uploader.isUploading}}
                         {{uploader.progressBar}}
-                    {{else if (not previewSrc payload.src)}}
+                    {{else if (not this.previewSrc this.payload.src)}}
                         <button class="flex flex-column items-center center sans-serif fw4 f7 middarkgrey pa16 pt14 pb14 kg-image-button" onclick={{action "triggerFileDialog"}}>
                             {{svg-jar this.placeholder class="kg-placeholder-image"}}
                             <span class="mt2 midgrey">Click to select an image</span>
@@ -60,24 +60,24 @@
         </div>
 
         <div style="display:none">
-            {{gh-file-input multiple=false action=uploader.setFiles accept=imageMimeTypes}}
+            <GhFileInput @multiple={{false}} @action={{uploader.setFiles}} @accept={{this.imageMimeTypes}} />
         </div>
-    {{/gh-uploader}}
+    </GhUploader>
 
-    {{#if (or isSelected (clean-basic-html payload.caption))}}
+    {{#if (or this.isSelected (clean-basic-html this.payload.caption))}}
         {{#if this.isEditingAlt}}
-            <card.altInput
+            <card.AltInput
                 @alt={{this.payload.alt}}
                 @update={{this.updateAlt}}
                 @placeholder="Type alt text for image (optional)" />
         {{else}}
-            <card.captionInput
-                @caption={{payload.caption}}
+            <card.CaptionInput
+                @caption={{this.payload.caption}}
                 @update={{this.updateCaption}}
                 @placeholder="Type caption for image (optional)" />
         {{/if}}
 
-        {{#if isSelected}}
+        {{#if this.isSelected}}
             <button
                 title="Toggle between editing alt text and caption"
                 class="absolute right-0 bottom-0 ma2 pl1 pr1 ba br3 f8 sans-serif fw4 lh-title tracked-2 bg-white {{if this.isEditingAlt "bg-blue b--blue white" "b--midlightgrey midlightgrey"}}"
@@ -88,10 +88,10 @@
         {{/if}}
     {{/if}}
 
-    {{#if imageSelector}}
-        {{component imageSelector
-            searchTerm=payload.searchTerm
+    {{#if this.imageSelector}}
+        {{component this.imageSelector
+            searchTerm=this.payload.searchTerm
             select=(action "selectFromImageSelector")
             close=(action "closeImageSelector")}}
     {{/if}}
-{{/koenig-card}}
+</KoenigCard>

--- a/lib/koenig-editor/addon/templates/components/koenig-card-markdown.hbs
+++ b/lib/koenig-editor/addon/templates/components/koenig-card-markdown.hbs
@@ -1,49 +1,49 @@
-{{#koenig-card
-    icon="koenig/card-indicator-markdown"
-    class=(concat (kg-style "container-card") " koenig-card-markdown-rendered")
-    headerOffset=headerOffset
-    toolbar=toolbar
-    payload=payload
-    isSelected=isSelected
-    isEditing=isEditing
-    onEnterEdit=(action "enterEditMode")
-    onLeaveEdit=(action "leaveEditMode")
-    selectCard=(action selectCard)
-    deselectCard=(action deselectCard)
-    editCard=(action editCard)
-    saveCard=(action saveCard)
-    editor=editor
-}}
-    {{#if isEditing}}
-        {{#gh-editor as |editor|}}
-            {{gh-scroll-trigger
-                triggerOffset=(hash bottom=bottomOffset)
-                enter=(action "topEntered")
-                exit=(action "topExited")
-                registerElement=(action "registerTop")
-            }}
+<KoenigCard
+    @icon="koenig/card-indicator-markdown"
+    @class={{concat (kg-style "container-card") " koenig-card-markdown-rendered"}}
+    @headerOffset={{this.headerOffset}}
+    @toolbar={{this.toolbar}}
+    @payload={{this.payload}}
+    @isSelected={{this.isSelected}}
+    @isEditing={{this.isEditing}}
+    @onEnterEdit={{action "enterEditMode"}}
+    @onLeaveEdit={{action "leaveEditMode"}}
+    @selectCard={{action this.selectCard}}
+    @deselectCard={{action this.deselectCard}}
+    @editCard={{action this.editCard}}
+    @saveCard={{action this.saveCard}}
+    @editor={{this.editor}}
+>
+    {{#if this.isEditing}}
+        <GhEditor as |editor|>
+            <GhScrollTrigger
+                @triggerOffset={{hash bottom=this.bottomOffset}}
+                @enter={{action "topEntered"}}
+                @exit={{action "topExited"}}
+                @registerElement={{action "registerTop"}}
+            />
 
-            {{#gh-markdown-editor
-                markdown=(readonly payload.markdown)
-                onChange=(action "updateMarkdown")
-                autofocus=true
-                enableSideBySide=false
-                enablePreview=false
-                enableHemingway=false
-                options=(hash status=false)
-                uploadedImageUrls=editor.uploadedImageUrls
-                onImageFilesSelected=(action editor.uploadImages)
-                imageMimeTypes=editor.imageMimeTypes
+            <GhMarkdownEditor
+                @markdown={{readonly this.payload.markdown}}
+                @onChange={{action "updateMarkdown"}}
+                @autofocus={{true}}
+                @enableSideBySide={{false}}
+                @enablePreview={{false}}
+                @enableHemingway={{false}}
+                @options={{hash status=false}}
+                @uploadedImageUrls={{editor.uploadedImageUrls}}
+                @onImageFilesSelected={{action editor.uploadImages}}
+                @imageMimeTypes={{editor.imageMimeTypes}}
                 as |markdown|
-            }}
+            >
                 {{markdown.editor}}
-            {{/gh-markdown-editor}}
+            </GhMarkdownEditor>
 
-            {{gh-scroll-trigger
-                enter=(action "bottomEntered")
-                exit=(action "bottomExited")
-                registerElement=(action "registerBottom")
-            }}
+            <GhScrollTrigger
+                @enter={{action "bottomEntered"}}
+                @exit={{action "bottomExited"}}
+                @registerElement={{action "registerBottom"}}
+            />
 
             {{!-- files are dragged over editor pane --}}
             {{#if editor.isDraggedOver}}
@@ -56,14 +56,14 @@
 
             {{!-- files have been dropped ready to be uploaded --}}
             {{#if editor.droppedFiles}}
-                {{#gh-uploader
-                    files=editor.droppedFiles
-                    accept=editor.imageMimeTypes
-                    extensions=editor.imageExtensions
-                    onComplete=(action editor.uploadComplete)
-                    onCancel=(action editor.uploadCancelled)
+                <GhUploader
+                    @files={{editor.droppedFiles}}
+                    @accept={{editor.imageMimeTypes}}
+                    @extensions={{editor.imageExtensions}}
+                    @onComplete={{action editor.uploadComplete}}
+                    @onCancel={{action editor.uploadCancelled}}
                     as |upload|
-                }}
+                >
                     <div class="gh-editor-image-upload {{if upload.errors "-error"}}">
                         <div class="gh-editor-image-upload-content">
                             {{#if upload.errors}}
@@ -83,15 +83,15 @@
                             {{/if}}
                         </div>
                     </div>
-                {{/gh-uploader}}
+                </GhUploader>
             {{/if}}
-        {{/gh-editor}}
+        </GhEditor>
 
-        {{#if preventClick}}
+        {{#if this.preventClick}}
             <div class="absolute absolute--fill z-max"></div>
         {{/if}}
     {{else}}
-        {{renderedMarkdown}}
+        {{this.renderedMarkdown}}
         <div class="absolute absolute--fill z-999"></div>
     {{/if}}
-{{/koenig-card}}
+</KoenigCard>

--- a/lib/koenig-editor/addon/templates/components/koenig-card.hbs
+++ b/lib/koenig-editor/addon/templates/components/koenig-card.hbs
@@ -1,26 +1,26 @@
-{{#if icon}}
-    {{#sticky-element top=iconTop bottom=36}}
-        {{svg-jar icon class=iconClass}}
-    {{/sticky-element}}
+{{#if this.icon}}
+    <StickyElement @top={{this.iconTop}} @bottom={{36}}>
+        {{svg-jar this.icon class=this.iconClass}}
+    </StickyElement>
 {{/if}}
 
 {{yield (hash
-    captionInput=(component "koenig-caption-input"
-        captureInput=isSelected
-        addParagraphAfterCard=addParagraphAfterCard
-        moveCursorToPrevSection=moveCursorToPrevSection
-        moveCursorToNextSection=moveCursorToNextSection
+    CaptionInput=(component "koenig-caption-input"
+        captureInput=this.isSelected
+        addParagraphAfterCard=this.addParagraphAfterCard
+        moveCursorToPrevSection=this.moveCursorToPrevSection
+        moveCursorToNextSection=this.moveCursorToNextSection
     )
-    altInput=(component "koenig-alt-input"
-        addParagraphAfterCard=addParagraphAfterCard
-        moveCursorToPrevSection=moveCursorToPrevSection
-        moveCursorToNextSection=moveCursorToNextSection
+    AltInput=(component "koenig-alt-input"
+        addParagraphAfterCard=this.addParagraphAfterCard
+        moveCursorToPrevSection=this.moveCursorToPrevSection
+        moveCursorToNextSection=this.moveCursorToNextSection
     )
 )}}
 
-{{#if toolbar}}
-    {{#kg-action-bar class="absolute" style=toolbarStyle isVisible=shouldShowToolbar}}
-        {{#each toolbar.items as |item|}}
+{{#if this.toolbar}}
+    <KgActionBar @class="absolute" @style={{this.toolbarStyle}} @isVisible={{this.shouldShowToolbar}}>
+        {{#each this.toolbar.items as |item|}}
             {{#if item.divider}}
                 <li class="ma0 kg-action-bar-divider bg-darkgrey-d2 h5"></li>
             {{else}}
@@ -36,5 +36,5 @@
                 </li>
             {{/if}}
         {{/each}}
-    {{/kg-action-bar}}
+    </KgActionBar>
 {{/if}}

--- a/lib/koenig-editor/addon/templates/components/koenig-editor.hbs
+++ b/lib/koenig-editor/addon/templates/components/koenig-editor.hbs
@@ -3,65 +3,65 @@
 </div>
 
 {{!-- pop-up markup toolbar is shown when there's a selection --}}
-{{koenig-toolbar
-    editor=editor
-    editorRange=selectedRange
-    activeMarkupTagNames=activeMarkupTagNames
-    activeSectionTagNames=activeSectionTagNames
-    toggleMarkup=(action "toggleMarkup")
-    toggleSection=(action "toggleSection")
-    toggleHeaderSection=(action "toggleHeaderSection")
-    editLink=(action "editLink")
-}}
+<KoenigToolbar
+    @editor={{this.editor}}
+    @editorRange={{this.selectedRange}}
+    @activeMarkupTagNames={{this.activeMarkupTagNames}}
+    @activeSectionTagNames={{this.activeSectionTagNames}}
+    @toggleMarkup={{action "toggleMarkup"}}
+    @toggleSection={{action "toggleSection"}}
+    @toggleHeaderSection={{action "toggleHeaderSection"}}
+    @editLink={{action "editLink"}}
+/>
 
 {{!-- pop-up link hover toolbar --}}
-{{koenig-link-toolbar
-    editor=editor
-    container=element
-    linkRange=linkRange
-    selectedRange=selectedRange
-    editLink=(action "editLink")
-}}
+<KoenigLinkToolbar
+    @editor={{this.editor}}
+    @container={{this.element}}
+    @linkRange={{this.linkRange}}
+    @selectedRange={{this.selectedRange}}
+    @editLink={{action "editLink"}}
+/>
 
 {{!-- pop-up link editing toolbar --}}
-{{#if linkRange}}
-    {{koenig-link-input
-        editor=editor
-        linkRange=linkRange
-        selectedRange=selectedRange
-        cancel=(action "cancelEditLink")
-    }}
+{{#if this.linkRange}}
+    <KoenigLinkInput
+        @editor={{this.editor}}
+        @linkRange={{this.linkRange}}
+        @selectedRange={{this.selectedRange}}
+        @cancel={{action "cancelEditLink"}}
+    />
 {{/if}}
 
 {{!-- (+) icon and pop-up menu --}}
-{{koenig-plus-menu
-    editor=editor
-    editorRange=selectedRange
-    replaceWithCardSection=(action "replaceWithCardSection")
-}}
+<KoenigPlusMenu
+    @editor={{this.editor}}
+    @editorRange={{this.selectedRange}}
+    @replaceWithCardSection={{action "replaceWithCardSection"}}
+/>
 
 {{!-- slash menu popup --}}
-{{koenig-slash-menu
-    editor=editor
-    editorRange=selectedRange
-    replaceWithCardSection=(action "replaceWithCardSection")
-}}
+<KoenigSlashMenu
+    @editor={{this.editor}}
+    @editorRange={{this.selectedRange}}
+    @replaceWithCardSection={{action "replaceWithCardSection"}}
+/>
 
 {{!-- all component cards wormholed into the editor canvas --}}
-{{#each componentCards as |card|}}
+{{#each this.componentCards as |card|}}
     {{!--
         TODO: move to the public {{in-element}} API when it's available
         https://github.com/cibernox/rfcs/blob/make-in-element-public/text/0000-promote-in-element-to-public-api.md
     --}}
     {{#-in-element card.destinationElement}}
         {{component card.componentName
-            editor=editor
+            editor=this.editor
             postModel=card.postModel
             cardName=card.cardName
             payload=card.payload
             env=card.env
             options=card.options
-            headerOffset=headerOffset
+            headerOffset=this.headerOffset
             saveCard=(action card.env.save)
             cancelCard=(action card.env.cancel)
             removeCard=(action card.env.remove)

--- a/lib/koenig-editor/addon/templates/components/koenig-plus-menu.hbs
+++ b/lib/koenig-editor/addon/templates/components/koenig-plus-menu.hbs
@@ -1,14 +1,14 @@
-{{#if showButton}}
+{{#if this.showButton}}
     <button class="koenig-plus-menu-button flex justify-center items-center relative w9 h9 ba b--midlightgrey-l2 bg-white br-100 anim-normal" onclick={{action "openMenu"}}>{{svg-jar "plus" class="w4 h4 stroke-middarkgrey i-strokew--2"}}</button>
 {{/if}}
 
-{{#if showMenu}}
+{{#if this.showMenu}}
     {{!-- TODO: restructure HTML and update kg-style helper to avoid negative margins on divider/title elements --}}
     <div class="{{kg-style "cardmenu"}} pa0">
         {{!-- <div class="koenig-cardmenu-search">
             {{svg-jar "koenig/search"}}
             <input type="text" placeholder="Search for a card..." class="gh-input koenig-cardmenu-search-input">
         </div> --}}
-        {{koenig-menu-content itemSections=itemSections itemClicked=(action "itemClicked")}}
+        <KoenigMenuContent @itemSections={{this.itemSections}} @itemClicked={{action "itemClicked"}} />
     </div>
 {{/if}}

--- a/lib/koenig-editor/addon/templates/components/koenig-slash-menu.hbs
+++ b/lib/koenig-editor/addon/templates/components/koenig-slash-menu.hbs
@@ -1,5 +1,5 @@
-{{#if showMenu}}
+{{#if this.showMenu}}
     <div class="koenig-cardmenu {{kg-style "cardmenu"}}">
-        {{koenig-menu-content itemSections=itemSections itemClicked=(action "itemClicked")}}
+        <KoenigMenuContent @itemSections={{this.itemSections}} @itemClicked={{action "itemClicked"}} />
     </div>
 {{/if}}

--- a/lib/koenig-editor/addon/templates/components/koenig-toolbar.hbs
+++ b/lib/koenig-editor/addon/templates/components/koenig-toolbar.hbs
@@ -1,4 +1,4 @@
-{{#kg-action-bar class="relative" instantClose=true isVisible=showToolbar}}
+<KgActionBar @class="relative" @instantClose={{true}} @isVisible={{this.showToolbar}}>
     <li class="ma0 lh-solid">
         <button
             type="button"
@@ -6,7 +6,7 @@
             class="dib dim-lite link h9 w9 nudge-top--1"
             {{action "toggleMarkup" "strong"}}
         >
-            {{svg-jar "koenig/kg-bold" class=(concat (if activeMarkupTagNames.isStrong "fill-blue-l2" "fill-white") " w4 h4")}}
+            {{svg-jar "koenig/kg-bold" class=(concat (if this.activeMarkupTagNames.isStrong "fill-blue-l2" "fill-white") " w4 h4")}}
         </button>
     </li>
     <li class="ma0 lh-solid">
@@ -16,7 +16,7 @@
             class="dib dim-lite link h9 w9 nudge-top--1"
             {{action "toggleMarkup" "em"}}
         >
-            {{svg-jar "koenig/kg-italic" class=(concat (if (or activeMarkupTagNames.isEm activeMarkupTagNames.isI) "fill-blue-l2" "fill-white") " w4 h4")}}
+            {{svg-jar "koenig/kg-italic" class=(concat (if (or this.activeMarkupTagNames.isEm this.activeMarkupTagNames.isI) "fill-blue-l2" "fill-white") " w4 h4")}}
         </button>
     </li>
     {{#unless basicOnly}}
@@ -27,7 +27,7 @@
                 class="dib dim-lite link h9 w9 nudge-top--1"
                 {{action "toggleHeaderSection" "h2"}}
             >
-                {{svg-jar "koenig/kg-heading-1" class=(concat (if activeSectionTagNames.isH2 "fill-blue-l2" "fill-white") " w4 h4")}}
+                {{svg-jar "koenig/kg-heading-1" class=(concat (if this.activeSectionTagNames.isH2 "fill-blue-l2" "fill-white") " w4 h4")}}
             </button>
         </li>
         <li class="ma0 lh-solid">
@@ -37,7 +37,7 @@
                 class="dib dim-lite link h9 w9 nudge-top--1"
                 {{action "toggleHeaderSection" "h3"}}
             >
-                {{svg-jar "koenig/kg-heading-2" class=(concat (if activeSectionTagNames.isH3 "fill-blue-l2" "fill-white") " w4 h4")}}
+                {{svg-jar "koenig/kg-heading-2" class=(concat (if this.activeSectionTagNames.isH3 "fill-blue-l2" "fill-white") " w4 h4")}}
             </button>
         </li>
     {{/unless}}
@@ -52,7 +52,7 @@
                 class="dib dim-lite link h9 w9 nudge-top--1"
                 {{action "toggleSection" "blockquote"}}
             >
-                {{svg-jar "koenig/kg-quote" class=(concat (if activeSectionTagNames.isBlockquote "fill-blue-l2" "fill-white") " w4 h4")}}
+                {{svg-jar "koenig/kg-quote" class=(concat (if this.activeSectionTagNames.isBlockquote "fill-blue-l2" "fill-white") " w4 h4")}}
             </button>
         </li>
     {{/unless}}
@@ -63,7 +63,7 @@
             class="dib dim-lite link h9 w9 nudge-top--1"
             {{action "editLink"}}
         >
-            {{svg-jar "koenig/kg-link" class=(concat (if activeMarkupTagNames.isA "fill-blue-l2" "fill-white") " w4 h4")}}
+            {{svg-jar "koenig/kg-link" class=(concat (if this.activeMarkupTagNames.isA "fill-blue-l2" "fill-white") " w4 h4")}}
         </button>
     </li>
-{{/kg-action-bar}}
+</KgActionBar>

--- a/tests/integration/components/gh-feature-flag-test.js
+++ b/tests/integration/components/gh-feature-flag-test.js
@@ -17,12 +17,12 @@ describe('Integration: Component: gh-feature-flag', function () {
     });
 
     it('renders properties correctly', async function () {
-        await render(hbs`{{gh-feature-flag "testFlag"}}`);
+        await render(hbs`<GhFeatureFlag @flag="testFlag" />`);
         expect(find('label').getAttribute('for')).to.equal(find('input[type="checkbox"]').id);
     });
 
     it('renders correctly when flag is set to true', async function () {
-        await render(hbs`{{gh-feature-flag "testFlag"}}`);
+        await render(hbs`<GhFeatureFlag @flag="testFlag" />`);
         expect(find('label input[type="checkbox"]').checked).to.be.true;
     });
 
@@ -30,12 +30,12 @@ describe('Integration: Component: gh-feature-flag', function () {
         let feature = this.owner.lookup('service:feature');
         feature.set('testFlag', false);
 
-        await render(hbs`{{gh-feature-flag "testFlag"}}`);
+        await render(hbs`<GhFeatureFlag @flag="testFlag" />`);
         expect(find('label input[type="checkbox"]').checked).to.be.false;
     });
 
     it('updates to reflect changes in flag property', async function () {
-        await render(hbs`{{gh-feature-flag "testFlag"}}`);
+        await render(hbs`<GhFeatureFlag @flag="testFlag" />`);
         expect(find('label input[type="checkbox"]').checked).to.be.true;
 
         await click('label');

--- a/tests/integration/components/gh-task-button-test.js
+++ b/tests/integration/components/gh-task-button-test.js
@@ -12,28 +12,28 @@ describe('Integration: Component: gh-task-button', function () {
 
     it('renders', async function () {
         // sets button text using positional param
-        await render(hbs`{{gh-task-button "Test"}}`);
+        await render(hbs`<GhTaskButton @buttonText="Test" />`);
         expect(find('button')).to.exist;
         expect(find('button')).to.contain.text('Test');
         expect(find('button').disabled).to.be.false;
 
-        await render(hbs`{{gh-task-button class="testing"}}`);
+        await render(hbs`<GhTaskButton @class="testing" />`);
         expect(find('button')).to.have.class('testing');
         // default button text is "Save"
         expect(find('button')).to.contain.text('Save');
 
         // passes disabled attr
-        await render(hbs`{{gh-task-button disabled=true buttonText="Test"}}`);
+        await render(hbs`<GhTaskButton @disabled={{true}} @buttonText="Test" />`);
         expect(find('button').disabled).to.be.true;
         // allows button text to be set via hash param
         expect(find('button')).to.contain.text('Test');
 
         // passes type attr
-        await render(hbs`{{gh-task-button type="submit"}}`);
+        await render(hbs`<GhTaskButton @type="submit" />`);
         expect(find('button')).to.have.attr('type', 'submit');
 
         // passes tabindex attr
-        await render(hbs`{{gh-task-button tabindex="-1"}}`);
+        await render(hbs`<GhTaskButton @tabindex="-1" />`);
         expect(find('button')).to.have.attr('tabindex', '-1');
     });
 
@@ -42,7 +42,7 @@ describe('Integration: Component: gh-task-button', function () {
             yield timeout(50);
         }));
 
-        await render(hbs`{{gh-task-button task=myTask}}`);
+        await render(hbs`<GhTaskButton @task={{myTask}} />`);
 
         this.myTask.perform();
 
@@ -55,7 +55,7 @@ describe('Integration: Component: gh-task-button', function () {
             yield timeout(50);
         }));
 
-        await render(hbs`{{gh-task-button task=myTask runningText="Running"}}`);
+        await render(hbs`<GhTaskButton @task={{myTask}} @runningText="Running" />`);
 
         this.myTask.perform();
 
@@ -70,7 +70,7 @@ describe('Integration: Component: gh-task-button', function () {
             yield timeout(50);
         }));
 
-        await render(hbs`{{gh-task-button task=myTask}}`);
+        await render(hbs`<GhTaskButton @task={{myTask}} />`);
         expect(find('button'), 'initial class').to.not.have.class('appear-disabled');
 
         this.myTask.perform();
@@ -87,7 +87,7 @@ describe('Integration: Component: gh-task-button', function () {
             return true;
         }));
 
-        await render(hbs`{{gh-task-button task=myTask}}`);
+        await render(hbs`<GhTaskButton @task={{myTask}} />`);
 
         await this.myTask.perform();
 
@@ -101,7 +101,7 @@ describe('Integration: Component: gh-task-button', function () {
             return true;
         }));
 
-        await render(hbs`{{gh-task-button task=myTask successClass="im-a-success"}}`);
+        await render(hbs`<GhTaskButton @task={{myTask}} @successClass="im-a-success" />`);
 
         await this.myTask.perform();
 
@@ -120,7 +120,7 @@ describe('Integration: Component: gh-task-button', function () {
             }
         }));
 
-        await render(hbs`{{gh-task-button task=myTask failureClass="is-failed"}}`);
+        await render(hbs`<GhTaskButton @task={{myTask}} @failureClass="is-failed" />`);
 
         this.myTask.perform();
         await waitFor('button.is-failed');
@@ -136,7 +136,7 @@ describe('Integration: Component: gh-task-button', function () {
             return false;
         }));
 
-        await render(hbs`{{gh-task-button task=myTask}}`);
+        await render(hbs`<GhTaskButton @task={{myTask}} />`);
 
         this.myTask.perform();
         await waitFor('button.gh-btn-red', {timeout: 50});
@@ -152,7 +152,7 @@ describe('Integration: Component: gh-task-button', function () {
             return false;
         }));
 
-        await render(hbs`{{gh-task-button task=myTask failureClass="im-a-failure"}}`);
+        await render(hbs`<GhTaskButton @task={{myTask}} @failureClass="im-a-failure" />`);
 
         this.myTask.perform();
 
@@ -172,7 +172,7 @@ describe('Integration: Component: gh-task-button', function () {
             taskCount = taskCount + 1;
         }));
 
-        await render(hbs`{{gh-task-button task=myTask}}`);
+        await render(hbs`<GhTaskButton @task={{myTask}} />`);
         await click('button');
         await settled();
 
@@ -184,7 +184,7 @@ describe('Integration: Component: gh-task-button', function () {
             yield timeout(50);
         }));
 
-        await render(hbs`{{gh-task-button task=myTask}}`);
+        await render(hbs`<GhTaskButton @task={{myTask}} />`);
         let width = find('button').clientWidth;
         let height = find('button').clientHeight;
         expect(find('button')).to.not.have.attr('style');


### PR DESCRIPTION
no issue

Ember is migrating to `<AngleBracketSyntax />` for component invocation, see https://github.com/emberjs/rfcs/blob/master/text/0311-angle-bracket-invocation.md

We were in a half-way situation where some templates used angle bracket syntax in some places. This PR updates templates to use the syntax everywhere.

Angle bracket syntax simplifies the rules for knowing what template code is referring to...

`<Component>` = a component
`{{helper}}` = a helper (or locally assigned handlebars variable)
`{{this.foo}}` = data on the template backing context (a component/controller)
`{{@foo}}` = a named argument passed into the component that the component backing class has not modified (note: this commit does not introduce any usage of named arguments)

- ran codemod https://github.com/ember-codemods/ember-angle-brackets-codemod on the following directories:
  - `app/templates`
  - `lib/koenig-editor/addon/templates`
- removed positional params from components as angle bracket syntax does not support them
  - `gh-feature-flag`
  - `gh-tour-item`
  - `gh-cm-editor`
  - `gh-fullscreen-modal`
  - `gh-task-button`