### PR TITLE
✨ Added all/free/paid filter to members admin screen

### DIFF
--- a/app/components/gh-members-filter.hbs
+++ b/app/components/gh-members-filter.hbs
@@ -34,3 +34,20 @@
         </ul>
     </GhDropdown>
 </span>
+
+<div class="gh-contentfilter-menu {{if @selectedPaidParam.value "gh-contentfilter-selected"}}" data-test-select="paidParam">
+    <PowerSelect
+        @selected={{@selectedPaidParam}}
+        @options={{@availablePaidParams}}
+        @searchEnabled={{false}}
+        @onChange={{@onPaidParamChange}}
+        @triggerComponent="gh-power-select/trigger"
+        @triggerClass="gh-contentfilter-menu-trigger"
+        @dropdownClass="gh-contentfilter-menu-dropdown"
+        @searchPlaceholder="Search authors"
+        @matchTriggerWidth={{false}}
+        as |paidParam|
+    >
+        {{#if paidParam.name}}{{paidParam.name}}{{else}}<span class="red">Unknown paid status</span>{{/if}}
+    </PowerSelect>
+</div>

--- a/app/helpers/reset-query-params.js
+++ b/app/helpers/reset-query-params.js
@@ -17,6 +17,7 @@ export const DEFAULT_QUERY_PARAMS = {
     },
     'members.index': {
         label: null,
+        paid: null,
         search: ''
     }
 };

--- a/app/routes/members.js
+++ b/app/routes/members.js
@@ -6,7 +6,8 @@ export default class MembersRoute extends AuthenticatedRoute {
 
     queryParams = {
         label: {refreshModel: true},
-        searchParam: {refreshModel: true, replace: true}
+        searchParam: {refreshModel: true, replace: true},
+        paidParam: {refreshModel: true}
     };
 
     // redirect to posts screen if:

--- a/app/templates/members.hbs
+++ b/app/templates/members.hbs
@@ -8,6 +8,9 @@
                 @onLabelChange={{this.changeLabel}}
                 @onLabelAdd={{this.addLabel}}
                 @onLabelEdit={{this.editLabel}}
+                @selectedPaidParam={{this.selectedPaidParam}}
+                @availablePaidParams={{this.paidParams}}
+                @onPaidParamChange={{this.changePaidParam}}
             />
             <div class="relative gh-members-header-search">
                 {{svg-jar "search" class="gh-input-search-icon"}}


### PR DESCRIPTION
requires https://github.com/TryGhost/Ghost/pull/11892

- adds `?paid` query parameter to members route that is tied to the `?paid` query param in the API request
- added all/free/paid members dropdown to members filter component

TODO:
- [x] fix chart not taking paid filter into account
  - matched existing design where chart is hidden when a label or search filter is applied