### PR TITLE
✨ Added "Email" card for inserting content that only appears when emailing posts to members

### DIFF
--- a/lib/koenig-editor/addon/options/cards.js
+++ b/lib/koenig-editor/addon/options/cards.js
@@ -105,8 +105,7 @@ export const CARD_MENU = [
             icon: 'koenig/kg-card-type-email',
             matches: ['email'],
             type: 'card',
-            replaceArg: 'email',
-            developerExperiment: true
+            replaceArg: 'email'
         }]
     },
     {


### PR DESCRIPTION
no issue

- any content inside the email card will not appear on the site, instead it will only be shown when using the members system to email the post to your members
- email card content can contain `{first_name}` or `{first_name, "fallback"}` to personalise it for each member