### PR TITLE
Migrated controllers to native classes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,11 @@ module.exports = {
         // disable linting of `this.get` until there's a reliable autofix
         'ghost/ember/use-ember-get-and-set': 'off',
 
-        // disable linting of mixins until we migrate away
-        'ghost/ember/no-new-mixins': 'off'
+        // disable linting of mixins until we've migrated away
+        'ghost/ember/no-new-mixins': 'off',
+
+        // turn on some Octane rules
+        'ghost/ember/classic-decorator-hooks': 'error',
+        'ghost/ember/classic-decorator-no-classic-methods': 'error'
     }
 };

--- a/app/components/gh-basic-dropdown.js
+++ b/app/components/gh-basic-dropdown.js
@@ -1,8 +1,10 @@
 import BasicDropdown from 'ember-basic-dropdown/components/basic-dropdown';
+import classic from 'ember-classic-decorator';
 import templateLayout from 'ember-basic-dropdown/templates/components/basic-dropdown';
 import {layout} from '@ember-decorators/component';
 import {inject as service} from '@ember/service';
 
+@classic
 @layout(templateLayout)
 class GhBasicDropdown extends BasicDropdown {
     @service dropdown

--- a/app/components/gh-token-input.js
+++ b/app/components/gh-token-input.js
@@ -1,6 +1,7 @@
 /* global key */
 import Component from '@ember/component';
 import Ember from 'ember';
+import classic from 'ember-classic-decorator';
 import fallbackIfUndefined from '../utils/computed-fallback-if-undefined';
 import {A, isArray} from '@ember/array';
 import {action, computed, get} from '@ember/object';
@@ -19,6 +20,7 @@ const {Handlebars} = Ember;
 const BACKSPACE = 8;
 const TAB = 9;
 
+@classic
 @tagName('')
 class GhTokenInput extends Component {
     // public attrs

--- a/app/components/gh-token-input.js
+++ b/app/components/gh-token-input.js
@@ -13,7 +13,7 @@ import {
 import {htmlSafe} from '@ember/string';
 import {isBlank} from '@ember/utils';
 import {tagName} from '@ember-decorators/component';
-import {task} from 'ember-concurrency';
+import {task} from 'ember-concurrency-decorators';
 
 const {Handlebars} = Ember;
 
@@ -119,14 +119,15 @@ class GhTokenInput extends Component {
 
     // tasks -------------------------------------------------------------------
 
-    @task(function* () {
+    @task
+    *optionsWithoutSelectedTask() {
         let options = yield this.options;
         let selected = yield this.selected;
         return options.filter(o => !selected.includes(o));
-    })
-    optionsWithoutSelectedTask;
+    }
 
-    @task(function* (term, select) {
+    @task
+    *searchAndSuggestTask(term, select) {
         let newOptions = (yield this.optionsWithoutSelected).toArray();
 
         if (term.length === 0) {
@@ -149,8 +150,7 @@ class GhTokenInput extends Component {
         this._addCreateOption(term, newOptions);
 
         return newOptions;
-    })
-    searchAndSuggestTask;
+    }
 
     // internal ----------------------------------------------------------------
 

--- a/app/components/gh-token-input/trigger.js
+++ b/app/components/gh-token-input/trigger.js
@@ -1,13 +1,15 @@
 import EmberPowerSelectMultipleTrigger from 'ember-power-select/components/power-select-multiple/trigger';
+import classic from 'ember-classic-decorator';
 import {action, get} from '@ember/object';
 import {assert} from '@ember/debug';
 import {isBlank} from '@ember/utils';
 
+@classic
 export default class Trigger extends EmberPowerSelectMultipleTrigger {
     @action
     handleOptionMouseDown(event) {
         if (!event.target.closest('[data-selected-index]')) {
-            let optionMouseDown = this.get('extra.optionMouseDown');
+            let optionMouseDown = get(this, 'extra.optionMouseDown');
             if (optionMouseDown) {
                 return optionMouseDown(event);
             }
@@ -18,7 +20,7 @@ export default class Trigger extends EmberPowerSelectMultipleTrigger {
 
     @action
     handleOptionTouchStart(event) {
-        let optionTouchStart = this.get('extra.optionTouchStart');
+        let optionTouchStart = get(this, 'extra.optionTouchStart');
         if (optionTouchStart) {
             return optionTouchStart(event);
         }
@@ -46,11 +48,11 @@ export default class Trigger extends EmberPowerSelectMultipleTrigger {
             if (isBlank(e.target.value)) {
                 let lastSelection = this.select.selected[this.select.selected.length - 1];
                 if (lastSelection) {
-                    this.select.actions.select(this.get('buildSelection')(lastSelection, this.select), e);
+                    this.select.actions.select(this.buildSelection(lastSelection, this.select), e);
                     if (typeof lastSelection === 'string') {
                         this.select.actions.search(lastSelection);
                     } else {
-                        let searchField = this.get('searchField');
+                        let searchField = this.searchField;
                         assert('`{{power-select-multiple}}` requires a `searchField` when the options are not strings to remove options using backspace', searchField);
                         this.select.actions.search(get(lastSelection, searchField));
                     }

--- a/app/controllers/about.js
+++ b/app/controllers/about.js
@@ -1,14 +1,17 @@
 import Controller from '@ember/controller';
+import classic from 'ember-classic-decorator';
 import {computed} from '@ember/object';
 import {inject as service} from '@ember/service';
 
 /* eslint-disable ghost/ember/alias-model-in-controller */
-export default Controller.extend({
-    config: service(),
-    upgradeStatus: service(),
+@classic
+export default class AboutController extends Controller {
+    @service config;
+    @service upgradeStatus;
 
-    copyrightYear: computed(function () {
+    @computed
+    get copyrightYear() {
         let date = new Date();
         return date.getFullYear();
-    })
-});
+    }
+}

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,16 +1,23 @@
-/* eslint-disable ghost/ember/alias-model-in-controller */
-import Controller from '@ember/controller';
+import classic from 'ember-classic-decorator';
 import {computed} from '@ember/object';
 import {inject as service} from '@ember/service';
+/* eslint-disable ghost/ember/alias-model-in-controller */
+import Controller from '@ember/controller';
 
-export default Controller.extend({
-    dropdown: service(),
-    router: service(),
-    session: service(),
-    settings: service(),
-    ui: service(),
+@classic
+export default class ApplicationController extends Controller {
+    @service dropdown;
+    @service router;
+    @service session;
+    @service settings;
+    @service ui;
 
-    showNavMenu: computed('router.currentRouteName', 'session.{isAuthenticated,user.isFulfilled}', 'ui.isFullScreen', function () {
+    @computed(
+        'router.currentRouteName',
+        'session.{isAuthenticated,user.isFulfilled}',
+        'ui.isFullScreen'
+    )
+    get showNavMenu() {
         let {router, session, ui} = this;
 
         // if we're in fullscreen mode don't show the nav menu
@@ -26,5 +33,5 @@ export default Controller.extend({
 
         return (router.currentRouteName !== 'error404' || session.isAuthenticated)
                 && !router.currentRouteName.match(/(signin|signup|setup|reset)/);
-    })
-});
+    }
+}

--- a/app/controllers/editor/edit-loading.js
+++ b/app/controllers/editor/edit-loading.js
@@ -1,7 +1,9 @@
 import Controller from '@ember/controller';
+import classic from 'ember-classic-decorator';
 import {inject as service} from '@ember/service';
 
 /* eslint-disable ghost/ember/alias-model-in-controller */
-export default Controller.extend({
-    ui: service()
-});
+@classic
+export default class EditLoadingController extends Controller {
+    @service ui;
+}

--- a/app/controllers/error.js
+++ b/app/controllers/error.js
@@ -1,21 +1,26 @@
 import Controller from '@ember/controller';
+import classic from 'ember-classic-decorator';
 import {computed} from '@ember/object';
 import {readOnly} from '@ember/object/computed';
 
-export default Controller.extend({
+@classic
+export default class ErrorController extends Controller {
+    stack = false;
 
-    stack: false,
-    error: readOnly('model'),
+    @readOnly('model')
+    error;
 
-    code: computed('error.status', function () {
+    @computed('error.status')
+    get code() {
         return this.get('error.status') > 200 ? this.get('error.status') : 500;
-    }),
+    }
 
-    message: computed('error.statusText', function () {
+    @computed('error.statusText')
+    get message() {
         if (this.code === 404) {
             return 'Page not found';
         }
 
         return this.get('error.statusText') !== 'error' ? this.get('error.statusText') : 'Internal Server Error';
-    })
-});
+    }
+}

--- a/app/controllers/members.js
+++ b/app/controllers/members.js
@@ -1,23 +1,26 @@
 import Controller from '@ember/controller';
+import classic from 'ember-classic-decorator';
 import ghostPaths from 'ghost-admin/utils/ghost-paths';
 import moment from 'moment';
-import {computed} from '@ember/object';
+import {action, computed} from '@ember/object';
 import {inject as service} from '@ember/service';
-import {task} from 'ember-concurrency';
+import {task} from 'ember-concurrency-decorators';
 
 /* eslint-disable ghost/ember/alias-model-in-controller */
-export default Controller.extend({
-    store: service(),
+@classic
+export default class MembersController extends Controller {
+    @service store;
 
-    members: null,
-    searchText: '',
+    members = null;
+    searchText = '';
 
     init() {
-        this._super(...arguments);
+        super.init(...arguments);
         this.set('members', this.store.peekAll('member'));
-    },
+    }
 
-    filteredMembers: computed('members.@each.{name,email}', 'searchText', function () {
+    @computed('members.@each.{name,email}', 'searchText')
+    get filteredMembers() {
         let {members, searchText} = this;
         searchText = searchText.toLowerCase();
 
@@ -34,25 +37,25 @@ export default Controller.extend({
         });
 
         return filtered;
-    }),
+    }
 
-    actions: {
-        exportData() {
-            let exportUrl = ghostPaths().url.api('members/csv');
-            let downloadURL = `${exportUrl}?limit=all`;
-            let iframe = document.getElementById('iframeDownload');
+    @action
+    exportData() {
+        let exportUrl = ghostPaths().url.api('members/csv');
+        let downloadURL = `${exportUrl}?limit=all`;
+        let iframe = document.getElementById('iframeDownload');
 
-            if (!iframe) {
-                iframe = document.createElement('iframe');
-                iframe.id = 'iframeDownload';
-                iframe.style.display = 'none';
-                document.body.append(iframe);
-            }
-            iframe.setAttribute('src', downloadURL);
+        if (!iframe) {
+            iframe = document.createElement('iframe');
+            iframe.id = 'iframeDownload';
+            iframe.style.display = 'none';
+            document.body.append(iframe);
         }
-    },
+        iframe.setAttribute('src', downloadURL);
+    }
 
-    fetchMembers: task(function* () {
+    @task
+    *fetchMembers() {
         let newFetchDate = new Date();
 
         if (this._hasFetchedAll) {
@@ -72,5 +75,5 @@ export default Controller.extend({
         }
 
         this._lastFetchDate = newFetchDate;
-    })
-});
+    }
+}

--- a/app/controllers/members/import.js
+++ b/app/controllers/members/import.js
@@ -1,19 +1,22 @@
 import Controller from '@ember/controller';
+import classic from 'ember-classic-decorator';
+import {action} from '@ember/object';
 import {inject as controller} from '@ember/controller';
 import {inject as service} from '@ember/service';
 
 /* eslint-disable ghost/ember/alias-model-in-controller */
-export default Controller.extend({
-    members: controller(),
-    router: service(),
+@classic
+export default class ImportController extends Controller {
+    @controller members;
+    @service router;
 
-    actions: {
-        fetchNewMembers() {
-            this.members.fetchMembers.perform();
-        },
-
-        close() {
-            this.router.transitionTo('members');
-        }
+    @action
+    fetchNewMembers() {
+        this.members.fetchMembers.perform();
     }
-});
+
+    @action
+    close() {
+        this.router.transitionTo('members');
+    }
+}

--- a/app/controllers/pages-loading.js
+++ b/app/controllers/pages-loading.js
@@ -1,9 +1,13 @@
 import PostsLoadingController from './posts-loading';
+import classic from 'ember-classic-decorator';
 import {inject as controller} from '@ember/controller';
 import {inject as service} from '@ember/service';
 
 /* eslint-disable ghost/ember/alias-model-in-controller */
-export default PostsLoadingController.extend({
-    postsController: controller('pages'),
-    ui: service()
-});
+@classic
+export default class PagesLoadingController extends PostsLoadingController {
+    @service ui;
+
+    @controller('pages')
+    postsController;
+}

--- a/app/controllers/pages.js
+++ b/app/controllers/pages.js
@@ -1,4 +1,6 @@
 import PostsController from './posts';
+import classic from 'ember-classic-decorator';
+import {action} from '@ember/object';
 
 const TYPES = [{
     name: 'All pages',
@@ -18,15 +20,15 @@ const TYPES = [{
 }];
 
 /* eslint-disable ghost/ember/alias-model-in-controller */
-export default PostsController.extend({
+@classic
+export default class PagesController extends PostsController {
     init() {
-        this._super(...arguments);
+        super.init(...arguments);
         this.availableTypes = TYPES;
-    },
-
-    actions: {
-        openEditor(page) {
-            this.transitionToRoute('editor.edit', 'page', page.get('id'));
-        }
     }
-});
+
+    @action
+    openEditor(page) {
+        this.transitionToRoute('editor.edit', 'page', page.get('id'));
+    }
+}

--- a/app/controllers/posts-loading.js
+++ b/app/controllers/posts-loading.js
@@ -1,20 +1,38 @@
 import Controller, {inject as controller} from '@ember/controller';
+import classic from 'ember-classic-decorator';
 import {readOnly} from '@ember/object/computed';
 import {inject as service} from '@ember/service';
 
 /* eslint-disable ghost/ember/alias-model-in-controller */
-export default Controller.extend({
+@classic
+export default class PostsLoadingController extends Controller {
+    @service session;
+    @service ui;
 
-    postsController: controller('posts'),
-    session: service(),
-    ui: service(),
+    @controller('posts')
+    postsController;
 
-    availableTypes: readOnly('postsController.availableTypes'),
-    selectedType: readOnly('postsController.selectedType'),
-    availableTags: readOnly('postsController.availableTags'),
-    selectedTag: readOnly('postsController.selectedTag'),
-    availableAuthors: readOnly('postsController.availableAuthors'),
-    selectedAuthor: readOnly('postsController.selectedAuthor'),
-    availableOrders: readOnly('postsController.availableOrders'),
-    selectedOrder: readOnly('postsController.selectedOrder')
-});
+    @readOnly('postsController.availableTypes')
+    availableTypes;
+
+    @readOnly('postsController.selectedType')
+    selectedType;
+
+    @readOnly('postsController.availableTags')
+    availableTags;
+
+    @readOnly('postsController.selectedTag')
+    selectedTag;
+
+    @readOnly('postsController.availableAuthors')
+    availableAuthors;
+
+    @readOnly('postsController.selectedAuthor')
+    selectedAuthor;
+
+    @readOnly('postsController.availableOrders')
+    availableOrders;
+
+    @readOnly('postsController.selectedOrder')
+    selectedOrder;
+}

--- a/app/controllers/posts.js
+++ b/app/controllers/posts.js
@@ -1,7 +1,7 @@
 import Controller from '@ember/controller';
+import classic from 'ember-classic-decorator';
+import {action, computed, get} from '@ember/object';
 import {alias} from '@ember/object/computed';
-import {computed} from '@ember/object';
-import {get} from '@ember/object';
 import {inject as service} from '@ember/service';
 
 const TYPES = [{
@@ -32,52 +32,55 @@ const ORDERS = [{
     value: 'updated_at desc'
 }];
 
-export default Controller.extend({
+@classic
+export default class PostsController extends Controller {
+    @service store;
 
-    store: service(),
-
-    queryParams: ['type', 'author', 'tag', 'order'],
-
-    type: null,
-    author: null,
-    tag: null,
-    order: null,
-
-    _hasLoadedTags: false,
-    _hasLoadedAuthors: false,
-
-    availableTypes: null,
-    availableOrders: null,
+    queryParams = ['type', 'author', 'tag', 'order'];
+    type = null;
+    author = null;
+    tag = null;
+    order = null;
+    _hasLoadedTags = false;
+    _hasLoadedAuthors = false;
+    availableTypes = null;
+    availableOrders = null;
 
     init() {
-        this._super(...arguments);
+        super.init(...arguments);
         this.availableTypes = TYPES;
         this.availableOrders = ORDERS;
-    },
+    }
 
-    postsInfinityModel: alias('model'),
+    @alias('model')
+    postsInfinityModel;
 
-    showingAll: computed('type', 'author', 'tag', function () {
+    @computed('type', 'author', 'tag')
+    get showingAll() {
         let {type, author, tag} = this.getProperties(['type', 'author', 'tag']);
 
         return !type && !author && !tag;
-    }),
+    }
 
-    selectedType: computed('type', function () {
+    @computed('type')
+    get selectedType() {
         let types = this.get('availableTypes');
         return types.findBy('value', this.get('type'));
-    }),
+    }
 
-    selectedOrder: computed('order', function () {
+    @computed('order')
+    get selectedOrder() {
         let orders = this.get('availableOrders');
         return orders.findBy('value', this.get('order'));
-    }),
+    }
 
-    _availableTags: computed(function () {
+    @computed
+    get _availableTags() {
         return this.get('store').peekAll('tag');
-    }),
+    }
 
-    availableTags: computed('_availableTags.[]', function () {
+    @computed('_availableTags.[]')
+    get availableTags() {
         let tags = this.get('_availableTags')
             .filter(tag => tag.get('id') !== null)
             .sort((tagA, tagB) => tagA.name.localeCompare(tagB.name, undefined, {ignorePunctuation: true}));
@@ -86,54 +89,61 @@ export default Controller.extend({
         options.unshiftObject({name: 'All tags', slug: null});
 
         return options;
-    }),
+    }
 
-    selectedTag: computed('tag', '_availableTags.[]', function () {
+    @computed('tag', '_availableTags.[]')
+    get selectedTag() {
         let tag = this.get('tag');
         let tags = this.get('availableTags');
 
         return tags.findBy('slug', tag);
-    }),
+    }
 
-    _availableAuthors: computed(function () {
+    @computed
+    get _availableAuthors() {
         return this.get('store').peekAll('user');
-    }),
+    }
 
-    availableAuthors: computed('_availableAuthors.[]', function () {
+    @computed('_availableAuthors.[]')
+    get availableAuthors() {
         let authors = this.get('_availableAuthors');
         let options = authors.toArray();
 
         options.unshiftObject({name: 'All authors', slug: null});
 
         return options;
-    }),
+    }
 
-    selectedAuthor: computed('author', 'availableAuthors.[]', function () {
+    @computed('author', 'availableAuthors.[]')
+    get selectedAuthor() {
         let author = this.get('author');
         let authors = this.get('availableAuthors');
 
         return authors.findBy('slug', author);
-    }),
-
-    actions: {
-        changeType(type) {
-            this.set('type', get(type, 'value'));
-        },
-
-        changeAuthor(author) {
-            this.set('author', get(author, 'slug'));
-        },
-
-        changeTag(tag) {
-            this.set('tag', get(tag, 'slug'));
-        },
-
-        changeOrder(order) {
-            this.set('order', get(order, 'value'));
-        },
-
-        openEditor(post) {
-            this.transitionToRoute('editor.edit', 'post', post.get('id'));
-        }
     }
-});
+
+    @action
+    changeType(type) {
+        this.set('type', get(type, 'value'));
+    }
+
+    @action
+    changeAuthor(author) {
+        this.set('author', get(author, 'slug'));
+    }
+
+    @action
+    changeTag(tag) {
+        this.set('tag', get(tag, 'slug'));
+    }
+
+    @action
+    changeOrder(order) {
+        this.set('order', get(order, 'value'));
+    }
+
+    @action
+    openEditor(post) {
+        this.transitionToRoute('editor.edit', 'post', post.get('id'));
+    }
+}

--- a/app/controllers/reset.js
+++ b/app/controllers/reset.js
@@ -1,35 +1,39 @@
 /* eslint-disable ghost/ember/alias-model-in-controller */
 import Controller from '@ember/controller';
 import ValidationEngine from 'ghost-admin/mixins/validation-engine';
+import classic from 'ember-classic-decorator';
+import {action} from '@ember/object';
 import {computed} from '@ember/object';
 import {inject as service} from '@ember/service';
-import {task} from 'ember-concurrency';
+import {task} from 'ember-concurrency-decorators';
 
-export default Controller.extend(ValidationEngine, {
-    ghostPaths: service(),
-    notifications: service(),
-    session: service(),
-    ajax: service(),
-    config: service(),
+@classic
+export default class ResetController extends Controller.extend(ValidationEngine) {
+    @service ajax;
+    @service config;
+    @service ghostPaths;
+    @service notifications;
+    @service session;
 
-    newPassword: '',
-    ne2Password: '',
-    token: '',
-    flowErrors: '',
+    newPassword = '';
+    ne2Password = '';
+    token = '';
+    flowErrors = '';
 
-    validationType: 'reset',
+    // ValidationEngine settings
+    validationType = 'reset';
 
-    email: computed('token', function () {
+    @computed('token')
+    email() {
         // The token base64 encodes the email (and some other stuff),
         // each section is divided by a '|'. Email comes second.
         return atob(this.token).split('|')[1];
-    }),
+    }
 
-    actions: {
-        submit() {
-            return this.resetPassword.perform();
-        }
-    },
+    @action
+    submit() {
+        return this.resetPassword.perform();
+    }
 
     // Used to clear sensitive information
     clearData() {
@@ -38,9 +42,10 @@ export default Controller.extend(ValidationEngine, {
             ne2Password: '',
             token: ''
         });
-    },
+    }
 
-    resetPassword: task(function* () {
+    @task({drop: true})
+    *resetPassword() {
         let credentials = this.getProperties('newPassword', 'ne2Password', 'token');
         let authUrl = this.get('ghostPaths.url').api('authentication', 'passwordreset');
 
@@ -74,5 +79,5 @@ export default Controller.extend(ValidationEngine, {
                 throw error;
             }
         }
-    }).drop()
-});
+    }
+}

--- a/app/controllers/settings/general.js
+++ b/app/controllers/settings/general.js
@@ -1,3 +1,6 @@
+import classic from 'ember-classic-decorator';
+import {action, computed} from '@ember/object';
+import {inject as service} from '@ember/service';
 /* eslint-disable ghost/ember/alias-model-in-controller */
 import $ from 'jquery';
 import Controller from '@ember/controller';
@@ -7,11 +10,9 @@ import {
     IMAGE_EXTENSIONS,
     IMAGE_MIME_TYPES
 } from 'ghost-admin/components/gh-image-uploader';
-import {computed} from '@ember/object';
 import {htmlSafe} from '@ember/string';
 import {run} from '@ember/runloop';
-import {inject as service} from '@ember/service';
-import {task} from 'ember-concurrency';
+import {task} from 'ember-concurrency-decorators';
 
 const ICON_EXTENSIONS = ['ico', 'png'];
 
@@ -22,292 +23,306 @@ function randomPassword() {
     return word + randomN;
 }
 
-export default Controller.extend({
-    config: service(),
-    ghostPaths: service(),
-    notifications: service(),
-    session: service(),
-    settings: service(),
-    ui: service(),
+@classic
+export default class GeneralController extends Controller {
+    @service config;
+    @service ghostPaths;
+    @service notifications;
+    @service session;
+    @service settings;
+    @service ui;
 
-    availableTimezones: null,
-    iconExtensions: null,
-    iconMimeTypes: 'image/png,image/x-icon',
-    imageExtensions: IMAGE_EXTENSIONS,
-    imageMimeTypes: IMAGE_MIME_TYPES,
-    _scratchFacebook: null,
-    _scratchTwitter: null,
+    availableTimezones = null;
+    iconExtensions = null;
+    iconMimeTypes = 'image/png,image/x-icon';
+    imageExtensions = IMAGE_EXTENSIONS;
+    imageMimeTypes = IMAGE_MIME_TYPES;
+    _scratchFacebook = null;
+    _scratchTwitter = null;
 
     init() {
-        this._super(...arguments);
+        super.init(...arguments);
         this.iconExtensions = ICON_EXTENSIONS;
-    },
+    }
 
-    privateRSSUrl: computed('config.blogUrl', 'settings.publicHash', function () {
+    @computed('config.blogUrl', 'settings.publicHash')
+    get privateRSSUrl() {
         let blogUrl = this.get('config.blogUrl');
         let publicHash = this.get('settings.publicHash');
 
         return `${blogUrl}/${publicHash}/rss`;
-    }),
+    }
 
-    backgroundStyle: computed('settings.brand.primaryColor', function () {
+    @computed('settings.brand.primaryColor')
+    get backgroundStyle() {
         let color = this.get('settings.brand.primaryColor') || '#ffffff';
         return htmlSafe(`background-color: ${color}`);
-    }),
+    }
 
-    brandColor: computed('settings.brand.primaryColor', function () {
+    @computed('settings.brand.primaryColor')
+    get brandColor() {
         let color = this.get('settings.brand.primaryColor');
         if (color && color[0] === '#') {
             return color.slice(1);
         }
         return color;
-    }),
+    }
 
-    actions: {
-        save() {
-            this.save.perform();
-        },
+    @action
+    save() {
+        this.saveTask.perform();
+    }
 
-        setTimezone(timezone) {
-            this.set('settings.activeTimezone', timezone.name);
-        },
+    @action
+    setTimezone(timezone) {
+        this.set('settings.activeTimezone', timezone.name);
+    }
 
-        removeImage(image) {
-            // setting `null` here will error as the server treats it as "null"
-            this.settings.set(image, '');
-        },
+    @action
+    removeImage(image) {
+        // setting `null` here will error as the server treats it as "null"
+        this.settings.set(image, '');
+    }
 
-        /**
-         * Opens a file selection dialog - Triggered by "Upload Image" buttons,
-         * searches for the hidden file input within the .gh-setting element
-         * containing the clicked button then simulates a click
-         * @param  {MouseEvent} event - MouseEvent fired by the button click
-         */
-        triggerFileDialog(event) {
-            // simulate click to open file dialog
-            // using jQuery because IE11 doesn't support MouseEvent
-            $(event.target)
-                .closest('.gh-setting-action')
-                .find('input[type="file"]')
-                .click();
-        },
+    /**
+     * Opens a file selection dialog - Triggered by "Upload Image" buttons,
+     * searches for the hidden file input within the .gh-setting element
+     * containing the clicked button then simulates a click
+     * @param  {MouseEvent} event - MouseEvent fired by the button click
+     */
+    @action
+    triggerFileDialog(event) {
+        // simulate click to open file dialog
+        // using jQuery because IE11 doesn't support MouseEvent
+        $(event.target)
+            .closest('.gh-setting-action')
+            .find('input[type="file"]')
+            .click();
+    }
 
-        /**
-         * Fired after an image upload completes
-         * @param  {string} property - Property name to be set on `this.settings`
-         * @param  {UploadResult[]} results - Array of UploadResult objects
-         * @return {string} The URL that was set on `this.settings.property`
-         */
-        imageUploaded(property, results) {
-            if (results[0]) {
-                return this.settings.set(property, results[0].url);
-            }
-        },
+    /**
+     * Fired after an image upload completes
+     * @param  {string} property - Property name to be set on `this.settings`
+     * @param  {UploadResult[]} results - Array of UploadResult objects
+     * @return {string} The URL that was set on `this.settings.property`
+     */
+    @action
+    imageUploaded(property, results) {
+        if (results[0]) {
+            return this.settings.set(property, results[0].url);
+        }
+    }
 
-        toggleIsPrivate(isPrivate) {
-            let settings = this.settings;
+    @action
+    toggleIsPrivate(isPrivate) {
+        let settings = this.settings;
 
-            settings.set('isPrivate', isPrivate);
-            settings.get('errors').remove('password');
+        settings.set('isPrivate', isPrivate);
+        settings.get('errors').remove('password');
 
-            let changedAttrs = settings.changedAttributes();
+        let changedAttrs = settings.changedAttributes();
 
-            // set a new random password when isPrivate is enabled
-            if (isPrivate && changedAttrs.isPrivate) {
-                settings.set('password', randomPassword());
+        // set a new random password when isPrivate is enabled
+        if (isPrivate && changedAttrs.isPrivate) {
+            settings.set('password', randomPassword());
 
-            // reset the password when isPrivate is disabled
-            } else if (changedAttrs.password) {
-                settings.set('password', changedAttrs.password[0]);
-            }
-        },
+        // reset the password when isPrivate is disabled
+        } else if (changedAttrs.password) {
+            settings.set('password', changedAttrs.password[0]);
+        }
+    }
 
-        toggleLeaveSettingsModal(transition) {
-            let leaveTransition = this.leaveSettingsTransition;
+    @action
+    toggleLeaveSettingsModal(transition) {
+        let leaveTransition = this.leaveSettingsTransition;
 
-            if (!transition && this.showLeaveSettingsModal) {
-                this.set('leaveSettingsTransition', null);
-                this.set('showLeaveSettingsModal', false);
-                return;
-            }
+        if (!transition && this.showLeaveSettingsModal) {
+            this.set('leaveSettingsTransition', null);
+            this.set('showLeaveSettingsModal', false);
+            return;
+        }
 
-            if (!leaveTransition || transition.targetName === leaveTransition.targetName) {
-                this.set('leaveSettingsTransition', transition);
+        if (!leaveTransition || transition.targetName === leaveTransition.targetName) {
+            this.set('leaveSettingsTransition', transition);
 
-                // if a save is running, wait for it to finish then transition
-                if (this.get('save.isRunning')) {
-                    return this.get('save.last').then(() => {
-                        transition.retry();
-                    });
-                }
-
-                // we genuinely have unsaved data, show the modal
-                this.set('showLeaveSettingsModal', true);
-            }
-        },
-
-        leaveSettings() {
-            let transition = this.leaveSettingsTransition;
-            let settings = this.settings;
-
-            if (!transition) {
-                this.notifications.showAlert('Sorry, there was an error in the application. Please let the Ghost team know what happened.', {type: 'error'});
-                return;
-            }
-
-            // roll back changes on settings props
-            settings.rollbackAttributes();
-
-            return transition.retry();
-        },
-
-        validateFacebookUrl() {
-            let newUrl = this._scratchFacebook;
-            let oldUrl = this.get('settings.facebook');
-            let errMessage = '';
-
-            // reset errors and validation
-            this.get('settings.errors').remove('facebook');
-            this.get('settings.hasValidated').removeObject('facebook');
-
-            if (newUrl === '') {
-                // Clear out the Facebook url
-                this.set('settings.facebook', '');
-                return;
-            }
-
-            // _scratchFacebook will be null unless the user has input something
-            if (!newUrl) {
-                newUrl = oldUrl;
-            }
-
-            try {
-                // strip any facebook URLs out
-                newUrl = newUrl.replace(/(https?:\/\/)?(www\.)?facebook\.com/i, '');
-
-                // don't allow any non-facebook urls
-                if (newUrl.match(/^(http|\/\/)/i)) {
-                    throw 'invalid url';
-                }
-
-                // strip leading / if we have one then concat to full facebook URL
-                newUrl = newUrl.replace(/^\//, '');
-                newUrl = `https://www.facebook.com/${newUrl}`;
-
-                // don't allow URL if it's not valid
-                if (!validator.isURL(newUrl)) {
-                    throw 'invalid url';
-                }
-
-                this.set('settings.facebook', '');
-                run.schedule('afterRender', this, function () {
-                    this.set('settings.facebook', newUrl);
+            // if a save is running, wait for it to finish then transition
+            if (this.get('save.isRunning')) {
+                return this.get('save.last').then(() => {
+                    transition.retry();
                 });
-            } catch (e) {
-                if (e === 'invalid url') {
-                    errMessage = 'The URL must be in a format like '
-                               + 'https://www.facebook.com/yourPage';
-                    this.get('settings.errors').add('facebook', errMessage);
-                    return;
-                }
-
-                throw e;
-            } finally {
-                this.get('settings.hasValidated').pushObject('facebook');
-            }
-        },
-
-        validateTwitterUrl() {
-            let newUrl = this._scratchTwitter;
-            let oldUrl = this.get('settings.twitter');
-            let errMessage = '';
-
-            // reset errors and validation
-            this.get('settings.errors').remove('twitter');
-            this.get('settings.hasValidated').removeObject('twitter');
-
-            if (newUrl === '') {
-                // Clear out the Twitter url
-                this.set('settings.twitter', '');
-                return;
             }
 
-            // _scratchTwitter will be null unless the user has input something
-            if (!newUrl) {
-                newUrl = oldUrl;
+            // we genuinely have unsaved data, show the modal
+            this.set('showLeaveSettingsModal', true);
+        }
+    }
+
+    @action
+    leaveSettings() {
+        let transition = this.leaveSettingsTransition;
+        let settings = this.settings;
+
+        if (!transition) {
+            this.notifications.showAlert('Sorry, there was an error in the application. Please let the Ghost team know what happened.', {type: 'error'});
+            return;
+        }
+
+        // roll back changes on settings props
+        settings.rollbackAttributes();
+
+        return transition.retry();
+    }
+
+    @action
+    validateFacebookUrl() {
+        let newUrl = this._scratchFacebook;
+        let oldUrl = this.get('settings.facebook');
+        let errMessage = '';
+
+        // reset errors and validation
+        this.get('settings.errors').remove('facebook');
+        this.get('settings.hasValidated').removeObject('facebook');
+
+        if (newUrl === '') {
+            // Clear out the Facebook url
+            this.set('settings.facebook', '');
+            return;
+        }
+
+        // _scratchFacebook will be null unless the user has input something
+        if (!newUrl) {
+            newUrl = oldUrl;
+        }
+
+        try {
+            // strip any facebook URLs out
+            newUrl = newUrl.replace(/(https?:\/\/)?(www\.)?facebook\.com/i, '');
+
+            // don't allow any non-facebook urls
+            if (newUrl.match(/^(http|\/\/)/i)) {
+                throw 'invalid url';
             }
 
-            if (newUrl.match(/(?:twitter\.com\/)(\S+)/) || newUrl.match(/([a-z\d.]+)/i)) {
-                let username = [];
+            // strip leading / if we have one then concat to full facebook URL
+            newUrl = newUrl.replace(/^\//, '');
+            newUrl = `https://www.facebook.com/${newUrl}`;
 
-                if (newUrl.match(/(?:twitter\.com\/)(\S+)/)) {
-                    [, username] = newUrl.match(/(?:twitter\.com\/)(\S+)/);
-                } else {
-                    [username] = newUrl.match(/([^/]+)\/?$/mi);
-                }
+            // don't allow URL if it's not valid
+            if (!validator.isURL(newUrl)) {
+                throw 'invalid url';
+            }
 
-                // check if username starts with http or www and show error if so
-                if (username.match(/^(http|www)|(\/)/) || !username.match(/^[a-z\d._]{1,15}$/mi)) {
-                    errMessage = !username.match(/^[a-z\d._]{1,15}$/mi) ? 'Your Username is not a valid Twitter Username' : 'The URL must be in a format like https://twitter.com/yourUsername';
-
-                    this.get('settings.errors').add('twitter', errMessage);
-                    this.get('settings.hasValidated').pushObject('twitter');
-                    return;
-                }
-
-                newUrl = `https://twitter.com/${username}`;
-
-                this.get('settings.hasValidated').pushObject('twitter');
-
-                this.set('settings.twitter', '');
-                run.schedule('afterRender', this, function () {
-                    this.set('settings.twitter', newUrl);
-                });
-            } else {
+            this.set('settings.facebook', '');
+            run.schedule('afterRender', this, function () {
+                this.set('settings.facebook', newUrl);
+            });
+        } catch (e) {
+            if (e === 'invalid url') {
                 errMessage = 'The URL must be in a format like '
-                           + 'https://twitter.com/yourUsername';
+                           + 'https://www.facebook.com/yourPage';
+                this.get('settings.errors').add('facebook', errMessage);
+                return;
+            }
+
+            throw e;
+        } finally {
+            this.get('settings.hasValidated').pushObject('facebook');
+        }
+    }
+
+    @action
+    validateTwitterUrl() {
+        let newUrl = this._scratchTwitter;
+        let oldUrl = this.get('settings.twitter');
+        let errMessage = '';
+
+        // reset errors and validation
+        this.get('settings.errors').remove('twitter');
+        this.get('settings.hasValidated').removeObject('twitter');
+
+        if (newUrl === '') {
+            // Clear out the Twitter url
+            this.set('settings.twitter', '');
+            return;
+        }
+
+        // _scratchTwitter will be null unless the user has input something
+        if (!newUrl) {
+            newUrl = oldUrl;
+        }
+
+        if (newUrl.match(/(?:twitter\.com\/)(\S+)/) || newUrl.match(/([a-z\d.]+)/i)) {
+            let username = [];
+
+            if (newUrl.match(/(?:twitter\.com\/)(\S+)/)) {
+                [, username] = newUrl.match(/(?:twitter\.com\/)(\S+)/);
+            } else {
+                [username] = newUrl.match(/([^/]+)\/?$/mi);
+            }
+
+            // check if username starts with http or www and show error if so
+            if (username.match(/^(http|www)|(\/)/) || !username.match(/^[a-z\d._]{1,15}$/mi)) {
+                errMessage = !username.match(/^[a-z\d._]{1,15}$/mi) ? 'Your Username is not a valid Twitter Username' : 'The URL must be in a format like https://twitter.com/yourUsername';
+
                 this.get('settings.errors').add('twitter', errMessage);
                 this.get('settings.hasValidated').pushObject('twitter');
                 return;
             }
-        },
-        validateBrandColor() {
-            let newColor = this.get('brandColor');
-            let oldColor = this.get('settings.brand.primaryColor');
-            let errMessage = '';
 
-            // reset errors and validation
-            this.get('settings.errors').remove('brandColor');
-            this.get('settings.hasValidated').removeObject('brandColor');
+            newUrl = `https://twitter.com/${username}`;
 
-            if (newColor === '') {
-                // Clear out the brand color
-                this.set('settings.brand.primaryColor', '');
-                return;
-            }
+            this.get('settings.hasValidated').pushObject('twitter');
 
-            // brandColor will be null unless the user has input something
-            if (!newColor) {
-                newColor = oldColor;
-            }
-
-            if (newColor[0] !== '#') {
-                newColor = `#${newColor}`;
-            }
-
-            if (newColor.match(/#[0-9A-Fa-f]{6}$/)) {
-                this.set('settings.brand.primaryColor', '');
-                run.schedule('afterRender', this, function () {
-                    this.set('settings.brand.primaryColor', newColor);
-                });
-            } else {
-                errMessage = 'The color should be in valid hex format';
-                this.get('settings.errors').add('brandColor', errMessage);
-                this.get('settings.hasValidated').pushObject('brandColor');
-                return;
-            }
+            this.set('settings.twitter', '');
+            run.schedule('afterRender', this, function () {
+                this.set('settings.twitter', newUrl);
+            });
+        } else {
+            errMessage = 'The URL must be in a format like '
+                       + 'https://twitter.com/yourUsername';
+            this.get('settings.errors').add('twitter', errMessage);
+            this.get('settings.hasValidated').pushObject('twitter');
+            return;
         }
-    },
+    }
+
+    @action
+    validateBrandColor() {
+        let newColor = this.get('brandColor');
+        let oldColor = this.get('settings.brand.primaryColor');
+        let errMessage = '';
+
+        // reset errors and validation
+        this.get('settings.errors').remove('brandColor');
+        this.get('settings.hasValidated').removeObject('brandColor');
+
+        if (newColor === '') {
+            // Clear out the brand color
+            this.set('settings.brand.primaryColor', '');
+            return;
+        }
+
+        // brandColor will be null unless the user has input something
+        if (!newColor) {
+            newColor = oldColor;
+        }
+
+        if (newColor[0] !== '#') {
+            newColor = `#${newColor}`;
+        }
+
+        if (newColor.match(/#[0-9A-Fa-f]{6}$/)) {
+            this.set('settings.brand.primaryColor', '');
+            run.schedule('afterRender', this, function () {
+                this.set('settings.brand.primaryColor', newColor);
+            });
+        } else {
+            errMessage = 'The color should be in valid hex format';
+            this.get('settings.errors').add('brandColor', errMessage);
+            this.get('settings.hasValidated').pushObject('brandColor');
+            return;
+        }
+    }
 
     _deleteTheme() {
         let theme = this.store.peekRecord('theme', this.themeToDelete.name);
@@ -319,9 +334,10 @@ export default Controller.extend({
         return theme.destroyRecord().catch((error) => {
             this.notifications.showAPIError(error);
         });
-    },
+    }
 
-    save: task(function* () {
+    @task
+    *saveTask() {
         let notifications = this.notifications;
         let config = this.config;
 
@@ -339,5 +355,5 @@ export default Controller.extend({
             }
             throw error;
         }
-    })
-});
+    }
+}

--- a/app/controllers/settings/integration/webhooks/edit.js
+++ b/app/controllers/settings/integration/webhooks/edit.js
@@ -1,24 +1,28 @@
 import Controller from '@ember/controller';
+import classic from 'ember-classic-decorator';
+import {action} from '@ember/object';
 import {alias} from '@ember/object/computed';
 
-export default Controller.extend({
-    webhook: alias('model'),
+@classic
+export default class EditController extends Controller {
+    @alias('model')
+    webhook;
 
-    actions: {
-        save() {
-            return this.webhook.save();
-        },
+    @action
+    save() {
+        return this.webhook.save();
+    }
 
-        cancel() {
-            // 'new' route's dectivate hook takes care of rollback
-            return this.webhook.get('integration').then((integration) => {
-                this.transitionToRoute('settings.integration', integration);
-            });
-        }
-    },
+    @action
+    cancel() {
+        // 'new' route's dectivate hook takes care of rollback
+        return this.webhook.get('integration').then((integration) => {
+            this.transitionToRoute('settings.integration', integration);
+        });
+    }
 
     reset() {
         this.webhook.rollbackAttributes();
         this.webhook.errors.clear();
     }
-});
+}

--- a/app/controllers/settings/integration/webhooks/new.js
+++ b/app/controllers/settings/integration/webhooks/new.js
@@ -1,19 +1,23 @@
 import Controller from '@ember/controller';
+import classic from 'ember-classic-decorator';
+import {action} from '@ember/object';
 import {alias} from '@ember/object/computed';
 
-export default Controller.extend({
-    webhook: alias('model'),
+@classic
+export default class NewController extends Controller {
+    @alias('model')
+    webhook;
 
-    actions: {
-        save() {
-            return this.webhook.save();
-        },
-
-        cancel() {
-            // 'new' route's dectivate hook takes care of rollback
-            return this.webhook.get('integration').then((integration) => {
-                this.transitionToRoute('settings.integration', integration);
-            });
-        }
+    @action
+    save() {
+        return this.webhook.save();
     }
-});
+
+    @action
+    cancel() {
+        // 'new' route's dectivate hook takes care of rollback
+        return this.webhook.get('integration').then((integration) => {
+            this.transitionToRoute('settings.integration', integration);
+        });
+    }
+}

--- a/app/controllers/settings/integrations.js
+++ b/app/controllers/settings/integrations.js
@@ -1,34 +1,38 @@
-/* eslint-disable ghost/ember/alias-model-in-controller */
-import Controller from '@ember/controller';
+import classic from 'ember-classic-decorator';
 import {computed} from '@ember/object';
 import {inject as service} from '@ember/service';
-import {task} from 'ember-concurrency';
+/* eslint-disable ghost/ember/alias-model-in-controller */
+import Controller from '@ember/controller';
+import {task} from 'ember-concurrency-decorators';
 
-export default Controller.extend({
-    settings: service(),
-    store: service(),
+@classic
+export default class IntegrationsController extends Controller {
+    @service settings;
+    @service store;
 
-    _allIntegrations: null,
+    _allIntegrations = null;
 
     init() {
-        this._super(...arguments);
+        super.init(...arguments);
         this._allIntegrations = this.store.peekAll('integration');
-    },
+    }
 
     // filter over the live query so that the list is automatically updated
     // as integrations are added/removed
-    integrations: computed('_allIntegrations.@each.{isNew,type}', function () {
+    @computed('_allIntegrations.@each.{isNew,type}')
+    get integrations() {
         return this._allIntegrations.reject((integration) => {
             return integration.isNew || integration.type !== 'custom';
         });
-    }),
+    }
 
     // use ember-concurrency so that we can use the derived state to show
     // a spinner only in the integrations list and avoid delaying the whole
     // screen display
-    fetchIntegrations: task(function* () {
+    @task
+    *fetchIntegrations() {
         return yield this.store.findAll('integration');
-    }),
+    }
 
     // used by individual integration routes' `model` hooks
     integrationModelHook(prop, value, route, transition) {
@@ -49,4 +53,4 @@ export default Controller.extend({
             return integration;
         });
     }
-});
+}

--- a/app/controllers/settings/integrations/amp.js
+++ b/app/controllers/settings/integrations/amp.js
@@ -1,67 +1,74 @@
-/* eslint-disable ghost/ember/alias-model-in-controller */
-import Controller from '@ember/controller';
+import classic from 'ember-classic-decorator';
+import {action} from '@ember/object';
 import {alias} from '@ember/object/computed';
 import {inject as service} from '@ember/service';
-import {task} from 'ember-concurrency';
+/* eslint-disable ghost/ember/alias-model-in-controller */
+import Controller from '@ember/controller';
+import {task} from 'ember-concurrency-decorators';
 
-export default Controller.extend({
-    notifications: service(),
-    settings: service(),
+@classic
+export default class AmpController extends Controller {
+    @service notifications;
+    @service settings;
 
-    leaveSettingsTransition: null,
+    leaveSettingsTransition = null;
 
-    ampSettings: alias('settings.amp'),
+    @alias('settings.amp')
+    ampSettings;
 
-    actions: {
-        update(value) {
-            this.set('ampSettings', value);
-        },
+    @action
+    update(value) {
+        this.set('ampSettings', value);
+    }
 
-        save() {
-            this.save.perform();
-        },
+    @action
+    save() {
+        this.saveTask.perform();
+    }
 
-        toggleLeaveSettingsModal(transition) {
-            let leaveTransition = this.leaveSettingsTransition;
+    @action
+    toggleLeaveSettingsModal(transition) {
+        let leaveTransition = this.leaveSettingsTransition;
 
-            if (!transition && this.showLeaveSettingsModal) {
-                this.set('leaveSettingsTransition', null);
-                this.set('showLeaveSettingsModal', false);
-                return;
-            }
-
-            if (!leaveTransition || transition.targetName === leaveTransition.targetName) {
-                this.set('leaveSettingsTransition', transition);
-
-                // if a save is running, wait for it to finish then transition
-                if (this.get('save.isRunning')) {
-                    return this.get('save.last').then(() => {
-                        transition.retry();
-                    });
-                }
-
-                // we genuinely have unsaved data, show the modal
-                this.set('showLeaveSettingsModal', true);
-            }
-        },
-
-        leaveSettings() {
-            let transition = this.leaveSettingsTransition;
-            let settings = this.settings;
-
-            if (!transition) {
-                this.notifications.showAlert('Sorry, there was an error in the application. Please let the Ghost team know what happened.', {type: 'error'});
-                return;
-            }
-
-            // roll back changes on settings model
-            settings.rollbackAttributes();
-
-            return transition.retry();
+        if (!transition && this.showLeaveSettingsModal) {
+            this.set('leaveSettingsTransition', null);
+            this.set('showLeaveSettingsModal', false);
+            return;
         }
-    },
 
-    save: task(function* () {
+        if (!leaveTransition || transition.targetName === leaveTransition.targetName) {
+            this.set('leaveSettingsTransition', transition);
+
+            // if a save is running, wait for it to finish then transition
+            if (this.get('save.isRunning')) {
+                return this.get('save.last').then(() => {
+                    transition.retry();
+                });
+            }
+
+            // we genuinely have unsaved data, show the modal
+            this.set('showLeaveSettingsModal', true);
+        }
+    }
+
+    @action
+    leaveSettings() {
+        let transition = this.leaveSettingsTransition;
+        let settings = this.settings;
+
+        if (!transition) {
+            this.notifications.showAlert('Sorry, there was an error in the application. Please let the Ghost team know what happened.', {type: 'error'});
+            return;
+        }
+
+        // roll back changes on settings model
+        settings.rollbackAttributes();
+
+        return transition.retry();
+    }
+
+    @task({drop: true})
+    *saveTask() {
         let amp = this.ampSettings;
         let settings = this.settings;
 
@@ -73,5 +80,5 @@ export default Controller.extend({
             this.notifications.showAPIError(error);
             throw error;
         }
-    }).drop()
-});
+    }
+}

--- a/app/controllers/settings/integrations/new.js
+++ b/app/controllers/settings/integrations/new.js
@@ -1,17 +1,21 @@
 import Controller from '@ember/controller';
+import classic from 'ember-classic-decorator';
+import {action} from '@ember/object';
 import {alias} from '@ember/object/computed';
 
-export default Controller.extend({
-    integration: alias('model'),
+@classic
+export default class NewController extends Controller {
+    @alias('model')
+    integration;
 
-    actions: {
-        save() {
-            return this.integration.save();
-        },
-
-        cancel() {
-            // 'new' route's dectivate hook takes care of rollback
-            this.transitionToRoute('settings.integrations');
-        }
+    @action
+    save() {
+        return this.integration.save();
     }
-});
+
+    @action
+    cancel() {
+        // 'new' route's dectivate hook takes care of rollback
+        this.transitionToRoute('settings.integrations');
+    }
+}

--- a/app/controllers/settings/integrations/slack.js
+++ b/app/controllers/settings/integrations/slack.js
@@ -1,100 +1,111 @@
+import classic from 'ember-classic-decorator';
+import {action} from '@ember/object';
+import {empty} from '@ember/object/computed';
+import {inject as service} from '@ember/service';
 /* eslint-disable ghost/ember/alias-model-in-controller */
 import Controller from '@ember/controller';
 import boundOneWay from 'ghost-admin/utils/bound-one-way';
-import {empty} from '@ember/object/computed';
 import {isInvalidError} from 'ember-ajax/errors';
-import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 
-export default Controller.extend({
-    ghostPaths: service(),
-    ajax: service(),
-    notifications: service(),
-    settings: service(),
+@classic
+export default class SlackController extends Controller {
+    @service ajax;
+    @service ghostPaths;
+    @service notifications;
+    @service settings;
 
-    leaveSettingsTransition: null,
-    slackArray: null,
+    leaveSettingsTransition = null;
+    slackArray = null;
 
     init() {
-        this._super(...arguments);
+        super.init(...arguments);
         this.slackArray = [];
-    },
+    }
 
-    slackSettings: boundOneWay('settings.slack.firstObject'),
-    testNotificationDisabled: empty('slackSettings.url'),
+    @boundOneWay('settings.slack.firstObject')
+    slackSettings;
 
-    actions: {
-        save() {
-            this.save.perform();
-        },
+    @empty('slackSettings.url')
+    testNotificationDisabled;
 
-        updateURL(value) {
-            value = typeof value === 'string' ? value.trim() : value;
-            this.set('slackSettings.url', value);
-            this.get('slackSettings.errors').clear();
-        },
+    @action
+    save() {
+        this.saveTask.perform();
+    }
 
-        updateUsername(value) {
-            value = typeof value === 'string' ? value.trimLeft() : value;
-            this.set('slackSettings.username', value);
-            this.get('slackSettings.errors').clear();
-        },
+    @action
+    updateURL(value) {
+        value = typeof value === 'string' ? value.trim() : value;
+        this.set('slackSettings.url', value);
+        this.get('slackSettings.errors').clear();
+    }
 
-        triggerDirtyState() {
-            let slack = this.slackSettings;
-            let slackArray = this.slackArray;
-            let settings = this.settings;
+    @action
+    updateUsername(value) {
+        value = typeof value === 'string' ? value.trimLeft() : value;
+        this.set('slackSettings.username', value);
+        this.get('slackSettings.errors').clear();
+    }
 
-            // Hack to trigger the `isDirty` state on the settings model by setting a new Array
-            // for slack rather that replacing the existing one which would still point to the
-            // same reference and therfore not setting the model into a dirty state
-            slackArray.clear().pushObject(slack);
-            settings.set('slack', slackArray);
-        },
+    @action
+    triggerDirtyState() {
+        let slack = this.slackSettings;
+        let slackArray = this.slackArray;
+        let settings = this.settings;
 
-        toggleLeaveSettingsModal(transition) {
-            let leaveTransition = this.leaveSettingsTransition;
+        // Hack to trigger the `isDirty` state on the settings model by setting a new Array
+        // for slack rather that replacing the existing one which would still point to the
+        // same reference and therfore not setting the model into a dirty state
+        slackArray.clear().pushObject(slack);
+        settings.set('slack', slackArray);
+    }
 
-            if (!transition && this.showLeaveSettingsModal) {
-                this.set('leaveSettingsTransition', null);
-                this.set('showLeaveSettingsModal', false);
-                return;
-            }
+    @action
+    toggleLeaveSettingsModal(transition) {
+        let leaveTransition = this.leaveSettingsTransition;
 
-            if (!leaveTransition || transition.targetName === leaveTransition.targetName) {
-                this.set('leaveSettingsTransition', transition);
-
-                // if a save is running, wait for it to finish then transition
-                if (this.get('save.isRunning')) {
-                    return this.get('save.last').then(() => {
-                        transition.retry();
-                    });
-                }
-
-                // we genuinely have unsaved data, show the modal
-                this.set('showLeaveSettingsModal', true);
-            }
-        },
-
-        leaveSettings() {
-            let transition = this.leaveSettingsTransition;
-            let settings = this.settings;
-            let slackArray = this.slackArray;
-
-            if (!transition) {
-                this.notifications.showAlert('Sorry, there was an error in the application. Please let the Ghost team know what happened.', {type: 'error'});
-                return;
-            }
-
-            // roll back changes on model props
-            settings.rollbackAttributes();
-            slackArray.clear();
-
-            return transition.retry();
+        if (!transition && this.showLeaveSettingsModal) {
+            this.set('leaveSettingsTransition', null);
+            this.set('showLeaveSettingsModal', false);
+            return;
         }
-    },
 
-    save: task(function* () {
+        if (!leaveTransition || transition.targetName === leaveTransition.targetName) {
+            this.set('leaveSettingsTransition', transition);
+
+            // if a save is running, wait for it to finish then transition
+            if (this.get('save.isRunning')) {
+                return this.get('save.last').then(() => {
+                    transition.retry();
+                });
+            }
+
+            // we genuinely have unsaved data, show the modal
+            this.set('showLeaveSettingsModal', true);
+        }
+    }
+
+    @action
+    leaveSettings() {
+        let transition = this.leaveSettingsTransition;
+        let settings = this.settings;
+        let slackArray = this.slackArray;
+
+        if (!transition) {
+            this.notifications.showAlert('Sorry, there was an error in the application. Please let the Ghost team know what happened.', {type: 'error'});
+            return;
+        }
+
+        // roll back changes on model props
+        settings.rollbackAttributes();
+        slackArray.clear();
+
+        return transition.retry();
+    }
+
+    @task({drop: true})
+    *saveTask() {
         let slack = this.slackSettings;
         let settings = this.settings;
         let slackArray = this.slackArray;
@@ -111,14 +122,15 @@ export default Controller.extend({
                 throw error;
             }
         }
-    }).drop(),
+    }
 
-    sendTestNotification: task(function* () {
+    @task({drop: true})
+    *sendTestNotification() {
         let notifications = this.notifications;
         let slackApi = this.get('ghostPaths.url').api('slack', 'test');
 
         try {
-            yield this.save.perform();
+            yield this.saveTask.perform();
             yield this.ajax.post(slackApi);
             notifications.showNotification('Check your Slack channel for the test message!', {type: 'info', key: 'slack-test.send.success'});
             return true;
@@ -129,5 +141,5 @@ export default Controller.extend({
                 throw error;
             }
         }
-    }).drop()
-});
+    }
+}

--- a/app/controllers/settings/integrations/zapier.js
+++ b/app/controllers/settings/integrations/zapier.js
@@ -1,41 +1,49 @@
+import classic from 'ember-classic-decorator';
+import {alias} from '@ember/object/computed';
+import {computed} from '@ember/object';
+import {inject as service} from '@ember/service';
 /* eslint-disable ghost/ember/alias-model-in-controller */
 import Controller from '@ember/controller';
 import config from 'ghost-admin/config/environment';
 import copyTextToClipboard from 'ghost-admin/utils/copy-text-to-clipboard';
-import {alias} from '@ember/object/computed';
-import {computed} from '@ember/object';
-import {inject as service} from '@ember/service';
-import {task, timeout} from 'ember-concurrency';
+import {task} from 'ember-concurrency-decorators';
+import {timeout} from 'ember-concurrency';
 
-export default Controller.extend({
-    ghostPaths: service(),
+@classic
+export default class ZapierController extends Controller {
+    @service
+    ghostPaths;
 
-    isTesting: undefined,
+    isTesting = undefined;
 
     init() {
-        this._super(...arguments);
+        super.init(...arguments);
         if (this.isTesting === undefined) {
             this.isTesting = config.environment === 'test';
         }
-    },
+    }
 
-    integration: alias('model'),
+    @alias('model')
+    integration;
 
-    apiUrl: computed(function () {
+    @computed
+    get apiUrl() {
         let origin = window.location.origin;
         let subdir = this.ghostPaths.subdir;
         let url = this.ghostPaths.url.join(origin, subdir);
 
         return url.replace(/\/$/, '');
-    }),
+    }
 
-    copyAdminKey: task(function* () {
+    @task
+    *copyAdminKey() {
         copyTextToClipboard(this.integration.adminKey.secret);
         yield timeout(3000);
-    }),
+    }
 
-    copyApiUrl: task(function* () {
+    @task
+    *copyApiUrl() {
         copyTextToClipboard(this.apiUrl);
         yield timeout(3000);
-    })
-});
+    }
+}

--- a/app/controllers/setup.js
+++ b/app/controllers/setup.js
@@ -1,18 +1,22 @@
-/* eslint-disable ghost/ember/alias-model-in-controller */
-import Controller from '@ember/controller';
+import classic from 'ember-classic-decorator';
 import {computed} from '@ember/object';
 import {match} from '@ember/object/computed';
 import {inject as service} from '@ember/service';
+/* eslint-disable ghost/ember/alias-model-in-controller */
+import Controller from '@ember/controller';
 
-export default Controller.extend({
-    ghostPaths: service(),
-    router: service(),
+@classic
+export default class SetupController extends Controller {
+    @service ghostPaths;
+    @service router;
 
-    showBackLink: match('router.currentRouteName', /^setup\.(two|three)$/),
+    @match('router.currentRouteName', /^setup\.(two|three)$/)
+    showBackLink;
 
-    backRoute: computed('router.currentRouteName', function () {
+    @computed('router.currentRouteName')
+    get backRoute() {
         let currentRoute = this.router.currentRouteName;
 
         return currentRoute === 'setup.two' ? 'setup.one' : 'setup.two';
-    })
-});
+    }
+}

--- a/app/controllers/signin.js
+++ b/app/controllers/signin.js
@@ -1,43 +1,41 @@
 import $ from 'jquery';
 import Controller, {inject as controller} from '@ember/controller';
 import ValidationEngine from 'ghost-admin/mixins/validation-engine';
+import classic from 'ember-classic-decorator';
 import {alias} from '@ember/object/computed';
 import {isArray as isEmberArray} from '@ember/array';
 import {isVersionMismatchError} from 'ghost-admin/services/ajax';
 import {inject as service} from '@ember/service';
-import {task} from 'ember-concurrency';
+import {task} from 'ember-concurrency-decorators';
 
-export default Controller.extend(ValidationEngine, {
-    application: controller(),
-    ajax: service(),
-    config: service(),
-    ghostPaths: service(),
-    notifications: service(),
-    session: service(),
-    settings: service(),
+@classic
+export default class SigninController extends Controller.extend(ValidationEngine) { // eslint-disable-line ghost/ember/alias-model-in-controller
+    @controller application;
+    @service ajax;
+    @service config;
+    @service ghostPaths;
+    @service notifications;
+    @service session;
+    @service settings;
 
-    submitting: false,
-    loggingIn: false,
-    authProperties: null,
+    submitting = false;
+    loggingIn = false;
+    authProperties = null;
+    flowErrors = '';
 
-    flowErrors: '',
     // ValidationEngine settings
-    validationType: 'signin',
+    validationType = 'signin';
 
     init() {
-        this._super(...arguments);
+        super.init(...arguments);
         this.authProperties = ['identification', 'password'];
-    },
+    }
 
-    signin: alias('model'),
+    @alias('model')
+    signin;
 
-    actions: {
-        authenticate() {
-            return this.validateAndAuthenticate.perform();
-        }
-    },
-
-    authenticate: task(function* (authStrategy, authentication) {
+    @task({drop: true})
+    *authenticate(authStrategy, authentication) {
         try {
             return yield this.session
                 .authenticate(authStrategy, ...authentication)
@@ -71,9 +69,10 @@ export default Controller.extend(ValidationEngine, {
                 );
             }
         }
-    }).drop(),
+    }
 
-    validateAndAuthenticate: task(function* () {
+    @task({drop: true})
+    *validateAndAuthenticate() {
         let signin = this.signin;
         let authStrategy = 'authenticator:cookie';
 
@@ -93,9 +92,10 @@ export default Controller.extend(ValidationEngine, {
         } catch (error) {
             this.set('flowErrors', 'Please fill out the form to sign in.');
         }
-    }).drop(),
+    }
 
-    forgotten: task(function* () {
+    @task
+    *forgotten() {
         let email = this.get('signin.identification');
         let forgottenUrl = this.get('ghostPaths.url').api('authentication', 'passwordreset');
         let notifications = this.notifications;
@@ -134,5 +134,5 @@ export default Controller.extend(ValidationEngine, {
                 notifications.showAPIError(error, {defaultErrorText: 'There was a problem with the reset, please try again.', key: 'forgot-password.send'});
             }
         }
-    })
-});
+    }
+}

--- a/app/controllers/site.js
+++ b/app/controllers/site.js
@@ -1,6 +1,9 @@
 import Controller from '@ember/controller';
+import classic from 'ember-classic-decorator';
 import {alias} from '@ember/object/computed';
 
-export default Controller.extend({
-    guid: alias('model')
-});
+@classic
+export default class SiteController extends Controller {
+    @alias('model')
+    guid;
+}

--- a/app/controllers/tags.js
+++ b/app/controllers/tags.js
@@ -1,29 +1,32 @@
 import Controller from '@ember/controller';
+import classic from 'ember-classic-decorator';
+import {action, computed} from '@ember/object';
 import {alias, sort} from '@ember/object/computed';
-import {computed} from '@ember/object';
 
-export default Controller.extend({
+@classic
+export default class TagsController extends Controller {
+    queryParams = ['type'];
+    type = 'public';
 
-    queryParams: ['type'],
-    type: 'public',
+    @alias('model')
+    tags;
 
-    tags: alias('model'),
-
-    filteredTags: computed('tags.@each.isNew', 'type', function () {
+    @computed('tags.@each.isNew', 'type')
+    get filteredTags() {
         return this.tags.filter((tag) => {
             return (!tag.isNew && (!this.type || tag.visibility === this.type));
         });
-    }),
+    }
 
     // tags are sorted by name
-    sortedTags: sort('filteredTags', function (tagA, tagB) {
+    @sort('filteredTags', function (tagA, tagB) {
         // ignorePunctuation means the # in internal tag names is ignored
         return tagA.name.localeCompare(tagB.name, undefined, {ignorePunctuation: true});
-    }),
+    })
+    sortedTags;
 
-    actions: {
-        changeType(type) {
-            this.set('type', type);
-        }
+    @action
+    changeType(type) {
+        this.set('type', type);
     }
-});
+}

--- a/app/templates/editor.hbs
+++ b/app/templates/editor.hbs
@@ -49,8 +49,8 @@
                             @post={{this.post}}
                             @postStatus={{this.post.status}}
                             @saveTask={{this.save}}
-                            @setSaveType={{action "setSaveType"}}
-                            @onOpen={{action "cancelAutosave"}}
+                            @setSaveType={{this.setSaveType}}
+                            @onOpen={{this.cancelAutosave}}
                             @backgroundTask={{this.backgroundLoader}}
                             @memberCount={{this.memberCount}} />
                     {{/if}}
@@ -69,18 +69,18 @@
         <GhKoenigEditor
             @title={{readonly this.post.titleScratch}}
             @titlePlaceholder={{concat (capitalize this.post.displayName) " Title"}}
-            @onTitleChange={{action "updateTitleScratch"}}
-            @onTitleBlur={{action (perform this.saveTitle)}}
+            @onTitleChange={{this.updateTitleScratch}}
+            @onTitleBlur={{perform this.saveTitle}}
             @body={{readonly this.post.scratch}}
             @bodyPlaceholder={{concat "Begin writing your " this.post.displayName "..."}}
             @bodyAutofocus={{this.shouldFocusEditor}}
-            @onBodyChange={{action "updateScratch"}}
+            @onBodyChange={{this.updateScratch}}
             @headerOffset={{editor.headerHeight}}
             @scrollContainerSelector=".gh-koenig-editor"
             @scrollOffsetTopSelector=".gh-editor-header-small"
             @scrollOffsetBottomSelector=".gh-mobile-nav-bar"
-            @onEditorCreated={{action "setKoenigEditor"}}
-            @onWordCountChange={{action "updateWordCount"}}
+            @onEditorCreated={{this.setKoenigEditor}}
+            @onWordCountChange={{this.updateWordCount}}
         />
 
         <div class="absolute flex items-center br3 bg-white {{if editor.headerClass "right-4 bottom-4" "right-6 bottom-6"}}">
@@ -93,29 +93,33 @@
     </GhEditor>
 
     {{#if this.showDeletePostModal}}
-        <GhFullscreenModal @modal="delete-post"
+        <GhFullscreenModal
+            @modal="delete-post"
             @model={{hash post=this.post onSuccess=(route-action 'redirectToContentScreen')}}
-            @close={{action "toggleDeletePostModal"}}
+            @close={{this.toggleDeletePostModal}}
             @modifier="action wide" />
     {{/if}}
 
     {{#if this.showLeaveEditorModal}}
-        <GhFullscreenModal @modal="leave-editor"
-            @confirm={{action "leaveEditor"}}
-            @close={{action "toggleLeaveEditorModal"}}
+        <GhFullscreenModal
+            @modal="leave-editor"
+            @confirm={{this.leaveEditor}}
+            @close={{this.toggleLeaveEditorModal}}
             @modifier="action wide" />
     {{/if}}
 
     {{#if this.showReAuthenticateModal}}
-        <GhFullscreenModal @modal="re-authenticate"
-            @close={{action "toggleReAuthenticateModal"}}
+        <GhFullscreenModal
+            @modal="re-authenticate"
+            @close={{this.toggleReAuthenticateModal}}
             @modifier="action wide" />
     {{/if}}
 
     {{#if this.showEmailPreviewModal}}
-        <GhFullscreenModal @modal="post-email-preview"
+        <GhFullscreenModal
+            @modal="post-email-preview"
             @model={{this.post}}
-            @close={{action "toggleEmailPreviewModal"}}
+            @close={{this.toggleEmailPreviewModal}}
             @modifier="full-overlay email-preview" />
     {{/if}}
 
@@ -127,7 +131,7 @@
                 details=hostLimitError.details
                 upgradeLink=hostLimitError.help
             }}
-            @close={{action "closeUpgradeModal"}}
+            @close={{this.closeUpgradeModal}}
             @modifier="action wide"
         />
     {{/if}}
@@ -136,8 +140,8 @@
         <GhPostSettingsMenu
             @post={{this.post}}
             @showSettingsMenu={{this.ui.showSettingsMenu}}
-            @toggleEmailPreviewModal={{action "toggleEmailPreviewModal"}}
-            @deletePost={{action "toggleDeletePostModal"}}
+            @toggleEmailPreviewModal={{this.toggleEmailPreviewModal}}
+            @deletePost={{this.toggleDeletePostModal}}
             @updateSlug={{this.updateSlug}}
             @savePost={{this.savePost}}
         />

--- a/app/templates/member.hbs
+++ b/app/templates/member.hbs
@@ -11,7 +11,7 @@
                 {{/if}}
             </h2>
             <section class="view-actions">
-                <GhTaskButton @class="gh-btn gh-btn-blue gh-btn-icon" @type="button" @task={{this.save}} @data-test-button="save" />
+                <GhTaskButton @class="gh-btn gh-btn-blue gh-btn-icon" @type="button" @task={{this.saveTask}} @data-test-button="save" />
             </section>
         </GhCanvasHeader>
 
@@ -46,7 +46,7 @@
         <GhMemberSettingsForm
             @member={{this.member}}
             @scratchMember={{this.scratchMember}}
-            @setProperty={{action "setProperty"}}
+            @setProperty={{this.setProperty}}
             @isLoading={{this.isLoading}} />
     </form>
 
@@ -54,7 +54,7 @@
         <button
             type="button"
             class="gh-btn gh-btn-red gh-btn-icon mt3"
-            {{on "click" (action "toggleDeleteMemberModal")}}
+            {{on "click" this.toggleDeleteMemberModal}}
             data-test-button="delete-member"
         >
             <span>Delete member</span>
@@ -65,8 +65,8 @@
 {{#if this.showUnsavedChangesModal}}
     <GhFullscreenModal
         @modal="leave-settings"
-        @confirm={{action "leaveScreen"}}
-        @close={{action "toggleUnsavedChangesModal"}}
+        @confirm={{this.leaveScreen}}
+        @close={{this.toggleUnsavedChangesModal}}
         @modifier="action wide" />
 {{/if}}
 
@@ -74,7 +74,7 @@
     <GhFullscreenModal
         @modal="delete-member"
         @model={{this.member}}
-        @confirm={{action "deleteMember"}}
-        @close={{action "toggleDeleteMemberModal"}}
+        @confirm={{this.deleteMember}}
+        @close={{this.toggleDeleteMemberModal}}
         @modifier="action wide" />
 {{/if}}

--- a/app/templates/members.hbs
+++ b/app/templates/members.hbs
@@ -25,7 +25,7 @@
                         </LinkTo>
                     </li>
                     <li>
-                        <a href="#" {{action 'exportData'}} class="mr2">
+                        <a href="javascript:void(0)" {{on "click" this.exportData}} class="mr2">
                             <span>Export CSV</span>
                         </a>
                     </li>

--- a/app/templates/members/import.hbs
+++ b/app/templates/members/import.hbs
@@ -1,4 +1,4 @@
 <GhFullscreenModal @modal="import-members"
-    @close={{action "close"}}
-    @confirm={{action "fetchNewMembers"}}
+    @close={{this.close}}
+    @confirm={{this.fetchNewMembers}}
     @modifier="action wide" />

--- a/app/templates/pages-loading.hbs
+++ b/app/templates/pages-loading.hbs
@@ -5,16 +5,16 @@
             <GhContentfilter
                 @selectedType={{this.selectedType}}
                 @availableTypes={{this.availableTypes}}
-                @onTypeChange={{action (mut k)}}
+                @onTypeChange={{fn (mut k)}}
                 @selectedAuthor={{this.selectedAuthor}}
                 @availableAuthors={{this.availableAuthors}}
-                @onAuthorChange={{action (mut k)}}
+                @onAuthorChange={{fn (mut k)}}
                 @selectedTag={{this.selectedTag}}
                 @availableTags={{this.availableTags}}
-                @onTagChange={{action (mut k)}}
+                @onTagChange={{fn (mut k)}}
                 @selectedOrder={{this.selectedOrder}}
                 @availableOrders={{this.availableOrders}}
-                @onOrderChange={{action (mut k)}}
+                @onOrderChange={{fn (mut k)}}
             />
 
             <LinkTo @route="editor.new" @model="page" class="gh-btn gh-btn-green" data-test-new-page-button={{true}}><span>New page</span></LinkTo>

--- a/app/templates/pages.hbs
+++ b/app/templates/pages.hbs
@@ -5,16 +5,16 @@
             <GhContentfilter
                 @selectedType={{this.selectedType}}
                 @availableTypes={{this.availableTypes}}
-                @onTypeChange={{action "changeType"}}
+                @onTypeChange={{this.changeType}}
                 @selectedAuthor={{this.selectedAuthor}}
                 @availableAuthors={{this.availableAuthors}}
-                @onAuthorChange={{action "changeAuthor"}}
+                @onAuthorChange={{this.changeAuthor}}
                 @selectedTag={{this.selectedTag}}
                 @availableTags={{this.availableTags}}
-                @onTagChange={{action "changeTag"}}
+                @onTagChange={{this.changeTag}}
                 @selectedOrder={{this.selectedOrder}}
                 @availableOrders={{this.availableOrders}}
-                @onOrderChange={{action "changeOrder"}}
+                @onOrderChange={{this.changeOrder}}
             />
 
             <LinkTo @route="editor.new" @model="page" class="gh-btn gh-btn-green" data-test-new-page-button={{true}}><span>New page</span></LinkTo>

--- a/app/templates/posts-loading.hbs
+++ b/app/templates/posts-loading.hbs
@@ -5,16 +5,16 @@
             <GhContentfilter
                 @selectedType={{this.selectedType}}
                 @availableTypes={{this.availableTypes}}
-                @onTypeChange={{action (mut k)}}
+                @onTypeChange={{fn (mut k)}}
                 @selectedAuthor={{this.selectedAuthor}}
                 @availableAuthors={{this.availableAuthors}}
-                @onAuthorChange={{action (mut k)}}
+                @onAuthorChange={{fn (mut k)}}
                 @selectedTag={{this.selectedTag}}
                 @availableTags={{this.availableTags}}
-                @onTagChange={{action (mut k)}}
+                @onTagChange={{fn (mut k)}}
                 @selectedOrder={{this.selectedOrder}}
                 @availableOrders={{this.availableOrders}}
-                @onOrderChange={{action (mut k)}}
+                @onOrderChange={{fn (mut k)}}
             />
 
             <LinkTo @route="editor.new" @model="post" class="gh-btn gh-btn-green" data-test-new-post-button={{true}}><span>New post</span></LinkTo>

--- a/app/templates/posts.hbs
+++ b/app/templates/posts.hbs
@@ -5,16 +5,16 @@
             <GhContentfilter
                 @selectedType={{this.selectedType}}
                 @availableTypes={{this.availableTypes}}
-                @onTypeChange={{action "changeType"}}
+                @onTypeChange={{this.changeType}}
                 @selectedAuthor={{this.selectedAuthor}}
                 @availableAuthors={{this.availableAuthors}}
-                @onAuthorChange={{action "changeAuthor"}}
+                @onAuthorChange={{this.changeAuthor}}
                 @selectedTag={{this.selectedTag}}
                 @availableTags={{this.availableTags}}
-                @onTagChange={{action "changeTag"}}
+                @onTagChange={{this.changeTag}}
                 @selectedOrder={{this.selectedOrder}}
                 @availableOrders={{this.availableOrders}}
-                @onOrderChange={{action "changeOrder"}}
+                @onOrderChange={{this.changeOrder}}
             />
 
             <LinkTo @route="editor.new" @model="post" class="gh-btn gh-btn-green" data-test-new-post-button={{true}}><span>New post</span></LinkTo>

--- a/app/templates/reset.hbs
+++ b/app/templates/reset.hbs
@@ -1,7 +1,7 @@
 <div class="gh-flow">
     <div class="gh-flow-content-wrap">
         <section class="gh-flow-content fade-in">
-            <form id="reset" class="gh-signin" method="post" novalidate="novalidate" {{action "submit" on="submit"}}>
+            <form id="reset" class="gh-signin" method="post" novalidate="novalidate" {{on "submit" this.submit}}>
                 <GhFormGroup @errors={{this.errors}} @hasValidated={{this.hasValidated}} @property="newPassword">
                     <span class="gh-input-icon gh-icon-lock">
                         {{svg-jar "lock"}}

--- a/app/templates/settings/code-injection.hbs
+++ b/app/templates/settings/code-injection.hbs
@@ -10,8 +10,8 @@
 
     {{#if this.showLeaveSettingsModal}}
         <GhFullscreenModal @modal="leave-settings"
-            @confirm={{action "leaveSettings"}}
-            @close={{action "toggleLeaveSettingsModal"}}
+            @confirm={{this.leaveSettings}}
+            @close={{this.toggleLeaveSettingsModal}}
             @modifier="action wide" />
     {{/if}}
 
@@ -27,13 +27,13 @@
                     <div class="form-group settings-code">
                         <label for="ghost-head">Site Header</label>
                         <p>Code here will be injected into the <code>\{{ghost_head}}</code> tag on every page of the site</p>
-                        <GhCmEditor @value={{this.settings.codeinjectionHead}} @id="ghost-head" @class="gh-input settings-code-editor" @name="codeInjection[ghost_head]" @type="text" @update={{action (mut this.settings.codeinjectionHead)}} />
+                        <GhCmEditor @value={{this.settings.codeinjectionHead}} @id="ghost-head" @class="gh-input settings-code-editor" @name="codeInjection[ghost_head]" @type="text" @update={{fn (mut this.settings.codeinjectionHead)}} />
                     </div>
 
                     <div class="form-group settings-code">
                         <label for="ghost-foot">Site Footer</label>
                         <p>Code here will be injected into the <code>\{{ghost_foot}}</code> tag on every page of the site</p>
-                        <GhCmEditor @value={{this.settings.codeinjectionFoot}} @id="ghost-foot" @class="gh-input settings-code-editor" @name="codeInjection[ghost_foot]" @type="text" @update={{action (mut this.settings.codeinjectionFoot)}} />
+                        <GhCmEditor @value={{this.settings.codeinjectionFoot}} @id="ghost-foot" @class="gh-input settings-code-editor" @name="codeInjection[ghost_foot]" @type="text" @update={{fn (mut this.settings.codeinjectionFoot)}} />
                     </div>
                 </div>
             </fieldset>

--- a/app/templates/settings/design.hbs
+++ b/app/templates/settings/design.hbs
@@ -4,14 +4,14 @@
             Design
         </h2>
         <section class="view-actions">
-            <GhTaskButton @task={{this.save}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button={{true}} />
+            <GhTaskButton @task={{this.saveTask}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button={{true}} />
         </section>
     </GhCanvasHeader>
 
     {{#if this.showLeaveSettingsModal}}
         <GhFullscreenModal @modal="leave-settings"
-            @confirm={{action "leaveSettings"}}
-            @close={{action "toggleLeaveSettingsModal"}}
+            @confirm={{this.leaveSettings}}
+            @close={{this.toggleLeaveSettingsModal}}
             @modifier="action wide" />
     {{/if}}
 
@@ -25,10 +25,10 @@
                             <GhNavitem
                                 @navItem={{navItem}}
                                 @baseUrl={{this.blogUrl}}
-                                @addItem={{action "addNavItem"}}
-                                @deleteItem={{action "deleteNavItem"}}
-                                @updateUrl={{action "updateUrl"}}
-                                @updateLabel={{action "updateLabel"}}
+                                @addItem={{this.addNavItem}}
+                                @deleteItem={{this.deleteNavItem}}
+                                @updateUrl={{this.updateUrl}}
+                                @updateLabel={{this.updateLabel}}
                                 data-test-navitem={{index}} />
                         </DraggableObject>
                     {{/each}}
@@ -36,8 +36,8 @@
                 <GhNavitem
                     @navItem={{this.newNavItem}}
                     @baseUrl={{this.blogUrl}}
-                    @addItem={{action "addNavItem"}}
-                    @updateUrl={{action "updateUrl"}}
+                    @addItem={{this.addNavItem}}
+                    @updateUrl={{this.updateUrl}}
                     data-test-navitem="new" />
             </form>
         </div>
@@ -51,10 +51,10 @@
                             <GhNavitem
                                 @navItem={{navItem}}
                                 @baseUrl={{this.blogUrl}}
-                                @addItem={{action "addNavItem"}}
-                                @deleteItem={{action "deleteNavItem"}}
-                                @updateUrl={{action "updateUrl"}}
-                                @updateLabel={{action "updateLabel"}}
+                                @addItem={{this.addNavItem}}
+                                @deleteItem={{this.deleteNavItem}}
+                                @updateUrl={{this.updateUrl}}
+                                @updateLabel={{this.updateLabel}}
                                 data-test-navitem={{index}} />
                         </DraggableObject>
                     {{/each}}
@@ -62,8 +62,8 @@
                 <GhNavitem
                     @navItem={{this.newSecondaryNavItem}}
                     @baseUrl={{this.blogUrl}}
-                    @addItem={{action "addNavItem"}}
-                    @updateUrl={{action "updateUrl"}}
+                    @addItem={{this.addNavItem}}
+                    @updateUrl={{this.updateUrl}}
                     data-test-navitem="new" />
             </form>
         </div>
@@ -154,9 +154,9 @@
 
             <GhThemeTable
                 @themes={{this.themes}}
-                @activateTheme={{action "activateTheme"}}
-                @downloadTheme={{action "downloadTheme"}}
-                @deleteTheme={{action "deleteTheme"}} />
+                @activateTheme={{this.activateTheme}}
+                @downloadTheme={{this.downloadTheme}}
+                @deleteTheme={{this.deleteTheme}} />
 
             <LinkTo @route="settings.design.uploadtheme" class="gh-btn gh-btn-green gh-themes-uploadbtn" data-test-upload-theme-button={{true}}>
                 <span>Upload a theme</span>
@@ -164,37 +164,40 @@
 
 
             {{#if this.showDeleteThemeModal}}
-                <GhFullscreenModal @modal="delete-theme"
+                <GhFullscreenModal
+                    @modal="delete-theme"
                     @model={{hash
                         theme=this.themeToDelete
-                        download=(action "downloadTheme" this.themeToDelete)
+                        download=(fn this.downloadTheme this.themeToDelete)
                     }}
-                    @close={{action "hideDeleteThemeModal"}}
-                    @confirm={{action "deleteTheme"}}
+                    @close={{this.hideDeleteThemeModal}}
+                    @confirm={{this.deleteTheme}}
                     @modifier="action wide" />
             {{/if}}
 
             {{#if this.showThemeWarningsModal}}
-                <GhFullscreenModal @modal="theme-warnings"
+                <GhFullscreenModal
+                    @modal="theme-warnings"
                     @model={{hash
                         title="Activation successful"
                         warnings=this.themeWarnings
                         errors=this.themeErrors
                         canActivate=true
                     }}
-                    @close={{action "hideThemeWarningsModal"}}
+                    @close={{this.hideThemeWarningsModal}}
                     @modifier="action wide" />
             {{/if}}
 
             {{#if this.showThemeErrorsModal}}
-                <GhFullscreenModal @modal="theme-warnings"
+                <GhFullscreenModal
+                    @modal="theme-warnings"
                     @model={{hash
                         title="Activation failed"
                         errors=this.themeErrors
                         fatalErrors=this.themeFatalErrors
                         canActivate=false
                     }}
-                    @close={{action "hideThemeWarningsModal"}}
+                    @close={{this.hideThemeWarningsModal}}
                     @modifier="action wide" />
             {{/if}}
         </div>
@@ -204,7 +207,8 @@
 
 {{outlet}}
 
-<GhTourItem @throbberId="upload-a-theme"
+<GhTourItem
+    @throbberId="upload-a-theme"
     @target=".gh-themes-uploadbtn"
     @throbberAttachment="top middle"
     @popoverTriangleClass="bottom"

--- a/app/templates/settings/general.hbs
+++ b/app/templates/settings/general.hbs
@@ -5,14 +5,14 @@
             General settings
         </h2>
         <section class="view-actions">
-            <GhTaskButton @buttonText="Save settings" @task={{this.save}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button="true" />
+            <GhTaskButton @buttonText="Save settings" @task={{this.saveTask}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button="true" />
         </section>
     </GhCanvasHeader>
 
     {{#if this.showLeaveSettingsModal}}
         <GhFullscreenModal @modal="leave-settings"
-            @confirm={{action "leaveSettings"}}
-            @close={{action "toggleLeaveSettingsModal"}}
+            @confirm={{this.leaveSettings}}
+            @close={{this.toggleLeaveSettingsModal}}
             @modifier="action wide" />
     {{/if}}
 
@@ -51,7 +51,7 @@
                     {{/liquid-if}}
                 </div>
                 <div class="gh-setting-action">
-                    <button type="button" class="gh-btn" {{action (toggle "pubInfoOpen" this)}} data-test-toggle-pub-info><span>{{if this.pubInfoOpen "Close" "Expand"}}</span></button>
+                    <button type="button" class="gh-btn" {{fn (toggle "pubInfoOpen" this)}} data-test-toggle-pub-info><span>{{if this.pubInfoOpen "Close" "Expand"}}</span></button>
                 </div>
             </div>
 
@@ -64,12 +64,12 @@
                         <GhTimezoneSelect
                             @activeTimezone={{this.settings.activeTimezone}}
                             @availableTimezones={{this.availableTimezones}}
-                            @update={{action "setTimezone"}} />
+                            @update={{this.setTimezone}} />
                     </div>
                     {{/liquid-if}}
                 </div>
                 <div class="gh-setting-action">
-                    <button type="button" class="gh-btn" {{action (toggle "timezoneOpen" this)}} data-test-toggle-timezone><span>{{if this.timezoneOpen "Close" "Expand"}}</span></button>
+                    <button type="button" class="gh-btn" {{fn (toggle "timezoneOpen" this)}} data-test-toggle-timezone><span>{{if this.timezoneOpen "Close" "Expand"}}</span></button>
                 </div>
             </div>
             <div class="gh-setting-last">
@@ -92,7 +92,7 @@
                     {{/liquid-if}}
                 </div>
                 <div class="gh-setting-action">
-                    <button type="button" class="gh-btn" {{action (toggle "defaultLocaleOpen" this)}} data-test-toggle-default-locale><span>{{if this.defaultLocaleOpen "Close" "Expand"}}</span></button>
+                    <button type="button" class="gh-btn" {{fn (toggle "defaultLocaleOpen" this)}} data-test-toggle-default-locale><span>{{if this.defaultLocaleOpen "Close" "Expand"}}</span></button>
                 </div>
             </div>
         </div>
@@ -103,7 +103,7 @@
                 <GhUploader
                     @extensions={{this.iconExtensions}}
                     @paramsHash={{hash purpose="icon"}}
-                    @onComplete={{action "imageUploaded" "icon"}}
+                    @onComplete={{fn this.imageUploaded "icon"}}
                     as |uploader|
                 >
                 <div class="gh-setting-content">
@@ -117,12 +117,12 @@
                     {{#if uploader.isUploading}}
                         {{uploader.progressBar}}
                     {{else if this.settings.icon}}
-                        <img class="blog-icon" src="{{this.settings.icon}}" onclick={{action "triggerFileDialog"}} alt="icon" data-test-icon-img>
-                        <button type="button" class="gh-setting-action-smallimg-delete" {{action "removeImage" "icon"}} data-test-delete-image="icon">
+                        <img class="blog-icon" src="{{this.settings.icon}}" {{on "click" this.triggerFileDialog}} alt="icon" data-test-icon-img>
+                        <button type="button" class="gh-setting-action-smallimg-delete" {{on "click" (fn this.removeImage "icon")}} data-test-delete-image="icon">
                             <span>delete</span>
                         </button>
                     {{else}}
-                        <button type="button" class="gh-btn" onclick={{action "triggerFileDialog"}} data-test-image-upload-btn="icon">
+                        <button type="button" class="gh-btn" {{on "click" this.triggerFileDialog}} data-test-image-upload-btn="icon">
                             <span>Upload Image</span>
                         </button>
                     {{/if}}
@@ -135,7 +135,7 @@
             <div class="gh-setting" data-test-setting="logo">
                 <GhUploader
                     @extensions={{this.imageExtensions}}
-                    @onComplete={{action "imageUploaded" "logo"}}
+                    @onComplete={{fn this.imageUploaded "logo"}}
                     as |uploader|
                 >
                 <div class="gh-setting-content">
@@ -149,12 +149,12 @@
                     {{#if uploader.isUploading}}
                         {{uploader.progressBar}}
                     {{else if this.settings.logo}}
-                        <img class="blog-logo" src="{{this.settings.logo}}" onclick={{action "triggerFileDialog"}} alt="logo" data-test-logo-img>
-                        <button type="button" class="gh-setting-action-smallimg-delete" {{action "removeImage" "logo"}} data-test-delete-image="logo">
+                        <img class="blog-logo" src="{{this.settings.logo}}" {{on "click" this.triggerFileDialog}} alt="logo" data-test-logo-img>
+                        <button type="button" class="gh-setting-action-smallimg-delete" {{on "click" (fn this.removeImage "logo")}} data-test-delete-image="logo">
                             <span>delete</span>
                         </button>
                     {{else}}
-                        <button type="button" class="gh-btn" onclick={{action "triggerFileDialog"}} data-test-image-upload-btn="logo">
+                        <button type="button" class="gh-btn" {{on "click" this.triggerFileDialog}} data-test-image-upload-btn="logo">
                             <span>Upload Image</span>
                         </button>
                     {{/if}}
@@ -178,7 +178,7 @@
                                     @placeholder="abcdef"
                                     @autocorrect="off"
                                     @maxlength="6"
-                                    @focus-out={{action "validateBrandColor"}}
+                                    @focus-out={{this.validateBrandColor}}
                                     @value={{brandColor}}
                                     data-test-brand-color-input={{true}}
                                 />
@@ -192,7 +192,7 @@
             <div class="gh-setting-last" data-test-setting="coverImage">
                 <GhUploader
                     @extensions={{this.imageExtensions}}
-                    @onComplete={{action "imageUploaded" "coverImage"}}
+                    @onComplete={{fn this.imageUploaded "coverImage"}}
                     as |uploader|
                 >
                 <div class="gh-setting-content">
@@ -206,12 +206,12 @@
                     {{#if uploader.isUploading}}
                         {{uploader.progressBar}}
                     {{else if this.settings.coverImage}}
-                        <img class="blog-cover" src="{{this.settings.coverImage}}" onclick={{action "triggerFileDialog"}} alt="cover photo" data-test-cover-img>
-                        <button type="button" class="gh-setting-action-largeimg-delete" {{action "removeImage" "coverImage"}} data-test-delete-image="coverImage">
+                        <img class="blog-cover" src="{{this.settings.coverImage}}" {{on "click" this.triggerFileDialog}} alt="cover photo" data-test-cover-img>
+                        <button type="button" class="gh-setting-action-largeimg-delete" {{on "click" (fn this.removeImage "coverImage")}} data-test-delete-image="coverImage">
                             <span>delete</span>
                         </button>
                     {{else}}
-                        <button type="button" class="gh-btn" onclick={{action "triggerFileDialog"}} data-test-image-upload-btn="coverImage">
+                        <button type="button" class="gh-btn" {{on "click" this.triggerFileDialog}} data-test-image-upload-btn="coverImage">
                             <span>Upload Image</span>
                         </button>
                     {{/if}}
@@ -297,8 +297,8 @@
                                         @image={{this.settings.twitterImage}}
                                         @text="Add Twitter image"
                                         @allowUnsplash={{true}}
-                                        @update={{action (mut this.settings.twitterImage)}}
-                                        @remove={{action (mut this.settings.twitterImage "")}}
+                                        @update={{fn (mut this.settings.twitterImage)}}
+                                        @remove={{fn (mut this.settings.twitterImage "")}}
                                     />
                                 </GhFormGroup>
                                 <GhFormGroup @errors={{this.settings.errors}} @hasValidated={{this.settings.hasValidated}} @property="twitterTitle">
@@ -367,8 +367,8 @@
                                         @image={{this.settings.ogImage}}
                                         @text="Add Facebook image"
                                         @allowUnsplash={{true}}
-                                        @update={{action (mut this.settings.ogImage)}}
-                                        @remove={{action (mut this.settings.ogImage "")}}
+                                        @update={{fn (mut this.settings.ogImage)}}
+                                        @remove={{fn (mut this.settings.ogImage "")}}
                                     />
                                 </GhFormGroup>
                                 <GhFormGroup @errors={{this.settings.errors}} @hasValidated={{this.settings.hasValidated}} @property="ogTitle">
@@ -434,7 +434,7 @@
                                 @autocorrect="off"
                                 @value={{readonly this.settings.facebook}}
                                 @input={{action (mut this._scratchFacebook) value="target.value"}}
-                                @focus-out={{action "validateFacebookUrl"}}
+                                @focus-out={{this.validateFacebookUrl}}
                                 data-test-facebook-input={{true}}
                             />
                             <GhErrorMessage @errors={{this.settings.errors}} @property="facebook" data-test-facebook-error=true />
@@ -447,7 +447,7 @@
                                 @autocorrect="off"
                                 @value={{readonly this.settings.twitter}}
                                 @input={{action (mut this._scratchTwitter) value="target.value"}}
-                                @focus-out={{action "validateTwitterUrl"}}
+                                @focus-out={{this.validateTwitterUrl}}
                                 data-test-twitter-input={{true}}
                             />
                             <GhErrorMessage @errors={{this.settings.errors}} @property="twitter" data-test-twitter-error=true />

--- a/app/templates/settings/integration.hbs
+++ b/app/templates/settings/integration.hbs
@@ -1,5 +1,5 @@
 <section class="gh-canvas">
-    <form class="mb15" {{action (perform "save") on="submit"}}>
+    <form class="mb15" {{on "submit" (perform "save")}}>
         <GhCanvasHeader class="gh-canvas-header">
             <h2 class="gh-canvas-title" data-test-screen-title>
                 <LinkTo @route="settings.integrations" data-test-link="integrations-back">Integrations</LinkTo>
@@ -25,7 +25,7 @@
 
                         <GhUploader
                             @extensions={{this.imageExtensions}}
-                            @onComplete={{action "setIconImage"}}
+                            @onComplete={{this.setIconImage}}
                             as |uploader|
                         >
                             {{#if uploader.isUploading}}
@@ -36,7 +36,7 @@
                                 <button
                                     type="button"
                                     class="child absolute top-0 left-0 w-100 h-100 br4 b white text-center bg-black-70 f8"
-                                    {{action "triggerIconFileDialog"}}
+                                    {{on "click" this.triggerIconFileDialog}}
                                 >
                                     Upload
                                 </button>
@@ -102,7 +102,7 @@
                                 </span>
                                 <div class="absolute top-1 right-0">
                                     <div class="pt1 pr3 pb1 pl3 bg-black-70 child br3 f8 nudge-top--4 nudge-right--1">
-                                        <button type="button" {{action (perform this.copyContentKey)}} class="white fw4 flex items-center">
+                                        <button type="button" {{on "click" (perform this.copyContentKey)}} class="white fw4 flex items-center">
                                             {{#if this.copyContentKey.isRunning}}
                                             {{svg-jar "check-circle" class="w3 v-mid mr2"}} Copied
                                             {{else}}
@@ -123,7 +123,7 @@
                                 </span>
                                 <div class="absolute top-1 right-0">
                                     <div class="pt1 pr3 pb1 pl3 bg-black-70 child br3 f8 nudge-top--4 nudge-right--1">
-                                        <button type="button" {{action (perform this.copyAdminKey)}} class="white fw4 flex items-center">
+                                        <button type="button" {{on "click" (perform this.copyAdminKey)}} class="white fw4 flex items-center">
                                             {{#if this.copyAdminKey.isRunning}}
                                             {{svg-jar "check-circle" class="w3 v-mid mr2"}} Copied
                                             {{else}}
@@ -144,7 +144,7 @@
                                 </span>
                                 <div class="absolute top-1 right-0">
                                     <div class="pt1 pr3 pb1 pl3 bg-black-70 child br3 f8 nudge-top--4 nudge-right--1">
-                                        <button type="button" {{action (perform this.copyApiUrl)}} class="white fw4 flex items-center">
+                                        <button type="button" {{on "click" (perform this.copyApiUrl)}} class="white fw4 flex items-center">
                                             {{#if this.copyApiUrl.isRunning}}
                                             {{svg-jar "check-circle" class="w3 v-mid mr2"}} Copied
                                             {{else}}
@@ -185,7 +185,7 @@
                                 <LinkTo @route="settings.integration.webhooks.edit" @models={{array this.integration webhook}} data-test-link="edit-webhook">
                                     {{svg-jar "pen" class="w6 h6 fill-midgrey pa1 mr1"}}
                                 </LinkTo>
-                                <button {{action "confirmWebhookDeletion" webhook}} data-test-button="delete-webhook">
+                                <button {{on "click" (fn this.confirmWebhookDeletion webhook)}} data-test-button="delete-webhook">
                                     {{svg-jar "trash" class="w6 fill-red pa1"}}
                                 </button>
                             </div>
@@ -225,29 +225,29 @@
             {{/if}}
         </table>
     </div>
-    <button class="gh-btn gh-btn-red gh-btn-icon mb15 mt15" {{action "confirmIntegrationDeletion"}}>
+    <button class="gh-btn gh-btn-red gh-btn-icon mb15 mt15" {{on "click" this.confirmIntegrationDeletion}}>
         <span> Delete Integration </span>
     </button>
 </section>
 
 {{#if this.showUnsavedChangesModal}}
     <GhFullscreenModal @modal="leave-settings"
-        @confirm={{action "leaveScreen"}}
-        @close={{action "toggleUnsavedChangesModal"}}
+        @confirm={{this.leaveScreen}}
+        @close={{this.toggleUnsavedChangesModal}}
         @modifier="action wide" />
 {{/if}}
 
 {{#if this.showDeleteIntegrationModal}}
     <GhFullscreenModal @modal="delete-integration"
-        @confirm={{action "deleteIntegration"}}
-        @close={{action "cancelIntegrationDeletion"}}
+        @confirm={{this.deleteIntegration}}
+        @close={{this.cancelIntegrationDeletion}}
         @modifier="action wide" />
 {{/if}}
 
 {{#if this.webhookToDelete}}
     <GhFullscreenModal @modal="delete-webhook"
-        @confirm={{action "deleteWebhook"}}
-        @close={{action "cancelWebhookDeletion"}}
+        @confirm={{this.deleteWebhook}}
+        @close={{this.cancelWebhookDeletion}}
         @modifier="action wide" />
 {{/if}}
 

--- a/app/templates/settings/integration/webhooks/edit.hbs
+++ b/app/templates/settings/integration/webhooks/edit.hbs
@@ -1,5 +1,5 @@
 <GhFullscreenModal @modal="webhook-form"
     @model={{this.webhook}}
-    @confirm={{action "save"}}
-    @close={{action "cancel"}}
+    @confirm={{this.save}}
+    @close={{this.cancel}}
     @modifier="action wide" />

--- a/app/templates/settings/integration/webhooks/new.hbs
+++ b/app/templates/settings/integration/webhooks/new.hbs
@@ -1,5 +1,5 @@
 <GhFullscreenModal @modal="webhook-form"
     @model={{this.webhook}}
-    @confirm={{action "save"}}
-    @close={{action "cancel"}}
+    @confirm={{this.save}}
+    @close={{this.cancel}}
     @modifier="action wide" />

--- a/app/templates/settings/integrations/amp.hbs
+++ b/app/templates/settings/integrations/amp.hbs
@@ -6,14 +6,14 @@
             AMP
         </h2>
         <section class="view-actions">
-            <GhTaskButton @task={{this.save}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button={{true}} />
+            <GhTaskButton @task={{this.saveTask}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button={{true}} />
         </section>
     </GhCanvasHeader>
 
     {{#if this.showLeaveSettingsModal}}
         <GhFullscreenModal @modal="leave-settings"
-            @confirm={{action "leaveSettings"}}
-            @close={{action "toggleLeaveSettingsModal"}}
+            @confirm={{this.leaveSettings}}
+            @close={{this.toggleLeaveSettingsModal}}
             @modifier="action wide" />
     {{/if}}
 

--- a/app/templates/settings/integrations/new.hbs
+++ b/app/templates/settings/integrations/new.hbs
@@ -1,5 +1,5 @@
 <GhFullscreenModal @modal="new-integration"
     @model={{this.integration}}
-    @confirm={{action "save"}}
-    @close={{action "cancel"}}
+    @confirm={{this.save}}
+    @close={{this.cancel}}
     @modifier="action wide" />

--- a/app/templates/settings/integrations/slack.hbs
+++ b/app/templates/settings/integrations/slack.hbs
@@ -6,14 +6,14 @@
             Slack
         </h2>
         <section class="view-actions">
-            <GhTaskButton @task={{this.save}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button={{true}} />
+            <GhTaskButton @task={{this.saveTask}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button={{true}} />
         </section>
     </GhCanvasHeader>
 
     {{#if this.showLeaveSettingsModal}}
         <GhFullscreenModal @modal="leave-settings"
-            @confirm={{action "leaveSettings"}}
-            @close={{action "toggleLeaveSettingsModal"}}
+            @confirm={{this.leaveSettings}}
+            @close={{this.toggleLeaveSettingsModal}}
             @modifier="action wide" />
     {{/if}}
 
@@ -30,7 +30,7 @@
             </div>
         </section>
 
-        <form class="app-config-form" id="slack-settings" novalidate="novalidate" {{action "save" on="submit"}}>
+        <form class="app-config-form" id="slack-settings" novalidate="novalidate" {{on "submit" (perform this.saveTask)}}>
             <div class="gh-setting-header gh-first-header">Slack configuration</div>
 
                 <div class="flex flex-column br4 shadow-1 bg-grouped-table pa8 mt2">
@@ -46,9 +46,9 @@
                                     @value={{readonly this.slackSettings.url}}
                                     @input={{action "updateURL" value="target.value"}}
                                     @keyEvents={{hash
-                                        Enter=(action "save")
+                                        Enter=(perform this.saveTask)
                                     }}
-                                    @focus-out={{action "triggerDirtyState"}}
+                                    @focus-out={{this.triggerDirtyState}}
                                     data-test-slack-url-input={{true}}
                                 />
                                 {{#unless this.slackSettings.errors.url}}
@@ -72,9 +72,9 @@
                                     @value={{readonly this.slackSettings.username}}
                                     @input={{action "updateUsername" value="target.value"}}
                                     @keyEvents={{hash
-                                        Enter=(action "save")
+                                        Enter=(perform this.saveTask)
                                     }}
-                                    @focus-out={{action "triggerDirtyState"}}
+                                    @focus-out={{this.triggerDirtyState}}
                                     data-test-slack-username-input={{true}}
                                 />
                                 {{#if this.slackSettings.errors.username}}

--- a/app/templates/settings/integrations/unsplash.hbs
+++ b/app/templates/settings/integrations/unsplash.hbs
@@ -6,14 +6,14 @@
             Unsplash
         </h2>
         <section class="view-actions">
-            <GhTaskButton @task={{this.save}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button={{true}} />
+            <GhTaskButton @task={{this.saveTask}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button={{true}} />
         </section>
     </GhCanvasHeader>
 
     {{#if this.showLeaveSettingsModal}}
         <GhFullscreenModal @modal="leave-settings"
-            @confirm={{action "leaveSettings"}}
-            @close={{action "toggleLeaveSettingsModal"}}
+            @confirm={{this.leaveSettings}}
+            @close={{this.toggleLeaveSettingsModal}}
             @modifier="action wide" />
     {{/if}}
 

--- a/app/templates/settings/integrations/zapier.hbs
+++ b/app/templates/settings/integrations/zapier.hbs
@@ -32,7 +32,7 @@
                                 </span>
                                 <div class="absolute top-1 right-2">
                                     <div class="pt1 pr3 pb1 pl3 bg-black-70 child br3 f8 nudge-top--4 nudge-right--1">
-                                        <button type="button" {{action (perform this.copyAdminKey)}} class="white fw4 flex items-center">
+                                        <button type="button" {{on "click" (perform this.copyAdminKey)}} class="white fw4 flex items-center">
                                             {{#if this.copyAdminKey.isRunning}}
                                                 {{svg-jar "check-circle" class="w3 v-mid mr2"}} Copied
                                             {{else}}
@@ -53,7 +53,7 @@
                                 </span>
                                 <div class="absolute top-1 right-2">
                                     <div class="pt1 pr3 pb1 pl3 bg-black-70 child br3 f8 nudge-top--4 nudge-right--1">
-                                        <button type="button" {{action (perform this.copyApiUrl)}} class="white fw4 flex items-center">
+                                        <button type="button" {{on "click" (perform this.copyApiUrl)}} class="white fw4 flex items-center">
                                             {{#if this.copyApiUrl.isRunning}}
                                                 {{svg-jar "check-circle" class="w3 v-mid mr2"}} Copied
                                             {{else}}

--- a/app/templates/settings/labs.hbs
+++ b/app/templates/settings/labs.hbs
@@ -25,12 +25,13 @@
                     {{#liquid-if this.feature.labs.members}}
                     <GhMembersLabSetting
                         @settings={{this.settings}}
-                        @setDefaultContentVisibility={{action "setDefaultContentVisibility"}}
-                        @setMembersSubscriptionSettings={{action "setMembersSubscriptionSettings"}}
-                        @setBulkEmailSettings={{action "setBulkEmailSettings"}}
+                        @setDefaultContentVisibility={{this.setDefaultContentVisibility}}
+                        @setMembersSubscriptionSettings={{this.setMembersSubscriptionSettings}}
+                        @setBulkEmailSettings={{this.setBulkEmailSettings}}
                     />
                     <div class="mt5 pl5 pr5 pb5">
-                        <GhTaskButton @buttonText="Save members settings"
+                        <GhTaskButton
+                            @buttonText="Save members settings"
                             @task={{this.saveSettings}}
                             @successText="Saved"
                             @runningText="Saving"
@@ -55,7 +56,7 @@
                             @id="importfile"
                             @classNames="flex"
                             @uploadButtonText={{this.uploadButtonText}}
-                            @onUpload={{action "onUpload"}}
+                            @onUpload={{this.onUpload}}
                             @acceptEncoding={{this.importMimeType}}
                             data-test-file-input="import"
                         />
@@ -95,7 +96,7 @@
                     <div class="gh-setting-desc">Download all of your posts and settings in a single, glorious JSON file</div>
                 </div>
                 <div class="gh-setting-action">
-                    <button type="button" class="gh-btn gh-btn-hover-blue" {{action "downloadFile" "db"}}><span>Export</span></button>
+                    <button type="button" class="gh-btn gh-btn-hover-blue" {{on "click" (fn this.downloadFile "db")}}><span>Export</span></button>
                 </div>
             </div>
             <div class="gh-setting-last">
@@ -104,7 +105,7 @@
                     <div class="gh-setting-desc">Permanently delete all posts and tags from the database, a hard reset</div>
                 </div>
                 <div class="gh-setting-action">
-                    <button type="button" class="gh-btn gh-btn-hover-red js-delete" {{action "toggleDeleteAllModal"}}><span>Delete</span></button>
+                    <button type="button" class="gh-btn gh-btn-hover-red js-delete" {{on "click" this.toggleDeleteAllModal}}><span>Delete</span></button>
                 </div>
             </div>
         </div>
@@ -143,7 +144,7 @@
                         <button
                             type="button"
                             class="gh-btn gh-btn-icon {{if this.redirectSuccess "gh-btn-green"}} {{if this.redirectFailure "gh-btn-red"}}"
-                            onclick={{action "triggerFileDialog"}}
+                            {{on "click" this.triggerFileDialog}}
                             data-test-button="upload-redirects"
                         >
                             <span>
@@ -156,7 +157,7 @@
                                 {{/if}}
                             </span>
                         </button>
-                        <span><a href="#" {{action "downloadFile" "redirects/json"}} data-test-link="download-redirects">Download current redirects</a></span>
+                        <span><a href="javascript:void(0)" {{on "click" (fn this.downloadFile "redirects/json")}} data-test-link="download-redirects">Download current redirects</a></span>
                     {{/if}}
 
                     <div style="display:none">
@@ -188,7 +189,7 @@
                         <button
                             type="button"
                             class="gh-btn gh-btn-icon {{if this.routesSuccess "gh-btn-green"}} {{if this.routesFailure "gh-btn-red"}}"
-                            onclick={{action "triggerFileDialog"}}
+                            {{on "click" this.triggerFileDialog}}
                             data-test-button="upload-routes"
                         >
                             <span>
@@ -201,7 +202,7 @@
                                 {{/if}}
                             </span>
                         </button>
-                        <span><a href="#" {{action "downloadFile" "settings/routes/yaml"}} data-test-link="download-routes">Download current routes.yaml</a></span>
+                        <span><a href="javascript:void(0)" {{on "click" (fn this.downloadFile "settings/routes/yaml")}} data-test-link="download-routes">Download current routes.yaml</a></span>
                     {{/if}}
 
                     <div style="display:none">
@@ -229,7 +230,8 @@
 </section>
 
 {{#if this.showDeleteAllModal}}
-    <GhFullscreenModal @modal="delete-all"
-        @close={{action "toggleDeleteAllModal"}}
+    <GhFullscreenModal
+        @modal="delete-all"
+        @close={{this.toggleDeleteAllModal}}
         @modifier="action wide" />
 {{/if}}

--- a/app/templates/setup/three.hbs
+++ b/app/templates/setup/three.hbs
@@ -5,7 +5,7 @@
 
 <div><img class="gh-flow-faces" src="assets/img/users.png" alt="" /></div>
 
-<form class="gh-flow-invite" {{action "invite" on="submit"}}>
+<form class="gh-flow-invite" {{on "submit" this.invite}}>
     <GhFormGroup @errors={{this.errors}} @hasValidated={{this.hasValidated}} @property="users">
         <label for="users">Enter one email address per line, we’ll handle the rest! {{svg-jar "email"}}</label>
         <GhTextarea
@@ -13,7 +13,7 @@
             @required="required"
             @value={{readonly this.users}}
             @input={{action (mut this.users) value="target.value"}}
-            @focus-out={{action "validate"}}
+            @focus-out={{this.validate}}
         />
     </GhFormGroup>
 
@@ -35,6 +35,6 @@
     </GhTaskButton>
 </form>
 
-<button class="gh-flow-skip" {{action "skipInvite"}}>
+<button class="gh-flow-skip" {{on "click" this.skipInvite}}>
     I'll do this later, take me to my site!
 </button>

--- a/app/templates/setup/two.hbs
+++ b/app/templates/setup/two.hbs
@@ -3,7 +3,7 @@
 </header>
 
 <form id="setup" class="gh-flow-create">
-    <GhProfileImage @email={{this.email}} @setImage={{action "setImage"}} />
+    <GhProfileImage @email={{this.email}} @setImage={{this.setImage}} />
 
     <GhFormGroup @errors={{this.errors}} @hasValidated={{this.hasValidated}} @property="blogTitle">
         <label for="blog-title">Site title</label>
@@ -18,7 +18,7 @@
                 @autocorrect="off"
                 @value={{readonly this.blogTitle}}
                 @input={{action (mut this.blogTitle) value="target.value"}}
-                @focus-out={{action "preValidate" "blogTitle"}}
+                @focus-out={{fn this.preValidate "blogTitle"}}
                 data-test-blog-title-input={{true}} />
         </span>
         <GhErrorMessage @errors={{this.errors}} @property="blogTitle" />
@@ -37,7 +37,7 @@
                 @autocomplete="name"
                 @value={{readonly this.name}}
                 @input={{action (mut this.name) value="target.value"}}
-                @focus-out={{action "preValidate" "name"}}
+                @focus-out={{fn this.preValidate "name"}}
                 data-test-name-input={{true}} />
         </span>
         <GhErrorMessage @errors={{this.errors}} @property="name" />
@@ -57,7 +57,7 @@
                 @autocomplete="username email"
                 @value={{readonly this.email}}
                 @input={{action (mut this.email) value="target.value"}}
-                @focus-out={{action "preValidate" "email"}}
+                @focus-out={{fn this.preValidate "email"}}
                 data-test-email-input={{true}} />
         </span>
         <GhErrorMessage @errors={{this.errors}} @property="email" />
@@ -77,7 +77,7 @@
                 @autocomplete="new-password"
                 @value={{readonly this.password}}
                 @input={{action (mut this.password) value="target.value"}}
-                @focus-out={{action "preValidate" "password"}}
+                @focus-out={{fn this.preValidate "password"}}
                 data-test-password-input={{true}} />
         </span>
         <GhErrorMessage @errors={{this.errors}} @property="password" />

--- a/app/templates/signin.hbs
+++ b/app/templates/signin.hbs
@@ -1,7 +1,7 @@
 <div class="gh-flow">
     <div class="gh-flow-content-wrap">
         <section class="gh-flow-content">
-            <form id="login" method="post" class="gh-signin" novalidate="novalidate" {{action "authenticate" on="submit"}}>
+            <form id="login" method="post" class="gh-signin" novalidate="novalidate" {{on "submit" (perform this.authenticate)}}>
                 <GhFormGroup @errors={{this.signin.errors}} @hasValidated={{this.hasValidated}} @property="identification">
                     <span class="gh-input-icon gh-icon-mail">
                         {{svg-jar "email"}}
@@ -16,7 +16,7 @@
                             @tabindex="1"
                             @value={{readonly this.signin.identification}}
                             @input={{action (mut this.signin.identification) value="target.value"}}
-                            @focus-out={{action "validate" "identification"}}
+                            @focus-out={{fn this.validate "identification"}}
                         />
                     </span>
                 </GhFormGroup>

--- a/app/templates/signup.hbs
+++ b/app/templates/signup.hbs
@@ -6,8 +6,8 @@
                 <h1>Create your account</h1>
             </header>
 
-            <form id="signup" class="gh-flow-create" method="post" novalidate="novalidate" onsubmit={{action "submit"}}>
-                <GhProfileImage @email={{this.signupDetails.email}} @setImage={{action "setImage"}} />
+            <form id="signup" class="gh-flow-create" method="post" novalidate="novalidate" {{on "submit" this.submit}}>
+                <GhProfileImage @email={{this.signupDetails.email}} @setImage={{this.setImage}} />
 
                 <GhFormGroup @errors={{this.signupDetails.errors}} @hasValidated={{this.signupDetails.hasValidated}} @property="name">
                     <label for="name">Full name</label>
@@ -23,7 +23,7 @@
                             @autocomplete="name"
                             @value={{readonly this.signupDetails.name}}
                             @input={{action (mut this.signupDetails.name) value="target.value"}}
-                            @focus-out={{action "validate" "name"}}
+                            @focus-out={{fn this.validate "name"}}
                             data-test-input="name"
                         />
                     </span>
@@ -44,7 +44,7 @@
                             @autocomplete="username email"
                             @value={{readonly this.signupDetails.email}}
                             @input={{action (mut this.signupDetails.email) value="target.value"}}
-                            @focus-out={{action "validate" "email"}}
+                            @focus-out={{fn this.validate "email"}}
                             data-test-input="email"
                         />
                     </span>
@@ -65,7 +65,7 @@
                             @autocomplete="new-password"
                             @value={{readonly this.signupDetails.password}}
                             @input={{action (mut this.signupDetails.password) value="target.value"}}
-                            @focus-out={{action "validate" "password"}}
+                            @focus-out={{fn this.validate "password"}}
                             data-test-input="password"
                         />
                     </span>

--- a/app/templates/staff/index.hbs
+++ b/app/templates/staff/index.hbs
@@ -4,14 +4,15 @@
         {{!-- Do not show Invite user button to authors --}}
         {{#unless this.currentUser.isAuthorOrContributor}}
             <section class="view-actions">
-                <button class="gh-btn gh-btn-green" {{action "toggleInviteUserModal"}} ><span>Invite people</span></button>
+                <button class="gh-btn gh-btn-green" {{on "click" this.toggleInviteUserModal}} ><span>Invite people</span></button>
             </section>
         {{/unless}}
     </GhCanvasHeader>
 
     {{#if this.showInviteUserModal}}
-        <GhFullscreenModal @modal="invite-new-user"
-            @close={{action "toggleInviteUserModal"}}
+        <GhFullscreenModal
+            @modal="invite-new-user"
+            @close={{this.toggleInviteUserModal}}
             @modifier="action wide" />
     {{/if}}
 

--- a/app/templates/staff/user.hbs
+++ b/app/templates/staff/user.hbs
@@ -11,9 +11,10 @@
         </h2>
 
         {{#if this.showLeaveSettingsModal}}
-            <GhFullscreenModal @modal="leave-settings"
-                @confirm={{action "leaveSettings"}}
-                @close={{action "toggleLeaveSettingsModal"}}
+            <GhFullscreenModal
+                @modal="leave-settings"
+                @confirm={{this.leaveSettings}}
+                @close={{this.toggleLeaveSettingsModal}}
                 @modifier="action wide" />
         {{/if}}
 
@@ -29,33 +30,34 @@
                     <GhDropdown @name="user-actions-menu" @tagName="ul" @classNames="user-actions-menu dropdown-menu dropdown-triangle-top-right">
                         {{#if this.canMakeOwner}}
                             <li>
-                                <button {{action "toggleTransferOwnerModal"}}>
+                                <button {{on "click" this.toggleTransferOwnerModal}}>
                                     Make Owner
                                 </button>
                                 {{#if this.showTransferOwnerModal}}
-                                    <GhFullscreenModal @modal="transfer-owner"
-                                        @confirm={{action "transferOwnership"}}
-                                        @close={{action "toggleTransferOwnerModal"}}
+                                    <GhFullscreenModal
+                                        @modal="transfer-owner"
+                                        @confirm={{this.transferOwnership}}
+                                        @close={{this.toggleTransferOwnerModal}}
                                         @modifier="action wide" />
                                 {{/if}}
                             </li>
                         {{/if}}
                         {{#if this.deleteUserActionIsVisible}}
                             <li>
-                                <button {{action "toggleDeleteUserModal"}} class="delete" data-test-delete-button>
+                                <button {{on "click" this.toggleDeleteUserModal}} class="delete" data-test-delete-button>
                                     Delete User
                                 </button>
                             </li>
                             {{#if this.user.isActive}}
                                 <li>
-                                    <button {{action "toggleSuspendUserModal"}} class="suspend" data-test-suspend-button>
+                                    <button {{on "click" this.toggleSuspendUserModal}} class="suspend" data-test-suspend-button>
                                         Suspend User
                                     </button>
                                 </li>
                             {{/if}}
                             {{#if this.user.isSuspended}}
                                 <li>
-                                    <button {{action "toggleUnsuspendUserModal"}} class="unsuspend" data-test-unsuspend-button>
+                                    <button {{on "click" this.toggleUnsuspendUserModal}} class="unsuspend" data-test-unsuspend-button>
                                         Un-suspend User
                                     </button>
                                 </li>
@@ -68,26 +70,29 @@
             <GhTaskButton @class="gh-btn gh-btn-blue gh-btn-icon" @task={{this.save}} data-test-save-button={{true}} />
 
             {{#if this.showDeleteUserModal}}
-                <GhFullscreenModal @modal="delete-user"
+                <GhFullscreenModal
+                    @modal="delete-user"
                     @model={{this.user}}
-                    @confirm={{action "deleteUser"}}
-                    @close={{action "toggleDeleteUserModal"}}
+                    @confirm={{this.deleteUser}}
+                    @close={{this.toggleDeleteUserModal}}
                     @modifier="action wide" />
             {{/if}}
 
             {{#if this.showSuspendUserModal}}
-                <GhFullscreenModal @modal="suspend-user"
+                <GhFullscreenModal
+                    @modal="suspend-user"
                     @model={{this.user}}
-                    @confirm={{action "suspendUser"}}
-                    @close={{action "toggleSuspendUserModal"}}
+                    @confirm={{this.suspendUser}}
+                    @close={{this.toggleSuspendUserModal}}
                     @modifier="action wide" />
             {{/if}}
 
             {{#if this.showUnsuspendUserModal}}
-                <GhFullscreenModal @modal="unsuspend-user"
+                <GhFullscreenModal
+                    @modal="unsuspend-user"
                     @model={{this.user}}
-                    @confirm={{action "unsuspendUser"}}
-                    @close={{action "toggleUnsuspendUserModal"}}
+                    @confirm={{this.unsuspendUser}}
+                    @close={{this.toggleUnsuspendUserModal}}
                     @modifier="action wide" />
             {{/if}}
         </section>
@@ -96,25 +101,27 @@
     {{!-- <div class="bg-"> --}}
     <section class="br3 shadow-1 bg-grouped-table">
         <div class="gm-main view-container settings-user">
-            <form class="user-profile" novalidate="novalidate" autocomplete="off" {{action (perform this.save) on="submit"}}>
+            <form class="user-profile" novalidate="novalidate" autocomplete="off" {{on "submit" (perform this.save)}}>
 
                 <figure class="user-cover" style={{background-image-style this.user.coverImageUrl}}>
-                    <button type="button" class="gh-btn gh-btn-default user-cover-edit" {{action "toggleUploadCoverModal"}}><span>Change Cover</span></button>
+                    <button type="button" class="gh-btn gh-btn-default user-cover-edit" {{on "click" this.toggleUploadCoverModal}}><span>Change Cover</span></button>
                     {{#if this.showUploadCoverModal}}
-                        <GhFullscreenModal @modal="upload-image"
+                        <GhFullscreenModal
+                            @modal="upload-image"
                             @model={{hash model=this.user imageProperty="coverImage"}}
-                            @close={{action "toggleUploadCoverModal"}}
+                            @close={{this.toggleUploadCoverModal}}
                             @modifier="action wide" />
                     {{/if}}
                 </figure>
 
                 <figure class="user-image bg-whitegrey">
                     <div id="user-image" class="img" style={{background-image-style this.user.profileImageUrl}}><span class="hidden">{{this.user.name}}"s Picture</span></div>
-                    <button type="button" {{action "toggleUploadImageModal"}} class="edit-user-image">Edit Picture</button>
+                    <button type="button" {{on "click" this.toggleUploadImageModal}} class="edit-user-image">Edit Picture</button>
                     {{#if this.showUploadImageModal}}
-                        <GhFullscreenModal @modal="upload-image"
+                        <GhFullscreenModal
+                            @modal="upload-image"
                             @model={{hash model=this.user imageProperty="profileImage" paramsHash=(hash purpose="profile_image")}}
-                            @close={{action "toggleUploadImageModal"}}
+                            @close={{this.toggleUploadImageModal}}
                             @modifier="action wide" />
                     {{/if}}
                 </figure>
@@ -152,7 +159,7 @@
                                 @autocorrect="off"
                                 @value={{readonly this.slugValue}}
                                 @input={{action (mut this.slugValue) value="target.value"}}
-                                @focus-out={{action (perform this.updateSlug this.slugValue)}}
+                                @focus-out={{perform this.updateSlug this.slugValue}}
                                 data-test-slug-input={{true}}
                             />
                             <p><GhBlogUrl />/author/{{this.slugValue}}</p>
@@ -193,7 +200,7 @@
                                         @optionValuePath="id"
                                         @optionLabelPath="name"
                                         @value={{this.user.role}}
-                                        @update={{action "changeRole"}}
+                                        @update={{this.changeRole}}
                                     />
                                 </span>
                                 <p>What permissions should this user have?</p>
@@ -238,7 +245,7 @@
                                 @name="user[facebook]"
                                 @value={{readonly this.user.facebook}}
                                 @input={{action (mut this._scratchFacebook) value="target.value"}}
-                                @focus-out={{action "validateFacebookUrl"}}
+                                @focus-out={{this.validateFacebookUrl}}
                                 data-test-facebook-input={{true}}
                             />
                             <GhErrorMessage @errors={{this.user.errors}} @property="facebook" data-test-error="user-facebook" />
@@ -255,7 +262,7 @@
                                 @name="user[twitter]"
                                 @value={{readonly this.user.twitter}}
                                 @input={{action (mut this._scratchTwitter) value="target.value"}}
-                                @focus-out={{action "validateTwitterUrl"}}
+                                @focus-out={{this.validateTwitterUrl}}
                                 data-test-twitter-input={{true}}
                             />
                             <GhErrorMessage @errors={{this.user.errors}} @property="twitter" data-test-error="user-twitter" />
@@ -285,7 +292,7 @@
 
             {{!-- If an administrator is viewing Owner's profile then hide inputs for change password --}}
             {{#if this.canChangePassword}}
-                <form id="password-reset" class="user-profile" novalidate="novalidate" autocomplete="off" {{action (perform this.user.saveNewPassword) on="submit"}}>
+                <form id="password-reset" class="user-profile" novalidate="novalidate" autocomplete="off" {{on "submit" (perform this.user.saveNewPassword)}}>
                     <div class="pa5">
                         <fieldset class="user-details-password">
                             {{#if this.isOwnProfile}}
@@ -298,7 +305,7 @@
                                         @value={{readonly this.user.password}}
                                         @input={{action "updatePassword" value="target.value"}}
                                         @keyEvents={{hash
-                                            Enter=(action (perform this.user.saveNewPassword))
+                                            Enter=(perform this.user.saveNewPassword)
                                         }}
                                         data-test-old-pass-input={{true}}
                                     />
@@ -315,7 +322,7 @@
                                     @id="user-password-new"
                                     @input={{action "updateNewPassword" value="target.value"}}
                                     @keyEvents={{hash
-                                        Enter=(action (perform this.user.saveNewPassword))
+                                        Enter=(perform this.user.saveNewPassword)
                                     }}
                                     data-test-new-pass-input={{true}}
                                 />
@@ -330,7 +337,7 @@
                                     @id="user-new-password-verification"
                                     @input={{action "updateNe2Password" value="target.value"}}
                                     @keyEvents={{hash
-                                        Enter=(action (perform this.user.saveNewPassword))
+                                        Enter=(perform this.user.saveNewPassword)
                                     }}
                                     data-test-ne2-pass-input={{true}}
                                 />

--- a/app/templates/tag.hbs
+++ b/app/templates/tag.hbs
@@ -7,18 +7,18 @@
                 {{if this.tag.isNew "New tag" this.tag.name}}
             </h2>
             <section class="view-actions">
-                <GhTaskButton @task={{this.save}} @type="button" @class="gh-btn gh-btn-blue gh-btn-icon" @data-test-button="save" />
+                <GhTaskButton @task={{this.saveTask}} @type="button" @class="gh-btn gh-btn-blue gh-btn-icon" @data-test-button="save" />
             </section>
         </GhCanvasHeader>
 
         <GhTagSettingsForm
             @tag={{this.tag}}
             @scratchTag={{this.scratchTag}}
-            @setProperty={{action "setProperty"}} />
+            @setProperty={{this.setProperty}} />
     </form>
 
     {{#unless this.tag.isNew}}
-        <button type="button" class="gh-btn gh-btn-red gh-btn-icon mb15" {{on "click" (action "toggleDeleteTagModal")}}>
+        <button type="button" class="gh-btn gh-btn-red gh-btn-icon mb15" {{on "click" this.toggleDeleteTagModal}}>
             <span>Delete tag</span>
         </button>
     {{/unless}}
@@ -27,8 +27,8 @@
 {{#if this.showUnsavedChangesModal}}
     <GhFullscreenModal
         @modal="leave-settings"
-        @confirm={{action "leaveScreen"}}
-        @close={{action "toggleUnsavedChangesModal"}}
+        @confirm={{this.leaveScreen}}
+        @close={{this.toggleUnsavedChangesModal}}
         @modifier="action wide" />
 {{/if}}
 
@@ -36,7 +36,7 @@
     <GhFullscreenModal
         @modal="delete-tag"
         @model={{this.tag}}
-        @confirm={{action "deleteTag"}}
-        @close={{action "toggleDeleteTagModal"}}
+        @confirm={{this.deleteTag}}
+        @close={{this.toggleDeleteTagModal}}
         @modifier="action wide" />
 {{/if}}

--- a/app/templates/tags.hbs
+++ b/app/templates/tags.hbs
@@ -3,8 +3,8 @@
         <h2 class="gh-canvas-title" data-test-screen-title>Tags</h2>
         <section class="view-actions">
             <div class="gh-contentfilter gh-btn-group">
-                <button class="gh-btn {{if (eq this.type "public") "gh-btn-group-selected"}}" {{action "changeType" "public"}}><span>Public tags</span></button>
-                <button class="gh-btn {{if (eq this.type "internal") "gh-btn-group-selected"}}" {{action "changeType" "internal"}}><span>Internal tags</span></button>
+                <button class="gh-btn {{if (eq this.type "public") "gh-btn-group-selected"}}" {{on "click" (fn "changeType" "public")}}><span>Public tags</span></button>
+                <button class="gh-btn {{if (eq this.type "internal") "gh-btn-group-selected"}}" {{on "click" (fn "changeType" "internal")}}><span>Internal tags</span></button>
             </div>
             <LinkTo @route="tag.new" class="gh-btn gh-btn-green"><span>New tag</span></LinkTo>
         </section>

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "ember-ajax": "5.0.0",
     "ember-assign-helper": "0.2.0",
     "ember-auto-import": "1.5.3",
+    "ember-classic-decorator": "1.0.6",
     "ember-cli": "3.15.1",
     "ember-cli-app-version": "3.2.0",
     "ember-cli-babel": "7.13.2",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "ember-cli-uglify": "3.0.0",
     "ember-composable-helpers": "3.0.3",
     "ember-concurrency": "1.1.4",
+    "ember-concurrency-decorators": "1.0.0",
     "ember-data": "3.15.0",
     "ember-drag-drop": "0.4.8",
     "ember-exam": "4.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -949,7 +949,7 @@
     "@ember-decorators/utils" "^6.1.1"
     ember-cli-babel "^7.1.3"
 
-"@ember-decorators/utils@^6.1.1":
+"@ember-decorators/utils@^6.1.0", "@ember-decorators/utils@^6.1.1":
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/@ember-decorators/utils/-/utils-6.1.1.tgz#6b619814942b4fb3747cfa9f540c9f05283d7c5e"
   integrity sha512-0KqnoeoLKb6AyoSU65TRF5T85wmS4uDn06oARddwNPxxf/lt5jQlh41uX3W7V/fWL9tPu8x1L1Vvpc80MN1+YA==
@@ -4996,7 +4996,7 @@ ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.0:
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.0.tgz#de3baedd093163b6c2461f95964888c1676325ac"
   integrity sha512-Zr4my8Xn+CzO0gIuFNXji0eTRml5AxZUTDQz/wsNJ5AJAtyFWCY4QtKdoELNNbiCVGt1lq5yLiwTm4scGKu6xA==
 
-ember-cli-babel@7.13.2, ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.10.0, ember-cli-babel@^7.11.0, ember-cli-babel@^7.11.1, ember-cli-babel@^7.12.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.5.0, ember-cli-babel@^7.7.3, ember-cli-babel@^7.8.0:
+ember-cli-babel@7.13.2, ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.10.0, ember-cli-babel@^7.11.0, ember-cli-babel@^7.11.1, ember-cli-babel@^7.12.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.5.0, ember-cli-babel@^7.7.3, ember-cli-babel@^7.8.0, ember-cli-babel@^7.9.0:
   version "7.13.2"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.13.2.tgz#6b6f4d508cc3bb300c5711d3d02c59ba80f0f686"
   integrity sha512-VH2tMXaRFkbQEyVJnxUtAyta5bAKjtcLwJ4lStW/iRk/NIlNFNJh1uOd7uL9H9Vm0f4/xR7Mc0Q7ND9ezKOo+A==
@@ -5531,6 +5531,15 @@ ember-composable-helpers@3.0.3:
     broccoli-funnel "2.0.1"
     ember-cli-babel "^7.1.0"
     resolve "^1.10.0"
+
+ember-concurrency-decorators@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ember-concurrency-decorators/-/ember-concurrency-decorators-1.0.0.tgz#b327e9e487650f0670870a8233c35bd0b5a7452b"
+  integrity sha512-lvBp22RWjrrOMpVzMNx/un+9wMzAU97G2dEbqgg5t5i4n5oa8PSs4em6NDM+kVFX9hpf5rc1wBnisLbFRBIL6A==
+  dependencies:
+    "@ember-decorators/utils" "^6.1.0"
+    ember-cli-babel "^7.9.0"
+    ember-cli-typescript "^2.0.2"
 
 ember-concurrency@1.1.4:
   version "1.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4585,7 +4585,7 @@ debug@2.6.9, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.3.
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.0, debug@^3.0.1, debug@^3.1.0, debug@^3.1.1, debug@^3.2.6:
+debug@^3.0.0, debug@^3.0.1, debug@^3.1.0, debug@^3.1.1:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -4629,11 +4629,6 @@ deep-eql@^3.0.1:
   integrity sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==
   dependencies:
     type-detect "^4.0.0"
-
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -4720,11 +4715,6 @@ detect-indent@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.0.0.tgz#0abd0f549f69fc6659a254fe96786186b6f528fd"
   integrity sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-newline@3.1.0:
   version "3.1.0"
@@ -4984,6 +4974,14 @@ ember-basic-dropdown@^2.0.13, ember-basic-dropdown@^2.0.4:
     ember-element-helper "^0.2.0"
     ember-maybe-in-element "^0.4.0"
     ember-truth-helpers "2.1.0"
+
+ember-classic-decorator@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/ember-classic-decorator/-/ember-classic-decorator-1.0.6.tgz#b66c7411568af0b42d8ca214fe90ecca1638bfc8"
+  integrity sha512-ANYPH+oGsKBz7jjEi4n6ADUI5/kLRVyt2OWjMQVAx/+ZELl76hJxrVM8RceiXGWHUiyzZypPP1XRzSB2Yp8jsg==
+  dependencies:
+    babel-plugin-filter-imports "^3.0.0"
+    ember-cli-babel "^7.11.1"
 
 ember-cli-app-version@3.2.0:
   version "3.2.0"
@@ -7080,13 +7078,6 @@ fs-merger@^3.0.1:
     rimraf "^2.6.3"
     walk-sync "^2.0.2"
 
-fs-minipass@^1.2.5:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
-  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
-  dependencies:
-    minipass "^2.6.0"
-
 fs-tree-diff@^0.5.2, fs-tree-diff@^0.5.3, fs-tree-diff@^0.5.4, fs-tree-diff@^0.5.6, fs-tree-diff@^0.5.7, fs-tree-diff@^0.5.9:
   version "0.5.9"
   resolved "https://registry.yarnpkg.com/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz#a4ec6182c2f5bd80b9b83c8e23e4522e6f5fd946"
@@ -7837,7 +7828,7 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -7853,13 +7844,6 @@ iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
-
-ignore-walk@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
-  integrity sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==
-  dependencies:
-    minimatch "^3.0.4"
 
 ignore@^4.0.6:
   version "4.0.6"
@@ -7952,7 +7936,7 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@^1.3.4, ini@~1.3.0:
+ini@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -9509,20 +9493,13 @@ minimist@~0.0.1:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
   integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
 
-minipass@^2.2.0, minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
+minipass@^2.2.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
   integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
   dependencies:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
-
-minizlib@^1.2.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
-  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
-  dependencies:
-    minipass "^2.9.0"
 
 miragejs@^0.1.31:
   version "0.1.33"
@@ -9734,15 +9711,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-needle@^2.2.1:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.4.0.tgz#6833e74975c444642590e15a750288c5f939b57c"
-  integrity sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -9837,22 +9805,6 @@ node-notifier@^5.0.1:
     shellwords "^0.1.1"
     which "^1.3.0"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-releases@^1.1.44:
   version "1.1.45"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.45.tgz#4cf7e9175d71b1317f15ffd68ce63bce1d53e9f2"
@@ -9866,14 +9818,6 @@ nopt@^3.0.6, nopt@~3.0.6:
   integrity sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
   dependencies:
     abbrev "1"
-
-nopt@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
-  integrity sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=
-  dependencies:
-    abbrev "1"
-    osenv "^0.1.4"
 
 normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
   version "2.5.0"
@@ -9921,22 +9865,10 @@ normalize.css@3.0.3:
   resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-3.0.3.tgz#acc00262e235a2caa91363a2e5e3bfa4f8ad05c6"
   integrity sha1-rMACYuI1osqpE2Oi5eO/pPitBcY=
 
-npm-bundled@^1.0.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.1.tgz#1edd570865a94cdb1bc8220775e29466c9fb234b"
-  integrity sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==
-  dependencies:
-    npm-normalize-package-bin "^1.0.1"
-
 npm-git-info@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/npm-git-info/-/npm-git-info-1.0.3.tgz#a933c42ec321e80d3646e0d6e844afe94630e1d5"
   integrity sha1-qTPELsMh6A02RuDW6ESv6UYw4dU=
-
-npm-normalize-package-bin@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz#6e79a41f23fd235c0623218228da7d9c23b8f6e2"
-  integrity sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
 
 npm-package-arg@^6.1.1:
   version "6.1.1"
@@ -9947,14 +9879,6 @@ npm-package-arg@^6.1.1:
     osenv "^0.1.5"
     semver "^5.6.0"
     validate-npm-package-name "^3.0.0"
-
-npm-packlist@^1.1.6:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.7.tgz#9e954365a06b80b18111ea900945af4f88ed4848"
-  integrity sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==
-  dependencies:
-    ignore-walk "^3.0.1"
-    npm-bundled "^1.0.1"
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -9977,7 +9901,7 @@ npm-run-path@^4.0.0:
   dependencies:
     path-key "^3.0.0"
 
-npmlog@^4.0.0, npmlog@^4.0.2, npmlog@^4.1.2:
+npmlog@^4.0.0, npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -10170,7 +10094,7 @@ os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
-osenv@^0.1.3, osenv@^0.1.4, osenv@^0.1.5:
+osenv@^0.1.3, osenv@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
   integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
@@ -11138,16 +11062,6 @@ raw-body@~1.1.0:
     bytes "1"
     string_decoder "0.10"
 
-rc@^1.2.7:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
-
 read-cache@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/read-cache/-/read-cache-1.0.0.tgz#e664ef31161166c9751cdbe8dbcf86b5fb58f774"
@@ -11717,7 +11631,7 @@ sane@^4.0.0, sane@^4.1.0:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-sax@^1.2.4, sax@~1.2.4:
+sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -12402,7 +12316,7 @@ strip-indent@^1.0.1:
   dependencies:
     get-stdin "^4.0.1"
 
-strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
+strip-json-comments@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
@@ -12546,19 +12460,6 @@ tapable@^1.0.0, tapable@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
-
-tar@^4.4.2:
-  version "4.4.13"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
-  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
-  dependencies:
-    chownr "^1.1.1"
-    fs-minipass "^1.2.5"
-    minipass "^2.8.6"
-    minizlib "^1.2.1"
-    mkdirp "^0.5.0"
-    safe-buffer "^5.1.2"
-    yallist "^3.0.3"
 
 temp@0.9.0:
   version "0.9.0"
@@ -13571,7 +13472,7 @@ y18n@^4.0.0:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
 
-yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
+yallist@^3.0.0, yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==


### PR DESCRIPTION
no issue

With the Octane edition, Ember is moving to using native JS class syntax in place of it's custom EmberObject extension pattern.

- added linting for classic ember object usage inside native classes
- added ember-concurrency-decorators addon
  - provides a more concise and easier-to-read decorator syntax for ember-concurrency tasks
  - helps eslint determine when there are duplicate function names (it was previously failing to detect an action and a task that had the same name)
  - preparation for migrating to native classes
- migrated controllers to native classes
  - ran `ember-native-class-codemod` (https://github.com/ember-codemods/ember-native-class-codemod) on `app/controllers` and manually upgraded a couple of controllers that the codemod skipped
    - manually updated usage of `task` and `taskGroup` to use `ember-concurrency-decorators`
  - migrated controller-backed templates to use action methods directly rather than via the `{{action}}` helper
    - switched to using `{{fn}}` where appropriate
    - switched to using `{{on}}` where appropriate
    - skipped `{{action}}` usage where `target=` or `value=` is used for the time being, `target` requires the actions indicated to be using the action helper, `value` needs some investigation for the correct migration path

TODO:
- [ ] manually migrate `controllers/setup/three.js`
- [ ] manually migrate `controllers/signup.js`
- [ ] fix tests
- [ ] do a manual walk-through test