### PR TITLE
🐛 Fixed unreachable link toolbar when editing wrapped links

### DIFF
--- a/lib/koenig-editor/addon/components/koenig-editor.js
+++ b/lib/koenig-editor/addon/components/koenig-editor.js
@@ -581,15 +581,17 @@ export default Component.extend({
         // appropriate <a> markup. If there's a selection when the link edit
         // component renders it will re-select when finished which should
         // trigger the normal toolbar
-        editLink(range) {
+        editLink(range, rect) {
             let linkMarkup = getLinkMarkupFromRange(range);
             if ((!range.isCollapsed || linkMarkup) && range.headSection.isMarkerable) {
                 this.set('linkRange', range);
+                this.set('linkRect', rect);
             }
         },
 
         cancelEditLink() {
             this.set('linkRange', null);
+            this.set('linkRect', null);
         },
 
         deleteCard(card, cursorMovement = CURSOR_AFTER) {

--- a/lib/koenig-editor/addon/components/koenig-link-input.js
+++ b/lib/koenig-editor/addon/components/koenig-link-input.js
@@ -38,6 +38,7 @@ export default Component.extend({
     // public attrs
     editor: null,
     linkRange: null,
+    linkRect: null,
     selectedRange: null,
 
     // internal properties
@@ -199,7 +200,7 @@ export default Component.extend({
     // TODO: largely shared with {{koenig-toolbar}} code - extract to a shared util?
     _positionToolbar() {
         let containerRect = this.element.offsetParent.getBoundingClientRect();
-        let rangeRect = this._windowRange.getBoundingClientRect();
+        let rangeRect = this.linkRect || this._windowRange.getBoundingClientRect();
         let {width, height} = this.element.getBoundingClientRect();
         let newPosition = {};
 

--- a/lib/koenig-editor/addon/templates/components/koenig-editor.hbs
+++ b/lib/koenig-editor/addon/templates/components/koenig-editor.hbs
@@ -28,6 +28,7 @@
     <KoenigLinkInput
         @editor={{this.editor}}
         @linkRange={{this.linkRange}}
+        @linkRect={{this.linkRect}}
         @selectedRange={{this.selectedRange}}
         @cancel={{action "cancelEditLink"}}
     />


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/9792

- use `getClientRects()` to get separate rectangles for each line of a link and use the mouse position to find the closest one so that the toolbar can be positioned relative to that link section on that line rather than always in the middle of the editor canvas
- pass the rectangle used for positioning the link toolbar through to the link input component so that there is no jumping of position when clicking the edit button