### PR TITLE
🐛 Fixed various Close buttons throughout the UI.

### DIFF
--- a/app/components/modal-delete-all.hbs
+++ b/app/components/modal-delete-all.hbs
@@ -1,7 +1,7 @@
 <header class="modal-header">
     <h1>Would you really like to delete all content from your blog?</h1>
 </header>
-<a class="close" href="" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
+<a class="close" href="" role="button" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
 
 <div class="modal-body">
     <p>This is permanent! No backups, no restores, no magic undo button. We warned you, k?</p>

--- a/app/components/modal-delete-integration.hbs
+++ b/app/components/modal-delete-integration.hbs
@@ -1,7 +1,7 @@
 <header class="modal-header">
     <h1>Are you sure?</h1>
 </header>
-<a class="close" href="" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
+<a class="close" href="" role="button" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
 <div class="modal-body">
     <p>
         Deleting this integration will remove all webhooks and api keys associated with it.

--- a/app/components/modal-delete-member.hbs
+++ b/app/components/modal-delete-member.hbs
@@ -1,7 +1,7 @@
 <header class="modal-header">
     <h1>Are you sure you want to delete this member?</h1>
 </header>
-<a class="close" href="" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
+<a class="close" href="" role="button" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
 
 <div class="modal-body">
     <p>

--- a/app/components/modal-delete-post.hbs
+++ b/app/components/modal-delete-post.hbs
@@ -1,7 +1,7 @@
 <header class="modal-header">
     <h1>Are you sure you want to delete this {{this.post.displayName}}?</h1>
 </header>
-<a class="close" href="" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
+<a class="close" href="" role="button" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
 
 <div class="modal-body">
     <p>

--- a/app/components/modal-delete-tag.hbs
+++ b/app/components/modal-delete-tag.hbs
@@ -1,7 +1,7 @@
 <header class="modal-header">
     <h1>Are you sure you want to delete this tag?</h1>
 </header>
