### PR TITLE
startDateLabel populated

### DIFF
--- a/app/components/gh-members-chart.js
+++ b/app/components/gh-members-chart.js
@@ -18,13 +18,13 @@ export default Component.extend({
     stats: null,
     chartData: null,
     chartOptions: null,
-    startDateLabel: '',
-
     selectedRange: computed('membersStats.days', function () {
         const availableRanges = this.availableRanges;
         return availableRanges.findBy('days', this.membersStats.days);
     }),
-
+    startDateLabel: computed('membersStats.days', function(){
+        return moment(new Date()).add(-this.membersStats.days+1,'days').format(DATE_FORMAT);
+    }),
     availableRanges: computed(function () {
         return [{
             name: '30 days',


### PR DESCRIPTION
closes #012014

-startDateLabel calculated with moment and substract selectedRange from today.

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `ember test` from the repo root - will be `core/client` if working from the submodule in Ghost).
