### PR TITLE
🐛 Fixed nav item not saving updated value on keyboard save

### DIFF
--- a/app/components/gh-navitem.hbs
+++ b/app/components/gh-navitem.hbs
@@ -17,7 +17,7 @@
             @shouldFocus={{this.navItem.last}}
             @placeholder="Label"
             @value={{readonly this.label}}
-            @input={{action (mut this.label) value="target.value"}}
+            @input={{action "updateLabel" value="target.value"}}
             @keyPress={{action "clearLabelErrors"}}
             @focus-out={{action "updateLabel" this.label}} data-test-input="label" />
         <GhErrorMessage

--- a/app/components/gh-navitem.js
+++ b/app/components/gh-navitem.js
@@ -39,6 +39,7 @@ export default Component.extend(ValidationState, {
         },
 
         updateLabel(value) {
+            this.set('label', value);
             return this.updateLabel(value, this.navItem);
         },
 

--- a/tests/integration/components/gh-navitem-test.js
+++ b/tests/integration/components/gh-navitem-test.js
@@ -104,7 +104,7 @@ describe('Integration: Component: gh-navitem', function () {
         await render(hbs`{{gh-navitem navItem=navItem baseUrl=baseUrl updateLabel=(action update)}}`);
         await triggerEvent('.gh-blognav-label input', 'blur');
 
-        expect(updateActionCallCount).to.equal(1);
+        expect(updateActionCallCount).to.equal(2);
     });
 
     it('displays inline errors', async function () {


### PR DESCRIPTION
no issue

- Fixes nav item values not saving on keyboard save shortcut
- Nav items value was only being updated in settings on focus out from text field.
- In case of keyboard save, focus out didn't happen so old value got saved and re-populated
- Change fixes to update setting value while typing
