### PR TITLE
💄Updated save buttons to reset state

### DIFF
--- a/app/components/gh-task-button.js
+++ b/app/components/gh-task-button.js
@@ -34,7 +34,7 @@ const GhTaskButton = Component.extend({
     idleClass: '',
     runningClass: '',
     showSuccess: true, // set to false if you want the spinner to show until a transition occurs
-    autoReset: true, // set to false if you want don't want task button to reset after timeout
+    autoReset: false, // set to false if you want don't want task button to reset after timeout
     successText: 'Saved',
     successClass: 'gh-btn-green',
     failureText: 'Retry',

--- a/app/components/gh-task-button.js
+++ b/app/components/gh-task-button.js
@@ -166,7 +166,7 @@ const GhTaskButton = Component.extend({
     }),
 
     _resetButtonState: task(function* () {
-        yield timeout(5000);
+        yield timeout(2500);
         if (!this.get('task.last.isRunning')) {
             // Reset last task to bring button back to idle state
             yield this.set('task.last', null);

--- a/app/components/gh-task-button.js
+++ b/app/components/gh-task-button.js
@@ -34,6 +34,7 @@ const GhTaskButton = Component.extend({
     idleClass: '',
     runningClass: '',
     showSuccess: true, // set to false if you want the spinner to show until a transition occurs
+    autoReset: true, // set to false if you want don't want task button to reset after timeout
     successText: 'Saved',
     successClass: 'gh-btn-green',
     failureText: 'Retry',
@@ -118,7 +119,6 @@ const GhTaskButton = Component.extend({
             return false;
         }
 
-        let task = this.task;
         let taskName = this.get('task.name');
         let lastTaskName = this.get('task.last.task.name');
 
@@ -128,9 +128,8 @@ const GhTaskButton = Component.extend({
         if (this.isRunning && taskName === lastTaskName) {
             return;
         }
-
         this.action();
-        task.perform(this.taskArgs);
+        this._handleMainTask.perform();
 
         this._restartAnimation.perform();
 
@@ -156,7 +155,23 @@ const GhTaskButton = Component.extend({
             yield timeout(10);
             elem.classList.add('retry-animated');
         }
-    })
+    }),
+
+    _handleMainTask: task(function* () {
+        this._resetButtonState.cancelAll();
+        yield this.task.perform(this.taskArgs);
+        if (this.autoReset && !this.showSuccess) {
+            this._resetButtonState.perform();
+        }
+    }),
+
+    _resetButtonState: task(function* () {
+        yield timeout(5000);
+        if (!this.get('task.last.isRunning')) {
+            // Reset last task to bring button back to idle state
+            yield this.set('task.last', null);
+        }
+    }).restartable()
 });
 
 export default GhTaskButton;

--- a/app/components/gh-task-button.js
+++ b/app/components/gh-task-button.js
@@ -160,7 +160,8 @@ const GhTaskButton = Component.extend({
     _handleMainTask: task(function* () {
         this._resetButtonState.cancelAll();
         yield this.task.perform(this.taskArgs);
-        if (this.autoReset && this.showSuccess) {
+        const isTaskSuccess = this.get('task.last.isSuccessful') && this.get('task.last.value');
+        if (this.autoReset && this.showSuccess && isTaskSuccess) {
             this._resetButtonState.perform();
         }
     }),

--- a/app/components/gh-task-button.js
+++ b/app/components/gh-task-button.js
@@ -160,7 +160,7 @@ const GhTaskButton = Component.extend({
     _handleMainTask: task(function* () {
         this._resetButtonState.cancelAll();
         yield this.task.perform(this.taskArgs);
-        if (this.autoReset && !this.showSuccess) {
+        if (this.autoReset && this.showSuccess) {
             this._resetButtonState.perform();
         }
     }),

--- a/app/controllers/settings/general.js
+++ b/app/controllers/settings/general.js
@@ -11,7 +11,7 @@ import {computed} from '@ember/object';
 import {htmlSafe} from '@ember/string';
 import {run} from '@ember/runloop';
 import {inject as service} from '@ember/service';
-import {task} from 'ember-concurrency';
+import {task, timeout} from 'ember-concurrency';
 
 const ICON_EXTENSIONS = ['ico', 'png'];
 
@@ -321,7 +321,7 @@ export default Controller.extend({
         });
     },
 
-    save: task(function* () {
+    saveSettings: task(function* () {
         let notifications = this.notifications;
         let config = this.config;
 
@@ -338,6 +338,15 @@ export default Controller.extend({
                 notifications.showAPIError(error, {key: 'settings.save'});
             }
             throw error;
+        }
+    }),
+
+    save: task(function* () {
+        yield this.saveSettings.perform();
+        yield timeout(2500);
+        if (this.get('saveSettings.last.isSuccessful') && this.get('saveSettings.last.value')) {
+            // Reset last task to bring button back to idle state
+            yield this.set('saveSettings.last', null);
         }
     })
 });

--- a/app/controllers/settings/integration.js
+++ b/app/controllers/settings/integration.js
@@ -134,8 +134,17 @@ export default Controller.extend({
 
     },
 
-    save: task(function* () {
+    saveIntegration: task(function* () {
         return yield this.integration.save();
+    }),
+
+    save: task(function* () {
+        yield this.saveIntegration.perform();
+        yield timeout(2500);
+        if (this.get('saveIntegration.last.isSuccessful') && this.get('saveIntegration.last.value')) {
+            // Reset last task to bring button back to idle state
+            yield this.set('saveIntegration.last', null);
+        }
     }),
 
     copyContentKey: task(function* () {

--- a/app/controllers/settings/integrations/amp.js
+++ b/app/controllers/settings/integrations/amp.js
@@ -2,7 +2,7 @@
 import Controller from '@ember/controller';
 import {alias} from '@ember/object/computed';
 import {inject as service} from '@ember/service';
-import {task} from 'ember-concurrency';
+import {task, timeout} from 'ember-concurrency';
 
 export default Controller.extend({
     notifications: service(),
@@ -61,7 +61,7 @@ export default Controller.extend({
         }
     },
 
-    save: task(function* () {
+    saveTask: task(function* () {
         let amp = this.ampSettings;
         let settings = this.settings;
 
@@ -73,5 +73,15 @@ export default Controller.extend({
             this.notifications.showAPIError(error);
             throw error;
         }
+    }).drop(),
+
+    save: task(function* () {
+        yield this.saveTask.perform();
+        yield timeout(2500);
+        if (this.get('saveTask.last.isSuccessful') && this.get('saveTask.last.value')) {
+            // Reset last task to bring button back to idle state
+            yield this.set('saveTask.last', null);
+        }
     }).drop()
+
 });

--- a/app/controllers/settings/integrations/slack.js
+++ b/app/controllers/settings/integrations/slack.js
@@ -4,7 +4,7 @@ import boundOneWay from 'ghost-admin/utils/bound-one-way';
 import {empty} from '@ember/object/computed';
 import {isInvalidError} from 'ember-ajax/errors';
 import {inject as service} from '@ember/service';
-import {task} from 'ember-concurrency';
+import {task, timeout} from 'ember-concurrency';
 
 export default Controller.extend({
     ghostPaths: service(),
@@ -94,7 +94,7 @@ export default Controller.extend({
         }
     },
 
-    save: task(function* () {
+    saveTask: task(function* () {
         let slack = this.slackSettings;
         let settings = this.settings;
         let slackArray = this.slackArray;
@@ -110,6 +110,15 @@ export default Controller.extend({
                 this.notifications.showAPIError(error);
                 throw error;
             }
+        }
+    }).drop(),
+
+    save: task(function* () {
+        yield this.saveTask.perform();
+        yield timeout(2500);
+        if (this.get('saveTask.last.isSuccessful') && this.get('saveTask.last.value')) {
+            // Reset last task to bring button back to idle state
+            yield this.set('saveTask.last', null);
         }
     }).drop(),
 

--- a/app/templates/components/modal-custom-view-form.hbs
+++ b/app/templates/components/modal-custom-view-form.hbs
@@ -72,6 +72,7 @@
     <GhTaskButton
         @buttonText="Save"
         @successText="Saved"
+        @autoReset={{true}}
         @task={{this.saveTask}}
         @taskArgs={{this.model}}
         @class="gh-btn gh-btn-green gh-btn-icon"

--- a/app/templates/components/modal-members-label-form.hbs
+++ b/app/templates/components/modal-members-label-form.hbs
@@ -68,6 +68,7 @@
             @buttonText="Save"
             @runningText="Saving..."
             @successText="Saved"
+            @autoReset={{true}}
             @task={{this.saveTask}}
             @taskArgs={{this.label}}
             @class="gh-btn gh-btn-green gh-btn-icon"

--- a/app/templates/member.hbs
+++ b/app/templates/member.hbs
@@ -21,7 +21,7 @@
                 {{/unless}}
             {{/if}}
 
-            <GhTaskButton @class="gh-btn gh-btn-blue gh-btn-icon" @type="button" @task={{this.save}} @data-test-button="save" />
+            <GhTaskButton @class="gh-btn gh-btn-blue gh-btn-icon" @type="button" @task={{this.save}} @autoReset={{true}} @data-test-button="save" />
         </section>
     </GhCanvasHeader>
 
@@ -55,7 +55,7 @@
                         {{else}}
                             {{this.member.geolocation.country}}
                         {{/if}}
-                    {{else}}  
+                    {{else}}
                         Unknown location
                     {{/if}}
                     – Created on {{this.subscribedAt}}

--- a/app/templates/member.hbs
+++ b/app/templates/member.hbs
@@ -21,7 +21,7 @@
                 {{/unless}}
             {{/if}}
 
-            <GhTaskButton @class="gh-btn gh-btn-blue gh-btn-icon" @type="button" @task={{this.save}} @autoReset={{true}} @data-test-button="save" />
+            <GhTaskButton @class="gh-btn gh-btn-blue gh-btn-icon" @type="button" @task={{this.saveMember}} @autoReset={{true}} @data-test-button="save" />
         </section>
     </GhCanvasHeader>
 

--- a/app/templates/settings/code-injection.hbs
+++ b/app/templates/settings/code-injection.hbs
@@ -4,7 +4,7 @@
             Code injection
         </h2>
         <section class="view-actions">
-            <GhTaskButton @task={{this.save}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button={{true}} />
+            <GhTaskButton @task={{this.saveTask}} @autoReset={{true}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button={{true}} />
         </section>
     </GhCanvasHeader>
 

--- a/app/templates/settings/design.hbs
+++ b/app/templates/settings/design.hbs
@@ -4,7 +4,7 @@
             Design
         </h2>
         <section class="view-actions">
-            <GhTaskButton @task={{this.save}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button={{true}} />
+            <GhTaskButton @task={{this.saveTask}} @autoReset={{true}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button={{true}} />
         </section>
     </GhCanvasHeader>
 

--- a/app/templates/settings/general.hbs
+++ b/app/templates/settings/general.hbs
@@ -5,7 +5,7 @@
             General settings
         </h2>
         <section class="view-actions">
-            <GhTaskButton @buttonText="Save settings" @task={{this.save}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button="true" />
+            <GhTaskButton @buttonText="Save settings" @task={{this.save}} @autoReset={{true}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button="true" />
         </section>
     </GhCanvasHeader>
 

--- a/app/templates/settings/general.hbs
+++ b/app/templates/settings/general.hbs
@@ -5,7 +5,7 @@
             General settings
         </h2>
         <section class="view-actions">
-            <GhTaskButton @buttonText="Save settings" @task={{this.save}} @autoReset={{true}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button="true" />
+            <GhTaskButton @buttonText="Save settings" @task={{this.saveSettings}} @autoReset={{true}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button="true" />
         </section>
     </GhCanvasHeader>
 

--- a/app/templates/settings/integration.hbs
+++ b/app/templates/settings/integration.hbs
@@ -7,7 +7,7 @@
                 {{this.integration.name}}
             </h2>
             <section class="view-actions">
-                <GhTaskButton @task={{this.save}} @class="gh-btn gh-btn-blue gh-btn-icon" @autoReset={{true}} data-test-button="save" />
+                <GhTaskButton @task={{this.saveIntegration}} @class="gh-btn gh-btn-blue gh-btn-icon" @autoReset={{true}} data-test-button="save" />
             </section>
         </GhCanvasHeader>
 

--- a/app/templates/settings/integration.hbs
+++ b/app/templates/settings/integration.hbs
@@ -7,7 +7,7 @@
                 {{this.integration.name}}
             </h2>
             <section class="view-actions">
-                <GhTaskButton @task={{this.save}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-button="save" />
+                <GhTaskButton @task={{this.save}} @class="gh-btn gh-btn-blue gh-btn-icon" @autoReset={{true}} data-test-button="save" />
             </section>
         </GhCanvasHeader>
 

--- a/app/templates/settings/integrations/amp.hbs
+++ b/app/templates/settings/integrations/amp.hbs
@@ -6,7 +6,7 @@
             AMP
         </h2>
         <section class="view-actions">
-            <GhTaskButton @task={{this.save}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button={{true}} />
+            <GhTaskButton @task={{this.save}} @class="gh-btn gh-btn-blue gh-btn-icon" @autoReset={{true}} data-test-save-button={{true}} />
         </section>
     </GhCanvasHeader>
 

--- a/app/templates/settings/integrations/amp.hbs
+++ b/app/templates/settings/integrations/amp.hbs
@@ -6,7 +6,7 @@
             AMP
         </h2>
         <section class="view-actions">
-            <GhTaskButton @task={{this.save}} @class="gh-btn gh-btn-blue gh-btn-icon" @autoReset={{true}} data-test-save-button={{true}} />
+            <GhTaskButton @task={{this.saveTask}} @class="gh-btn gh-btn-blue gh-btn-icon" @autoReset={{true}} data-test-save-button={{true}} />
         </section>
     </GhCanvasHeader>
 

--- a/app/templates/settings/integrations/slack.hbs
+++ b/app/templates/settings/integrations/slack.hbs
@@ -6,7 +6,7 @@
             Slack
         </h2>
         <section class="view-actions">
-            <GhTaskButton @task={{this.save}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button={{true}} />
+            <GhTaskButton @task={{this.save}} @autoReset={{true}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button={{true}} />
         </section>
     </GhCanvasHeader>
 

--- a/app/templates/settings/integrations/slack.hbs
+++ b/app/templates/settings/integrations/slack.hbs
@@ -6,7 +6,7 @@
             Slack
         </h2>
         <section class="view-actions">
-            <GhTaskButton @task={{this.save}} @autoReset={{true}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button={{true}} />
+            <GhTaskButton @task={{this.saveTask}} @autoReset={{true}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button={{true}} />
         </section>
     </GhCanvasHeader>
 

--- a/app/templates/settings/integrations/unsplash.hbs
+++ b/app/templates/settings/integrations/unsplash.hbs
@@ -6,7 +6,7 @@
             Unsplash
         </h2>
         <section class="view-actions">
-            <GhTaskButton @task={{this.save}} @autoReset={{true}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button={{true}} />
+            <GhTaskButton @task={{this.saveTask}} @autoReset={{true}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button={{true}} />
         </section>
     </GhCanvasHeader>
 

--- a/app/templates/settings/integrations/unsplash.hbs
+++ b/app/templates/settings/integrations/unsplash.hbs
@@ -6,7 +6,7 @@
             Unsplash
         </h2>
         <section class="view-actions">
-            <GhTaskButton @task={{this.save}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button={{true}} />
+            <GhTaskButton @task={{this.save}} @autoReset={{true}} @class="gh-btn gh-btn-blue gh-btn-icon" data-test-save-button={{true}} />
         </section>
     </GhCanvasHeader>
 

--- a/app/templates/settings/labs.hbs
+++ b/app/templates/settings/labs.hbs
@@ -34,6 +34,7 @@
                             @task={{this.saveSettings}}
                             @successText="Saved"
                             @runningText="Saving"
+                            @autoReset={{true}}
                             @class="gh-btn gh-btn-blue gh-btn-icon"
                         />
                     </div>

--- a/app/templates/tag.hbs
+++ b/app/templates/tag.hbs
@@ -7,7 +7,7 @@
                 {{if this.tag.isNew "New tag" this.tag.name}}
             </h2>
             <section class="view-actions">
-                <GhTaskButton @task={{this.save}} @type="button" @class="gh-btn gh-btn-blue gh-btn-icon" @data-test-button="save" />
+                <GhTaskButton @task={{this.save}} @type="button" @class="gh-btn gh-btn-blue gh-btn-icon" @autoReset={{true}} @data-test-button="save" />
             </section>
         </GhCanvasHeader>
 

--- a/app/templates/tag.hbs
+++ b/app/templates/tag.hbs
@@ -7,7 +7,7 @@
                 {{if this.tag.isNew "New tag" this.tag.name}}
             </h2>
             <section class="view-actions">
-                <GhTaskButton @task={{this.save}} @type="button" @class="gh-btn gh-btn-blue gh-btn-icon" @autoReset={{true}} @data-test-button="save" />
+                <GhTaskButton @task={{this.saveTask}} @type="button" @class="gh-btn gh-btn-blue gh-btn-icon" @autoReset={{true}} @data-test-button="save" />
             </section>
         </GhCanvasHeader>
 


### PR DESCRIPTION
no issue

Currently the save buttons across Admin don't auto-reset to idle state after success/failure after click which can get confusing once user makes any subsequent changes and sees the old button state. This PR 

- adds auto-reset option to the task button component which allows reset to idle state after a fixed timeout
- updates all relevant save buttons in Admin to use the new option to auto-reset