### PR TITLE
Added custom error message handling for newsletter email failures

### DIFF
--- a/app/components/gh-post-settings-menu/email.hbs
+++ b/app/components/gh-post-settings-menu/email.hbs
@@ -22,11 +22,11 @@
                     <tbody>
                         <tr>
                             <td class="pa1 pl0 fw7 f8 w16 v-top lh-copy">Subject:</td>
-                            <td class="pa1 pa0 word-wrap midgrey v-top lh-copy">{{this.post.email.subject}}</td>
+                            <td class="pa1 pa0 midgrey v-top lh-copy">{{this.post.email.subject}}</td>
                         </tr>
                         <tr>
                             <td class="pa1 pl0 fw7 f8 w16 nowrap v-top lh-copy">Sent:</td>
-                            <td class="pa1 pa0 word-wrap midgrey v-top lh-copy">{{gh-format-post-time this.post.email.createdAtUTC}}</td>
+                            <td class="pa1 pa0 midgrey v-top lh-copy">{{gh-format-post-time this.post.email.createdAtUTC}}</td>
                         </tr>
                     </tbody>
                 </table>
@@ -61,7 +61,7 @@
                         <tbody>
                             <tr>
                                 <td class="pa1 pl0 fw7 f8 w16 v-top lh-copy">Error:</td>
-                                <td class="pa1 pl0 word-wrap midgrey v-top lh-copy">{{this.post.email.error}}</td>
+                                <td class="pa1 pl0 midgrey v-top lh-copy">{{this.post.email.error}}</td>
                             </tr>
                         </tbody>
                     </table>

--- a/app/components/gh-post-settings-menu/email.js
+++ b/app/components/gh-post-settings-menu/email.js
@@ -4,6 +4,7 @@ import validator from 'validator';
 import {action} from '@ember/object';
 import {alias, not, oneWay, or} from '@ember/object/computed';
 import {computed} from '@ember/object';
+import {htmlSafe} from '@ember/string';
 import {inject as service} from '@ember/service';
 import {task, timeout} from 'ember-concurrency';
 
@@ -91,7 +92,16 @@ export default Component.extend({
             return yield this.ajax.post(url, options);
         } catch (error) {
             if (error) {
-                this.set('sendTestEmailError', 'Email could not be sent, verify mail settings');
+                let message = 'Email could not be sent, verify mail settings';
+
+                // grab custom error message if present
+                if (
+                    error.payload && error.payload.errors
+                    && error.payload.errors[0] && error.payload.errors[0].message) {
+                    message = htmlSafe(error.payload.errors[0].message);
+                }
+
+                this.set('sendTestEmailError', message);
             }
         }
     }).drop(),

--- a/app/services/ajax.js
+++ b/app/services/ajax.js
@@ -128,6 +128,20 @@ export function isHostLimitError(errorOrStatus, payload) {
     }
 }
 
+export class EmailError extends AjaxError {
+    constructor(payload) {
+        super(payload, 'Please verify your email settings');
+    }
+}
+
+export function isEmailError(errorOrStatus, payload) {
+    if (isAjaxError(errorOrStatus)) {
+        return errorOrStatus instanceof EmailError;
+    } else {
+        return get(payload || {}, 'errors.firstObject.type') === 'EmailError';
+    }
+}
+
 /* end: custom error types */
 
 let ajaxService = AjaxService.extend({
@@ -182,6 +196,8 @@ let ajaxService = AjaxService.extend({
             return new ThemeValidationError(payload);
         } else if (this.isHostLimitError(status, headers, payload)) {
             return new HostLimitError(payload);
+        } else if (this.isEmailError(status, headers, payload)) {
+            return new EmailError(payload);
         }
 
         let isGhostRequest = GHOST_REQUEST.test(request.url);
@@ -244,6 +260,10 @@ let ajaxService = AjaxService.extend({
 
     isHostLimitError(status, headers, payload) {
         return isHostLimitError(status, payload);
+    },
+
+    isEmailError(status, headers, payload) {
+        return isEmailError(status, payload);
     }
 });
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/11971

- Newsletter preview email request has been using hardcoded fixed error message
- Reads custom error message from server's API response to show when available
