### PR TITLE
🐛 Fixed email preview not visible to Editors

### DIFF
--- a/app/components/gh-post-settings-menu.hbs
+++ b/app/components/gh-post-settings-menu.hbs
@@ -131,7 +131,7 @@
                         </button>
                         {{svg-jar "arrow-right"}}
                     </li>
-                    {{#if (and this.feature.members (eq this.post.displayName "post") this.session.user.isOwnerOrAdmin)}}
+                    {{#if (and this.feature.members (eq this.post.displayName "post") showEmailNewsletter)}}
                         <li class="nav-list-item" {{action "showSubview" "email-settings"}} data-test-button="email-settings">
                             <button type="button">
                                 <b>Email newsletter</b>

--- a/app/components/gh-post-settings-menu.js
+++ b/app/components/gh-post-settings-menu.js
@@ -48,6 +48,7 @@ export default Component.extend(SettingsMenuMixin, {
     twitterTitle: or('twitterTitleScratch', 'seoTitle'),
 
     showVisibilityInput: or('session.user.isOwner', 'session.user.isAdmin', 'session.user.isEditor'),
+    showEmailNewsletter: or('session.user.isOwner', 'session.user.isAdmin', 'session.user.isEditor'),
 
     seoTitle: computed('metaTitleScratch', 'post.titleScratch', function () {
         return this.metaTitleScratch || this.post.titleScratch || '(Untitled)';


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/11841

- Allows editors to see email customization option for sending test newsletters
- Editors had the necessary permission fixtures but the UI was previously only available to owners or administrators
