### PR TITLE
startDateLabel populated

### DIFF
--- a/app/components/gh-members-chart.js
+++ b/app/components/gh-members-chart.js
@@ -18,7 +18,9 @@ export default Component.extend({
     stats: null,
     chartData: null,
     chartOptions: null,
-    startDateLabel: '',
+    startDateLabel: computed('membersStats.days', function () {
+        return moment(new Date()).add(- this.membersStats.days + 1, 'days').format(DATE_FORMAT);
+    }),
 
     selectedRange: computed('membersStats.days', function () {
         const availableRanges = this.availableRanges;

--- a/app/components/gh-members-chart.js
+++ b/app/components/gh-members-chart.js
@@ -18,8 +18,14 @@ export default Component.extend({
     stats: null,
     chartData: null,
     chartOptions: null,
-    startDateLabel: computed('membersStats.days', function () {
-        return moment(new Date()).add(-this.membersStats.days + 1, 'days').format(DATE_FORMAT);
+
+    startDateLabel: computed('membersStats.stats', function () {
+        if (!this.membersStats?.stats?.total_on_date) {
+            return '';
+        }
+
+        let firstDate = Object.keys(this.membersStats.stats.total_on_date)[0];
+        return moment(firstDate).format(DATE_FORMAT);
     }),
 
     selectedRange: computed('membersStats.days', function () {

--- a/app/components/gh-members-chart.js
+++ b/app/components/gh-members-chart.js
@@ -19,7 +19,7 @@ export default Component.extend({
     chartData: null,
     chartOptions: null,
     startDateLabel: computed('membersStats.days', function () {
-        return moment(new Date()).add(- this.membersStats.days + 1, 'days').format(DATE_FORMAT);
+        return moment(new Date()).add(-this.membersStats.days + 1, 'days').format(DATE_FORMAT);
     }),
 
     selectedRange: computed('membersStats.days', function () {


### PR DESCRIPTION
closes #[12014](https://github.com/TryGhost/Ghost/issues/12014)

-startDateLabel variable populated in order to show start date for the members chart.

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `ember test` from the repo root - will be `core/client` if working from the submodule in Ghost).

More info can be found by clicking the "guidelines for contributing" link above.
