### PR TITLE
Refactored task buttons class handling

### DIFF
--- a/app/styles/patterns/buttons.css
+++ b/app/styles/patterns/buttons.css
@@ -141,6 +141,44 @@ fieldset[disabled] .gh-btn {
     box-shadow: none;
 }
 
+/* Green button
+/* ---------------------------------------------------------- */
+
+/* The background of the button creates 1px gradient border */
+.gh-btn-green,
+.gh-btn-green:hover {
+    border: 1px solid color-mod(var(--green) s(-5%));
+    color: #fff;
+    fill: #fff;
+    box-shadow: none;
+    transition-property: box-shadow;
+}
+
+.gh-btn-green:hover {
+    box-shadow: none;
+}
+
+/* The background of the span is the main visual element */
+.gh-btn-green span {
+    background: linear-gradient(color-mod(var(--green) l(+6%) s(-2%)), color-mod(var(--green) l(-8%) s(+5%)));
+    font-weight: 500;
+}
+
+.gh-btn-green:hover span {
+    background: linear-gradient(color-mod(var(--green) l(+9%) s(-1%)), color-mod(var(--green) l(-3%) saturation(-3%)));
+}
+
+/* When clicked or focused with keyboard */
+.gh-btn-green:active,
+.gh-btn-green:focus {
+    background: color-mod(var(--green) l(-9%) saturation(-9%));
+}
+.gh-btn-green:active span,
+.gh-btn-green:focus span {
+    background: color-mod(var(--green) l(-3%) saturation(-7%));
+    box-shadow: none;
+}
+
 
 /* Red button
 /* ---------------------------------------------------------- */
@@ -182,44 +220,6 @@ fieldset[disabled] .gh-btn {
 .gh-btn-red:active span,
 .gh-btn-red:focus span {
     background: color-mod(var(--red) l(-7%) saturation(-10%));
-    box-shadow: none;
-}
-
-/* Green button
-/* ---------------------------------------------------------- */
-
-/* The background of the button creates 1px gradient border */
-.gh-btn-green,
-.gh-btn-green:hover {
-    border: 1px solid color-mod(var(--green) s(-5%));
-    color: #fff;
-    fill: #fff;
-    box-shadow: none;
-    transition-property: box-shadow;
-}
-
-.gh-btn-green:hover {
-    box-shadow: none;
-}
-
-/* The background of the span is the main visual element */
-.gh-btn-green span {
-    background: linear-gradient(color-mod(var(--green) l(+6%) s(-2%)), color-mod(var(--green) l(-8%) s(+5%)));
-    font-weight: 500;
-}
-
-.gh-btn-green:hover span {
-    background: linear-gradient(color-mod(var(--green) l(+9%) s(-1%)), color-mod(var(--green) l(-3%) saturation(-3%)));
-}
-
-/* When clicked or focused with keyboard */
-.gh-btn-green:active,
-.gh-btn-green:focus {
-    background: color-mod(var(--green) l(-9%) saturation(-9%));
-}
-.gh-btn-green:active span,
-.gh-btn-green:focus span {
-    background: color-mod(var(--green) l(-3%) saturation(-7%));
     box-shadow: none;
 }
 

--- a/app/templates/staff/user.hbs
+++ b/app/templates/staff/user.hbs
@@ -338,7 +338,7 @@
                             </GhFormGroup>
 
                             <div class="form-group">
-                                <GhTaskButton @buttonText="Change Password" @class="gh-btn gh-btn-red gh-btn-icon button-change-password" @task={{this.user.saveNewPassword}} data-test-save-pw-button="true" />
+                                <GhTaskButton @buttonText="Change Password" @idleClass="gh-btn-red" @class="gh-btn gh-btn-icon button-change-password" @task={{this.user.saveNewPassword}} data-test-save-pw-button="true" />
                             </div>
                         </fieldset>
                     </div>


### PR DESCRIPTION
refs TryGhost/Ghost#11789
refs https://github.com/TryGhost/Ghost-Admin/commit/aaac4147456fbb2fe4bd1ab2decc0a8ee52b2fab

- Reverted aaac414 as we want to handle the state without relying on CSS specificity, handles properly using task button property
- Updates fix for change password button on staff user edit screen to use task button props instead

Cleanup for all task buttons to handle default button color using `idleClass` property is handled in separate commit.