### PR TITLE
🔥 Updated minimum Node versions to latest security releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint:js": "eslint ."
   },
   "engines": {
-    "node": "^10.13.0 || ^12.10.0"
+    "node": "^10.19.0 || ^12.15.0"
   },
   "devDependencies": {
     "@ember/jquery": "1.1.0",


### PR DESCRIPTION
no issue

- Node 10.19.0 and 12.15.0 are the latest security releases