### PR TITLE
🐛 Fixed staff profile editing incorrectly showing saved state

### DIFF
--- a/app/components/gh-task-button.js
+++ b/app/components/gh-task-button.js
@@ -59,9 +59,11 @@ const GhTaskButton = Component.extend({
     }),
 
     isRunning: computed('task.last.isRunning', 'hasRun', 'showSuccess', function () {
-        let isRunning = this.get('task.last.isRunning');
+        let taskName = this.get('task.name');
+        let lastTaskName = this.get('task.last.task.name');
 
-        if (this.hasRun && this.get('task.last.value') && !this.showSuccess) {
+        let isRunning = (taskName === lastTaskName) && this.get('task.last.isRunning');
+        if (this.hasRun && (taskName === lastTaskName) && this.get('task.last.value') && !this.showSuccess) {
             isRunning = true;
         }
 
@@ -73,12 +75,15 @@ const GhTaskButton = Component.extend({
     }),
 
     isSuccess: computed('hasRun', 'isRunning', 'task.last.value', function () {
+        let taskName = this.get('task.name');
+        let lastTaskName = this.get('task.last.task.name');
+
         if (!this.hasRun || this.isRunning || !this.showSuccess) {
             return false;
         }
 
         let value = this.get('task.last.value');
-        return !isBlank(value) && value !== false;
+        return (taskName === lastTaskName) && !isBlank(value) && value !== false;
     }),
 
     isSuccessClass: computed('isSuccess', function () {
@@ -86,11 +91,14 @@ const GhTaskButton = Component.extend({
     }),
 
     isFailure: computed('hasRun', 'isRunning', 'isSuccess', 'task.last.error', function () {
+        let taskName = this.get('task.name');
+        let lastTaskName = this.get('task.last.task.name');
+
         if (!this.hasRun || this.isRunning || this.isSuccess) {
             return false;
         }
 
-        return this.get('task.last.error') !== undefined;
+        return (taskName === lastTaskName) && this.get('task.last.error') !== undefined;
     }),
 
     isFailureClass: computed('isFailure', function () {


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/11866

Updating a slug on user profile triggers [`updateSlug`](https://github.com/TryGhost/Ghost-Admin/blob/28aa16f9a96b13bdcac116777e2be9b41b8ca437/app/controllers/staff/user.js#L369) task, which is in the [same task group](https://github.com/TryGhost/Ghost-Admin/blob/28aa16f9a96b13bdcac116777e2be9b41b8ca437/app/controllers/staff/user.js#L452) as `save` task which is tied to the Save button on page. Every-time `updateSlug` is called after editing a slug, it triggers the task button states causing the button to incorrectly show "Saving" -> "Saved" status change though no save action is called.

- Adds extra check to task button states if the last task ran was same as the current associated task
- In case of task groups, triggering one task in group also triggered states for other tasks in group
- Editing slug called `updateSlug` task which is part of the same task group as `save` task, which triggered the state for save button