### PR TITLE
Added handling for /billing route with query param passing to BMA

### DIFF
--- a/app/components/modal-billing.js
+++ b/app/components/modal-billing.js
@@ -6,7 +6,6 @@ export default ModalComponent.extend({
 
     actions: {
         closeModal() {
-            this._super(arguments);
             this.billing.closeBillingWindow();
         }
     }

--- a/app/components/modal-billing.js
+++ b/app/components/modal-billing.js
@@ -1,4 +1,13 @@
 import ModalComponent from 'ghost-admin/components/modal-base';
+import {inject as service} from '@ember/service';
 
 export default ModalComponent.extend({
+    billing: service(),
+
+    actions: {
+        closeModal() {
+            this._super(arguments);
+            this.billing.closeBillingWindow();
+        }
+    }
 });

--- a/app/controllers/billing.js
+++ b/app/controllers/billing.js
@@ -1,6 +1,0 @@
-import Controller from '@ember/controller';
-import {alias} from '@ember/object/computed';
-
-export default Controller.extend({
-    guid: alias('model')
-});

--- a/app/routes/billing.js
+++ b/app/routes/billing.js
@@ -1,0 +1,26 @@
+import Route from '@ember/routing/route';
+import {inject as service} from '@ember/service';
+
+export default Route.extend({
+    billing: service(),
+
+    queryParams: {
+        action: {refreshModel: true}
+    },
+
+    init() {
+        this._super(...arguments);
+    },
+
+    model(params) {
+        if (params.action) {
+            this.billing.set('action', params.action);
+        }
+
+        this.billing.set('billingWindowOpen', true);
+
+        // NOTE: if this route is ever triggered it was opened through external link because
+        //       the route has no underlying templates to render we redirect to root route
+        this.transitionTo('/');
+    }
+});

--- a/app/services/billing.js
+++ b/app/services/billing.js
@@ -6,10 +6,6 @@ export default Service.extend({
     config: service(),
     ghostPaths: service(),
 
-    init() {
-        this._super(...arguments);
-    },
-
     billingWindowOpen: false,
     upgrade: true,
     action: null,

--- a/app/services/billing.js
+++ b/app/services/billing.js
@@ -8,17 +8,26 @@ export default Service.extend({
 
     init() {
         this._super(...arguments);
-        this.billingWindowOpen = false;
     },
 
     billingWindowOpen: false,
     upgrade: true,
+    action: null,
 
-    endpoint: computed('config.billingUrl', 'billingWindowOpen', function () {
+    closeBillingWindow() {
+        this.set('billingWindowOpen', false);
+        this.set('action', null);
+    },
+
+    endpoint: computed('config.billingUrl', 'billingWindowOpen', 'action', function () {
         let url = this.config.get('billingUrl');
 
         if (this.get('upgrade')) {
             url = this.ghostPaths.url.join(url, 'plans');
+        }
+
+        if (this.get('action')) {
+            url += `?action=${this.get('action')}`;
         }
 
         return url;

--- a/app/templates/billing.hbs
+++ b/app/templates/billing.hbs
@@ -1,1 +1,0 @@
-<GhBillingIframe @guid={{this.guid}}></GhBillingIframe>

--- a/app/templates/components/modal-billing.hbs
+++ b/app/templates/components/modal-billing.hbs
@@ -1,5 +1,5 @@
 <div class="gh-billing-close">
-    <button class="close" href title="Close" {{on "click" this.closeModal}}>
+    <button class="close" href title="Close" {{on "click" (action "closeModal")}}>
         {{svg-jar "close"}}
     </button>
 </div>


### PR DESCRIPTION
The purpose if this change is to allow opening "billing" popup through a URL. It is not meant to render any information. It's purpose is:
1. Trigger open modal action
2.  Parse and pass relevant query parameter - "action"

@kevinansfield wanted to know your opinion on this approach and if the use of billing route is appropriate for this usecase. The naming of the parameters is not final (the "action" part). Naming will be reviewed once the whole flow works :) Let me know if this billing modal could be approached in a more ember-friendly way.

Example use: 
1. Open`http://localhost:2368/ghost/#/billing?action=success
2. This opens a modal with a BMA iframe which has `?action=success` passed in
3. After closing the BMA modal we return to default Ghost-Admin view

The rest of actions opening BMA - "upgrade" button and "view billing" should work as before without passing any additional parameters (action parameter should not be persisted between open/close of the BMA popup) 