### PR TITLE
Added tags sidebar navigation for editors

### DIFF
--- a/app/components/gh-nav-menu.hbs
+++ b/app/components/gh-nav-menu.hbs
@@ -66,7 +66,7 @@
                     <LinkTo @route="pages" data-test-nav="pages">{{svg-jar "page"}}Pages</LinkTo>
                 {{/if}}
             </li>
-            {{#if (gh-user-can-admin this.session.user)}}
+            {{#if this.showTagsNavigation}}
                 <li><LinkTo @route="tags" data-test-nav="tags">{{svg-jar "tag"}}Tags</LinkTo></li>
             {{/if}}
             {{#if (and this.feature.members (gh-user-can-admin this.session.user))}}

--- a/app/components/gh-nav-menu.js
+++ b/app/components/gh-nav-menu.js
@@ -2,7 +2,7 @@ import Component from '@ember/component';
 import ShortcutsMixin from 'ghost-admin/mixins/shortcuts';
 import calculatePosition from 'ember-basic-dropdown/utils/calculate-position';
 import ctrlOrCmd from 'ghost-admin/utils/ctrl-or-cmd';
-import {and, equal, match} from '@ember/object/computed';
+import {and, equal, match, or} from '@ember/object/computed';
 import {computed} from '@ember/object';
 import {getOwner} from '@ember/application';
 import {htmlSafe} from '@ember/string';
@@ -35,6 +35,7 @@ export default Component.extend(ShortcutsMixin, {
     // be a bug in Ember that's preventing it from working immediately after login
     isOnSite: equal('router.currentRouteName', 'site'),
 
+    showTagsNavigation: or('session.user.isOwnerOrAdmin', 'session.user.isEditor'),
     showMenuExtension: and('config.clientExtensions.menu', 'session.user.isOwner'),
     showDropdownExtension: and('config.clientExtensions.dropdown', 'session.user.isOwner'),
     showScriptExtension: and('config.clientExtensions.script', 'session.user.isOwner'),


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/11882

- Editors have all the same permissions and access to tags as Owner/Admin roles, but had the sidebar navigation for tags missing

- Adds "Tags" to sidebar for Editor roles as well