### PR TITLE
Fixed  #11814

### DIFF
--- a/app/styles/spirit/_koenig.css
+++ b/app/styles/spirit/_koenig.css
@@ -505,7 +505,7 @@
 .koenig-editor__editor code {
     border-radius: 2px;
     color: var(--darkgrey-d2);
-    font-size: 1.65rem;
+    font-size: .8em;
     line-height: 1em;
     padding: .4rem .4rem .2rem;
     vertical-align: middle;


### PR DESCRIPTION
Code tag within a heading in the editor ignores font-size fixed #11814.

https://github.com/TryGhost/Ghost/issues/11814

- [x] 🐛 Bug Fixed : replace font-size from rem to em (same size that is used in ghost).
