### PR TITLE
🐛 Fixed various small accessibility problems in the admin screen

### DIFF
--- a/app/components/gh-mobile-nav-bar.hbs
+++ b/app/components/gh-mobile-nav-bar.hbs
@@ -5,5 +5,5 @@
     <LinkTo @route="posts">{{svg-jar "content" data-test-mobile-nav="posts"}}Posts</LinkTo>
 {{/if}}
 <LinkTo @route="staff" @classNames="gh-nav-main-users" data-test-mobile-nav="staff">{{svg-jar "account-group"}}Staff</LinkTo>
-<div class="gh-mobile-nav-bar-more" {{action "openMobileMenu" target=this.ui data-test-mobile-nav="more"}}>{{svg-jar "icon" class="icon-gh"}}More</div>
+<div role="button" class="gh-mobile-nav-bar-more" {{action "openMobileMenu" target=this.ui data-test-mobile-nav="more"}}>{{svg-jar "icon" class="icon-gh"}}More</div>
 {{yield}}

--- a/app/components/gh-nav-menu.hbs
+++ b/app/components/gh-nav-menu.hbs
@@ -159,7 +159,7 @@
                             {{/if}}
                         </button>
                     </li>
-                    <li class="divider"></li>
+                    <li class="divider" role="separator"></li>
                     <li role="presentation">
                         <LinkTo @route="staff.user" @model={{this.session.user.slug}} @classNames="dropdown-item" @role="menuitem" @tabindex="-1" data-test-nav="user-profile">
                             {{svg-jar "user-circle"}} Your Profile
@@ -183,12 +183,12 @@
                             {{svg-jar "book-open"}} How to Use Ghost
                         </a>
                     </li>
-                    <li class="divider"></li>
+                    <li class="divider" role="separator"></li>
 
                     {{#if this.showDropdownExtension}}
                         {{#each this.config.clientExtensions.dropdown.items as |menuItem| }}
                             {{#if menuItem.divider}}
-                                <li class="divider"></li>
+                                <li class="divider" role="separator"></li>
                             {{else}}
                                 <li role="presentation">
                                     <a href="{{menuItem.href}}" target="_blank" class="dropdown-item {{menuItem.classes}}" role="menuitem" tabindex="-1">

--- a/app/components/gh-nav-menu.hbs
+++ b/app/components/gh-nav-menu.hbs
@@ -34,7 +34,7 @@
                 <GhLinkToCustomViewsIndex @route="posts" @query={{reset-query-params "posts"}} data-test-nav="posts">{{svg-jar "posts"}}Posts</GhLinkToCustomViewsIndex>
                 <LinkTo @route="editor.new" @model="post" @classNames="gh-secondary-action gh-nav-new-post" @alt="New post" @title="New post" data-test-nav="new-story"><span>{{svg-jar "add-stroke"}}</span></LinkTo>
                 {{#if this.customViews.forPosts}}
-                    <button type="button" class="absolute left-3 top-2 z-9999 flex items-center pl2 h4 gh-nav-button-expand {{if this.navigation.settings.expanded.posts "expanded"}}" {{on "click" (fn this.navigation.toggleExpansion "posts")}}>
+                    <button type="button" class="absolute left-3 top-2 z-9999 flex items-center pl2 h4 gh-nav-button-expand {{if this.navigation.settings.expanded.posts "expanded"}}" {{on "click" (fn this.navigation.toggleExpansion "posts")}} aria-label="{{if this.navigation.settings.expanded.posts "Collapse custom post types" "Expand custom post types"}}">
                         {{svg-jar (if this.navigation.settings.expanded.posts "arrow-down-stroke" "arrow-right-stroke")}}
                     </button>
                     {{#liquid-if this.navigation.settings.expanded.posts}}


### PR DESCRIPTION
These commits fix various small problems in the admin main screen.

- The button to show or hide the custom post types had no label.
- The menu separators weren't accessible.
- The mobile More menu button didn't have a proper Button role.

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `ember test` from the repo root - will be `core/client` if working from the submodule in Ghost).

