### PR TITLE
🐛 Fixed social settings not saved on keyboard shortcut

### DIFF
--- a/app/controllers/settings/general.js
+++ b/app/controllers/settings/general.js
@@ -8,7 +8,6 @@ import {
     IMAGE_MIME_TYPES
 } from 'ghost-admin/components/gh-image-uploader';
 import {computed} from '@ember/object';
-import {run} from '@ember/runloop';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 
@@ -147,7 +146,7 @@ export default Controller.extend({
             return transition.retry();
         },
 
-        validateFacebookUrl(skipRenderLoop) {
+        validateFacebookUrl() {
             let newUrl = this._scratchFacebook;
             let oldUrl = this.get('settings.facebook');
             let errMessage = '';
@@ -185,17 +184,8 @@ export default Controller.extend({
                     throw 'invalid url';
                 }
 
-                this.set('settings.facebook', '');
-                if (skipRenderLoop) {
-                    this.set('settings.facebook', newUrl);
-                } else {
-                    run.schedule('afterRender', this, function () {
-                        this.set('settings.facebook', newUrl);
-                    });
-                }
-                run.schedule('afterRender', this, function () {
-                    this.set('settings.facebook', newUrl);
-                });
+                this.settings.set('facebook', newUrl);
+                this.settings.notifyPropertyChange('facebook');
             } catch (e) {
                 if (e === 'invalid url') {
                     errMessage = 'The URL must be in a format like '
@@ -210,7 +200,7 @@ export default Controller.extend({
             }
         },
 
-        validateTwitterUrl(skipRenderLoop) {
+        validateTwitterUrl() {
             let newUrl = this._scratchTwitter;
             let oldUrl = this.get('settings.twitter');
             let errMessage = '';
@@ -250,16 +240,9 @@ export default Controller.extend({
 
                 newUrl = `https://twitter.com/${username}`;
 
-                this.get('settings.hasValidated').pushObject('twitter');
-
-                this.set('settings.twitter', '');
-                if (skipRenderLoop) {
-                    this.set('settings.twitter', newUrl);
-                } else {
-                    run.schedule('afterRender', this, function () {
-                        this.set('settings.twitter', newUrl);
-                    });
-                }
+                this.settings.get('hasValidated').pushObject('twitter');
+                this.settings.set('twitter', newUrl);
+                this.settings.notifyPropertyChange('twitter');
             } else {
                 errMessage = 'The URL must be in a format like '
                            + 'https://twitter.com/yourUsername';
@@ -287,11 +270,11 @@ export default Controller.extend({
         let config = this.config;
 
         if (this.settings.get('twitter') !== this._scratchTwitter) {
-            this.send('validateTwitterUrl', true);
+            this.send('validateTwitterUrl');
         }
 
         if (this.settings.get('facebook') !== this._scratchFacebook) {
-            this.send('validateFacebookUrl', true);
+            this.send('validateFacebookUrl');
         }
 
         try {


### PR DESCRIPTION
no issue

- Social account(twitter/facebook) values in general settings were only updated to settings upstream on focus out
- Keyboard shortcut save (Cmd/Ctr + S) doesn't trigger focus out event so values were not getting updated
- Updates save task to use new twitter/facebook values if changed on all save
