### PR TITLE
Enabled auto reset state for action buttons

### DIFF
--- a/app/components/gh-task-button.js
+++ b/app/components/gh-task-button.js
@@ -35,7 +35,7 @@ const GhTaskButton = Component.extend({
     idleClass: '',
     runningClass: '',
     showSuccess: true, // set to false if you want the spinner to show until a transition occurs
-    autoReset: false, // set to false if you want don't want task button to reset after timeout
+    autoReset: true, // set to false if you want don't want task button to reset after timeout
     successText: 'Saved',
     successClass: 'gh-btn-green',
     failureText: 'Retry',

--- a/app/styles/patterns/buttons.css
+++ b/app/styles/patterns/buttons.css
@@ -141,44 +141,6 @@ fieldset[disabled] .gh-btn {
     box-shadow: none;
 }
 
-/* Green button
-/* ---------------------------------------------------------- */
-
-/* The background of the button creates 1px gradient border */
-.gh-btn-green,
-.gh-btn-green:hover {
-    border: 1px solid color-mod(var(--green) s(-5%));
-    color: #fff;
-    fill: #fff;
-    box-shadow: none;
-    transition-property: box-shadow;
-}
-
-.gh-btn-green:hover {
-    box-shadow: none;
-}
-
-/* The background of the span is the main visual element */
-.gh-btn-green span {
-    background: linear-gradient(color-mod(var(--green) l(+6%) s(-2%)), color-mod(var(--green) l(-8%) s(+5%)));
-    font-weight: 500;
-}
-
-.gh-btn-green:hover span {
-    background: linear-gradient(color-mod(var(--green) l(+9%) s(-1%)), color-mod(var(--green) l(-3%) saturation(-3%)));
-}
-
-/* When clicked or focused with keyboard */
-.gh-btn-green:active,
-.gh-btn-green:focus {
-    background: color-mod(var(--green) l(-9%) saturation(-9%));
-}
-.gh-btn-green:active span,
-.gh-btn-green:focus span {
-    background: color-mod(var(--green) l(-3%) saturation(-7%));
-    box-shadow: none;
-}
-
 
 /* Red button
 /* ---------------------------------------------------------- */
@@ -220,6 +182,44 @@ fieldset[disabled] .gh-btn {
 .gh-btn-red:active span,
 .gh-btn-red:focus span {
     background: color-mod(var(--red) l(-7%) saturation(-10%));
+    box-shadow: none;
+}
+
+/* Green button
+/* ---------------------------------------------------------- */
+
+/* The background of the button creates 1px gradient border */
+.gh-btn-green,
+.gh-btn-green:hover {
+    border: 1px solid color-mod(var(--green) s(-5%));
+    color: #fff;
+    fill: #fff;
+    box-shadow: none;
+    transition-property: box-shadow;
+}
+
+.gh-btn-green:hover {
+    box-shadow: none;
+}
+
+/* The background of the span is the main visual element */
+.gh-btn-green span {
+    background: linear-gradient(color-mod(var(--green) l(+6%) s(-2%)), color-mod(var(--green) l(-8%) s(+5%)));
+    font-weight: 500;
+}
+
+.gh-btn-green:hover span {
+    background: linear-gradient(color-mod(var(--green) l(+9%) s(-1%)), color-mod(var(--green) l(-3%) saturation(-3%)));
+}
+
+/* When clicked or focused with keyboard */
+.gh-btn-green:active,
+.gh-btn-green:focus {
+    background: color-mod(var(--green) l(-9%) saturation(-9%));
+}
+.gh-btn-green:active span,
+.gh-btn-green:focus span {
+    background: color-mod(var(--green) l(-3%) saturation(-7%));
     box-shadow: none;
 }
 

--- a/tests/acceptance/staff-test.js
+++ b/tests/acceptance/staff-test.js
@@ -522,7 +522,12 @@ describe('Acceptance: Staff', function () {
                 // Save changes
                 await click('[data-test-save-button]');
 
-                expect(find('[data-test-save-button]').textContent.trim(), 'save button text').to.equal('Saved');
+                // Since we reset save status so there's no on-screen indication
+                // that we've had a save, check the request was fired instead
+                let [lastRequest] = this.server.pretender.handledRequests.slice(-1);
+                let params = JSON.parse(lastRequest.requestBody);
+
+                expect(params.users[0].name).to.equal('Test User');
 
                 // CMD-S shortcut works
                 await fillIn('[data-test-slug-input]', 'Test User');
@@ -532,10 +537,10 @@ describe('Acceptance: Staff', function () {
                     ctrlKey: ctrlOrCmd === 'ctrl'
                 });
 
-                // we've already saved in this test so there's no on-screen indication
-                // that we've had another save, check the request was fired instead
-                let [lastRequest] = this.server.pretender.handledRequests.slice(-1);
-                let params = JSON.parse(lastRequest.requestBody);
+                // Since we reset save status so there's no on-screen indication
+                // that we've had a save, check the request was fired instead
+                [lastRequest] = this.server.pretender.handledRequests.slice(-1);
+                params = JSON.parse(lastRequest.requestBody);
 
                 expect(params.users[0].name).to.equal('Test User');
 


### PR DESCRIPTION
Closes https://github.com/TryGhost/Ghost/issues/11789

- By default, action buttons had auto-reset off and reset had to be explicitly set
- Auto reset for action buttons is on by default now, and any button that should not reset should explicitly switch it off