-<a class="close" href="" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
+<a class="close" href="" role="button" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
 
 <div class="modal-body">
     {{#if this.tag.post_count}}

--- a/app/components/modal-delete-theme.hbs
+++ b/app/components/modal-delete-theme.hbs
@@ -1,7 +1,7 @@
 <header class="modal-header" data-test-delete-theme-modal>
     <h1>Are you sure you want to delete this</h1>
 </header>
-<a class="close" href="" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
+<a class="close" href="" role="button" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
 
 <div class="modal-body">
     <p>You're about to delete "<strong>{{this.theme.label}}</strong>". This is permanent! We warned you, k? Maybe <a href="#" {{action this.download}}>Download your theme before continuing</a></p>

--- a/app/components/modal-delete-user.hbs
+++ b/app/components/modal-delete-user.hbs
@@ -1,7 +1,7 @@
 <header class="modal-header" data-test-modal="delete-user">
     <h1>Are you sure you want to delete this user?</h1>
 </header>
-<a class="close" href="" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
+<a class="close" href="" role="button" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
 
 <div class="modal-body">
     {{#if this.user.count.posts}}

--- a/app/components/modal-delete-webhook.hbs
+++ b/app/components/modal-delete-webhook.hbs
@@ -1,7 +1,7 @@
 <header class="modal-header">
     <h1>Are you sure?</h1>
 </header>
-<a class="close" href="" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
+<a class="close" href="" role="button" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
 
 <div class="modal-body">
     <p>

--- a/app/components/modal-impersonate-member.hbs
+++ b/app/components/modal-impersonate-member.hbs
@@ -2,7 +2,7 @@
     <h1 style="margin: 0;">Impersonate</h1>
 </header>
 {{!-- disable mouseDown so it doesn't trigger focus-out validations --}}
-<a class="close" href title="Close" {{action "closeModal"}} {{action (optional this.noop) on="mouseDown"}}>
+<a class="close" href role="button" title="Close" {{action "closeModal"}} {{action (optional this.noop) on="mouseDown"}}>
     {{svg-jar "close"}}<span class="hidden">Close</span>
 </a>
 

--- a/app/components/modal-import-members.hbs
+++ b/app/components/modal-import-members.hbs
@@ -7,7 +7,7 @@
         {{/if}}
     </h1>
 </header>
-<a class="close" href="" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
+<a class="close" href="" role="button" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
 
 <div class="modal-body bg-whitegrey-l2 ba b--whitegrey br3">
     {{#if this.response}}

--- a/app/components/modal-invite-new-user.hbs
+++ b/app/components/modal-invite-new-user.hbs
@@ -2,7 +2,7 @@
     <h1>Invite a New User</h1>
 </header>
 {{!-- disable mouseDown so it doesn't trigger focus-out validations --}}
-<a class="close" href title="Close" {{action "closeModal"}} {{action (optional this.noop) on="mouseDown"}}>
+<a class="close" href role="button" title="Close" {{action "closeModal"}} {{action (optional this.noop) on="mouseDown"}}>
     {{svg-jar "close"}}<span class="hidden">Close</span>
 </a>
 

--- a/app/components/modal-leave-editor.hbs
+++ b/app/components/modal-leave-editor.hbs
@@ -1,7 +1,7 @@
 <header class="modal-header">
     <h1>Are you sure you want to leave this page?</h1>
 </header>
-<a class="close" href="" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
+<a class="close" href="" role="button" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
 
 <div class="modal-body">
     <p>

--- a/app/components/modal-leave-settings.hbs
+++ b/app/components/modal-leave-settings.hbs
@@ -1,7 +1,7 @@
 <header class="modal-header" data-test-modal="unsaved-settings">
     <h1>Are you sure you want to leave this page?</h1>
 </header>
-<a class="close" href="" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
+<a class="close" href="" role="button" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
 
 <div class="modal-body">
     <p>

--- a/app/components/modal-markdown-help.hbs
+++ b/app/components/modal-markdown-help.hbs
@@ -1,7 +1,7 @@
 <header class="modal-header">
     <h1>Markdown Help</h1>
 </header>
-<a class="close" href="" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
+<a class="close" href="" role="button" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
 
 <div class="modal-body">
     <section class="markdown-help-container">

--- a/app/components/modal-members-label-form.hbs
+++ b/app/components/modal-members-label-form.hbs
@@ -2,7 +2,7 @@
     <header class="modal-header">
         <h1>Are you sure you want to delete this label?</h1>
     </header>
-    <a class="close" href="" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
+    <a class="close" href="" role="button" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
 
     <div class="modal-body">
         <p>

--- a/app/components/modal-re-authenticate.hbs
+++ b/app/components/modal-re-authenticate.hbs
@@ -1,7 +1,7 @@
 <header class="modal-header">
     <h1>Please re-authenticate</h1>
 </header>
-<a class="close" href="" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
+<a class="close" href="" role="button" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
 
 <div class="modal-body {{if this.authenticationError 'error'}}">
 

--- a/app/components/modal-regenerate-key.hbs
+++ b/app/components/modal-regenerate-key.hbs
@@ -1,7 +1,7 @@
 <header class="modal-header">
     <h1>Regenerate {{capitalize this.apiKey.type}} API Key</h1>
 </header>
-<a class="close" href="" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
+<a class="close" href="" role="button" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
 
 <div class="modal-body">
     <p>

--- a/app/components/modal-suspend-user.hbs
+++ b/app/components/modal-suspend-user.hbs
@@ -1,7 +1,7 @@
 <header class="modal-header">
     <h1>Are you sure you want to suspend this user?</h1>
 </header>
-<a class="close" href="" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
+<a class="close" href="" role="button" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
 
 <div class="modal-body">
     <strong>WARNING:</strong> This user will no longer be able to log in but their posts will be kept.

--- a/app/components/modal-theme-warnings.hbs
+++ b/app/components/modal-theme-warnings.hbs
@@ -8,7 +8,7 @@
             {{/unless}}
         </h1>
     </header>
-    <a class="close" href="#" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
+    <a class="close" href="#" role="button" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
 
     <div class="modal-body">
         {{#if this.fatalErrors}}

--- a/app/components/modal-transfer-owner.hbs
+++ b/app/components/modal-transfer-owner.hbs
@@ -1,7 +1,7 @@
 <header class="modal-header">
     <h1>Transfer Ownership</h1>
 </header>
-<a class="close" href="" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
+<a class="close" href="" role="button" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
 
 <div class="modal-body">
     <p>

--- a/app/components/modal-unsuspend-user.hbs
+++ b/app/components/modal-unsuspend-user.hbs
@@ -1,7 +1,7 @@
 <header class="modal-header">
     <h1>Are you sure you want to un-suspend this user?</h1>
 </header>
-<a class="close" href="" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
+<a class="close" href="" role="button" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
 
 <div class="modal-body">
     <strong>WARNING:</strong> This user will be able to log in again and will have the same permissions they had previously.

--- a/app/components/modal-upload-theme.hbs
+++ b/app/components/modal-upload-theme.hbs
@@ -14,7 +14,7 @@
             {{/if}}
         </h1>
     </header>
-    <a class="close" href="#" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
+    <a class="close" href="#" role="button" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
 
     <div class="modal-body">
         {{#if this.theme}}


### PR DESCRIPTION
no issue.

Some `a` tags with `href` attributes that are empty are used as buttons, but since the href is not linkifying anything, they appear as text nodes to assistive technologies. Give them a `"button"` role so it is guaranteed that assistive technologies will pick them up as actionable controls.


- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `ember test` from the repo root - will be `core/client` if working from the submodule in Ghost).

