### PR TITLE
Removed accent color from general settings

### DIFF
--- a/app/controllers/settings/general.js
+++ b/app/controllers/settings/general.js
@@ -8,7 +8,6 @@ import {
     IMAGE_MIME_TYPES
 } from 'ghost-admin/components/gh-image-uploader';
 import {computed} from '@ember/object';
-import {htmlSafe} from '@ember/string';
 import {run} from '@ember/runloop';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
@@ -48,19 +47,6 @@ export default Controller.extend({
         let publicHash = this.get('settings.publicHash');
 
         return `${blogUrl}/${publicHash}/rss`;
-    }),
-
-    backgroundStyle: computed('settings.accentColor', function () {
-        let color = this.get('settings.accentColor') || '#ffffff';
-        return htmlSafe(`background-color: ${color}`);
-    }),
-
-    accentColor: computed('settings.accentColor', function () {
-        let color = this.get('settings.accentColor');
-        if (color && color[0] === '#') {
-            return color.slice(1);
-        }
-        return color;
     }),
 
     actions: {
@@ -268,43 +254,6 @@ export default Controller.extend({
                            + 'https://twitter.com/yourUsername';
                 this.get('settings.errors').add('twitter', errMessage);
                 this.get('settings.hasValidated').pushObject('twitter');
-                return;
-            }
-        },
-
-        validateAccentColor() {
-            let newColor = this.get('accentColor');
-            let oldColor = this.get('settings.accentColor');
-            let errMessage = '';
-
-            // reset errors and validation
-            this.get('settings.errors').remove('accentColor');
-            this.get('settings.hasValidated').removeObject('accentColor');
-
-            if (newColor === '') {
-                // Clear out the accent color
-                this.set('settings.accentColor', '');
-                return;
-            }
-
-            // accentColor will be null unless the user has input something
-            if (!newColor) {
-                newColor = oldColor;
-            }
-
-            if (newColor[0] !== '#') {
-                newColor = `#${newColor}`;
-            }
-
-            if (newColor.match(/#[0-9A-Fa-f]{6}$/)) {
-                this.set('settings.accentColor', '');
-                run.schedule('afterRender', this, function () {
-                    this.set('settings.accentColor', newColor);
-                });
-            } else {
-                errMessage = 'The color should be in valid hex format';
-                this.get('settings.errors').add('accentColor', errMessage);
-                this.get('settings.hasValidated').pushObject('accentColor');
                 return;
             }
         }

--- a/app/templates/settings/general.hbs
+++ b/app/templates/settings/general.hbs
@@ -99,32 +99,7 @@
 
         <div class="gh-setting-header">Publication identity</div>
         <div class="flex flex-column br3 shadow-1 bg-grouped-table pa5">
-            {{#if this.config.enableDeveloperExperiments}}
-                <div class="gh-setting-first" data-test-setting="accent-color">
-                    <div class="gh-setting-content">
-                        <div class="gh-setting-title">Accent Color</div>
-                        <div class="gh-setting-desc">Primary color used in your publication theme</div>
-                    </div>
-                    <div class="gh-setting-action">
-                        <GhFormGroup @errors={{settings.errors}} @hasValidated={{settings.hasValidated}} @property="accentColor" @class="input-color-form-group">
-                            <div class="input-color">
-                                <GhTextInput
-                                    @name="accent-color"
-                                    @placeholder="abcdef"
-                                    @autocorrect="off"
-                                    @maxlength="6"
-                                    @focus-out={{action "validateAccentColor"}}
-                                    @value={{accentColor}}
-                                    data-test-input="accentColor"
-                                />
-                                <div class="color-box" style={{this.backgroundStyle}}></div>
-                            </div>
-                            <GhErrorMessage @errors={{settings.errors}} @property="accentColor" data-test-error="accentColor" />
-                        </GhFormGroup>
-                    </div>
-                </div>
-            {{/if}}
-            <div class="{{if this.config.enableDeveloperExperiments "gh-setting" "gh-setting-first"}}" data-test-setting="icon">
+            <div class="gh-setting-first" data-test-setting="icon">
                 <GhUploader
                     @extensions={{this.iconExtensions}}
                     @paramsHash={{hash purpose="icon"}}


### PR DESCRIPTION
no issue

- Accent color setting was behind dev flag on General settings screen
- Its now moved inside Portal settings where its primarily being used
- This change removes it from general settings screen so its only on Portal settings
