### PR TITLE
🐛 Fixed unselectable routes files in macOS Safari

### DIFF
--- a/app/controllers/settings/labs.js
+++ b/app/controllers/settings/labs.js
@@ -54,6 +54,8 @@ export default Controller.extend({
     yamlExtension: null,
     yamlMimeType: null,
 
+    yamlAccept: null,
+
     init() {
         this._super(...arguments);
         this.importMimeType = IMPORT_MIME_TYPES;
@@ -61,6 +63,9 @@ export default Controller.extend({
         this.jsonMimeType = JSON_MIME_TYPE;
         this.yamlExtension = YAML_EXTENSION;
         this.yamlMimeType = YAML_MIME_TYPE;
+        // (macOS) Safari only allows files with the `yml` extension to be selected with the specified MIME types
+        // so explicitly allow the `yaml` extension.
+        this.yamlAccept = [...this.yamlMimeType, ...Array.from(this.yamlExtension, extension => '.' + extension)];
     },
 
     actions: {

--- a/app/templates/settings/labs.hbs
+++ b/app/templates/settings/labs.hbs
@@ -205,7 +205,7 @@
                     {{/if}}
 
                     <div style="display:none">
-                        <GhFileInput @multiple={{false}} @action={{uploader.setFiles}} @accept={{this.yamlMimeType}} data-test-file-input="routes" />
+                        <GhFileInput @multiple={{false}} @action={{uploader.setFiles}} @accept={{this.yamlAccept}} data-test-file-input="routes" />
                     </div>
                 </div>
                 </GhUploader>


### PR DESCRIPTION
closes TryGhost/Ghost#11472

Works around a probable Safari bug in which only `yml` files were selectable with the existing `accept` field value. Adds a new `yamlAccept` variable which combines the mime types with the yaml extension array (providing the `yaml` extension explicitly allows it).

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `ember test` from the repo root - will be `core/client` if working from the submodule in Ghost).
