### PR TITLE
Updated delete member UI to add toggle to cancel subscriptions

### DIFF
--- a/app/adapters/base.js
+++ b/app/adapters/base.js
@@ -28,11 +28,12 @@ export default RESTAdapter.extend(DataAdapterMixin, AjaxServiceSupport, {
     buildURL() {
         // Ensure trailing slashes
         let url = this._super(...arguments);
+        let parsedUrl = new URL(url);
 
-        if (url.slice(-1) !== '/') {
-            url += '/';
+        if (!parsedUrl.pathname.endsWith('/')) {
+            parsedUrl.pathname += '/';
         }
 
-        return url;
+        return parsedUrl.toString();
     }
 });

--- a/app/adapters/member.js
+++ b/app/adapters/member.js
@@ -1,0 +1,14 @@
+import ApplicationAdapter from 'ghost-admin/adapters/application';
+
+export default ApplicationAdapter.extend({
+    urlForDeleteRecord(id, modelName, snapshot) {
+        let url = this._super(...arguments);
+        let parsedUrl = new URL(url);
+
+        if (snapshot && snapshot.adapterOptions && snapshot.adapterOptions.cancel) {
+            parsedUrl.searchParams.set('cancel', 'true');
+        }
+
+        return parsedUrl.toString();
+    }
+});

--- a/app/components/modal-delete-member.hbs
+++ b/app/components/modal-delete-member.hbs
@@ -7,6 +7,21 @@
     <p>
         You're about to delete "<strong>{{or this.member.name this.member.email}}</strong>". This is permanent! We warned you, k?
     </p>
+
+    {{#if this.hasActiveStripeSubscriptions}}
+        <div class="flex justify-between">
+            <div>
+                <h4>Cancel Stripe subscription</h4>
+                <p class="pa0 ma0">If disabled, member's Stripe subscription will continue</p>
+            </div>
+            <div class="for-switch">
+                <label class="switch" >
+                    <input type="checkbox" checked={{this.cancelSubscriptions}} class="gh-input" onclick={{action "toggleCancelSubscriptions"}}>
+                    <span class="input-toggle-component mt1"></span>
+                </label>
+            </div>
+        </div>
+    {{/if}}
 </div>
 
 <div class="modal-footer">

--- a/app/components/modal-delete-member.hbs
+++ b/app/components/modal-delete-member.hbs
@@ -15,8 +15,13 @@
                 <p class="pa0 ma0">If disabled, member's Stripe subscription will continue</p>
             </div>
             <div class="for-switch">
-                <label class="switch" >
-                    <input type="checkbox" checked={{this.cancelSubscriptions}} class="gh-input" onclick={{action "toggleCancelSubscriptions"}}>
+                <label class="switch">
+                    <input
+                        class="gh-input"
+                        type="checkbox"
+                        checked={{this.shouldCancelSubscriptions}}
+                        {{on "click" (action "toggleShouldCancelSubscriptions")}}
+                    />
                     <span class="input-toggle-component mt1"></span>
                 </label>
             </div>

--- a/app/components/modal-delete-member.js
+++ b/app/components/modal-delete-member.js
@@ -7,7 +7,7 @@ import {task} from 'ember-concurrency';
 export default ModalComponent.extend({
     membersStats: service(),
 
-    cancelSubscriptions: false,
+    shouldCancelSubscriptions: false,
 
     // Allowed actions
     confirm: () => {},
@@ -33,14 +33,14 @@ export default ModalComponent.extend({
             this.deleteMember.perform();
         },
 
-        toggleCancelSubscriptions() {
-            this.cancelSubscriptions = !this.cancelSubscriptions;
+        toggleShouldCancelSubscriptions() {
+            this.shouldCancelSubscriptions = !this.shouldCancelSubscriptions;
         }
     },
 
     deleteMember: task(function* () {
         try {
-            yield this.confirm(this.cancelSubscriptions);
+            yield this.confirm(this.shouldCancelSubscriptions);
             this.membersStats.invalidate();
         } finally {
             this.send('closeModal');

--- a/app/components/modal-delete-member.js
+++ b/app/components/modal-delete-member.js
@@ -1,25 +1,46 @@
 import ModalComponent from 'ghost-admin/components/modal-base';
 import {alias} from '@ember/object/computed';
+import {computed} from '@ember/object';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 
 export default ModalComponent.extend({
     membersStats: service(),
 
+    cancelSubscriptions: false,
+
     // Allowed actions
     confirm: () => {},
 
     member: alias('model'),
 
+    hasActiveStripeSubscriptions: computed('member', function () {
+        let subscriptions = this.member.get('stripe');
+
+        if (!subscriptions || subscriptions.length === 0) {
+            return false;
+        }
+
+        let firstActiveStripeSubscription = subscriptions.find((subscription) => {
+            return subscription.status === 'active' || subscription.status === 'trialing';
+        });
+
+        return firstActiveStripeSubscription !== undefined;
+    }),
+
     actions: {
         confirm() {
             this.deleteMember.perform();
+        },
+
+        toggleCancelSubscriptions() {
+            this.cancelSubscriptions = !this.cancelSubscriptions;
         }
     },
 
     deleteMember: task(function* () {
         try {
-            yield this.confirm();
+            yield this.confirm(this.cancelSubscriptions);
             this.membersStats.invalidate();
         } finally {
             this.send('closeModal');

--- a/app/controllers/member.js
+++ b/app/controllers/member.js
@@ -65,8 +65,13 @@ export default class MemberController extends Controller {
     }
 
     @action
-    deleteMember() {
-        return this.member.destroyRecord().then(() => {
+    deleteMember(cancelSubscriptions = false) {
+        let options = {
+            adapterOptions: {
+                cancel: cancelSubscriptions
+            }
+        };
+        return this.member.destroyRecord(options).then(() => {
             this.members.refreshData();
             return this.transitionToRoute('members');
         }, (error) => {


### PR DESCRIPTION
no-issue

This adds a new adapter for the member model so we can (optionally) add a `cancel` query parameter to the DELETE URL for members

Also updates the delete member modal to include a conditionally (based on active subscriptions) displayed toggle to enable/disable the `cancel` query parameter. 