### PR TITLE
Allowed editors to send email on publish

### DIFF
--- a/app/components/gh-publishmenu-draft.js
+++ b/app/components/gh-publishmenu-draft.js
@@ -1,7 +1,7 @@
 import Component from '@ember/component';
 import moment from 'moment';
 import {computed} from '@ember/object';
-import {equal} from '@ember/object/computed';
+import {equal, or} from '@ember/object/computed';
 import {isEmpty} from '@ember/utils';
 import {inject as service} from '@ember/service';
 
@@ -19,6 +19,7 @@ export default Component.extend({
     'data-test-publishmenu-draft': true,
 
     disableEmailOption: equal('memberCount', 0),
+    showSendEmail: or('session.user.isOwner', 'session.user.isAdmin', 'session.user.isEditor'),
 
     canSendEmail: computed('feature.labs.members', 'post.{displayName,email}', function () {
         let membersEnabled = this.feature.get('labs.members');

--- a/app/components/gh-publishmenu-scheduled.js
+++ b/app/components/gh-publishmenu-scheduled.js
@@ -1,7 +1,7 @@
 import Component from '@ember/component';
 import moment from 'moment';
 import {computed} from '@ember/object';
-import {equal} from '@ember/object/computed';
+import {equal, or} from '@ember/object/computed';
 import {inject as service} from '@ember/service';
 
 export default Component.extend({
@@ -18,6 +18,7 @@ export default Component.extend({
     'data-test-publishmenu-scheduled': true,
 
     disableEmailOption: equal('memberCount', 0),
+    showSendEmail: or('session.user.isOwner', 'session.user.isAdmin', 'session.user.isEditor'),
 
     timeToPublished: computed('post.publishedAtUTC', 'clock.second', function () {
         let publishedAtUTC = this.get('post.publishedAtUTC');

--- a/app/templates/components/gh-publishmenu-draft.hbs
+++ b/app/templates/components/gh-publishmenu-draft.hbs
@@ -29,7 +29,7 @@
         </div>
     </div>
 
-    {{#if (and this.canSendEmail this.session.user.isOwnerOrAdmin)}}
+    {{#if (and this.canSendEmail showSendEmail)}}
         <div class="gh-publishmenu-section">
             <div class="gh-publishmenu-radio gh-publishmenu-email">
                 {{#if this.backgroundLoader.isRunning}}

--- a/app/templates/components/gh-publishmenu-scheduled.hbs
+++ b/app/templates/components/gh-publishmenu-scheduled.hbs
@@ -28,7 +28,7 @@
             </div>
         </div>
     </section>
-    {{#if this.session.user.isOwnerOrAdmin}}
+    {{#if showSendEmail}}
         {{#unless this.post.email}}
             <section class="gh-publishmenu-section">
                 <div class="gh-publishmenu-radio gh-publishmenu-email">


### PR DESCRIPTION
no issue

So far, only owners or Admins were allowed to control the send email setting while publishing/scheduling a post. This change allows Editors to see the setting as well and toggle as needed.
