### PR TITLE
🎨 Fixed page delete redirect

### DIFF
--- a/app/routes/editor.js
+++ b/app/routes/editor.js
@@ -66,8 +66,8 @@ export default AuthenticatedRoute.extend(ShortcutsRoute, {
             this.controller.send('toggleReAuthenticateModal');
         },
 
-        redirectToContentScreen() {
-            this.transitionTo('posts');
+        redirectToContentScreen(displayName) {
+            this.transitionTo(displayName === 'page' ? 'pages' : 'posts');
         },
 
         willTransition(transition) {

--- a/app/templates/editor.hbs
+++ b/app/templates/editor.hbs
@@ -94,7 +94,7 @@
 
     {{#if this.showDeletePostModal}}
         <GhFullscreenModal @modal="delete-post"
-            @model={{hash post=this.post onSuccess=(route-action 'redirectToContentScreen')}}
+            @model={{hash post=this.post onSuccess=(route-action 'redirectToContentScreen' this.post.displayName)}}
             @close={{action "toggleDeletePostModal"}}
             @modifier="action wide" />
     {{/if}}


### PR DESCRIPTION
Realised when a page is deleted the user is redirected to posts instead of staying in pages. This pull request keeps the user in pages when deleting a page and in posts when deleting a post. 