### PR TITLE
✨Added bulk delete of filtered members list in admin

### DIFF
--- a/app/components/gh-members-filter.hbs
+++ b/app/components/gh-members-filter.hbs
@@ -1,22 +1,28 @@
 <span class="dropdown dropdown-topmenu">
     <GhDropdownButton
         @dropdownName="members-label-menu"
-        @classNames="gh-btn gh-btn-white gh-btn-filter first" @title="Member Labels"
-        @data-test-user-actions="true">
-        <span class="nudge-bottom--1 {{if @selectedLabel.slug "blue fw6"}} gh-btn-filter-maxwidth" title="{{@selectedLabel.name}}">
+        @classNames="gh-btn gh-btn-white gh-btn-filter first"
+        @title="Member Labels"
+    >
+        <span class="nudge-bottom--1 {{if @selectedLabel.slug "blue fw6"}} gh-btn-filter-maxwidth" title="{{@selectedLabel.name}}" data-test-dropdown="label-filter">
             <span>{{@selectedLabel.name}}</span>
             {{svg-jar "arrow-down-stroke" class="w2 h2 stroke-midgrey ml1"}}
         </span>
     </GhDropdownButton>
-    <GhDropdown @name="members-label-menu" @tagName="div"
-        @classNames="dropdown-menu dropdown-triangle-top-right dropdown-action">
+    <GhDropdown
+        @name="members-label-menu"
+        @tagName="div"
+        @classNames="dropdown-menu dropdown-triangle-top-right dropdown-action"
+    >
         <ul class="dropdown-content">
             {{#each @availableLabels as |label|}}
                 <li class="{{if (eq @selectedLabel.name label.name) "selected"}}">
                     <a>
-                        <span class="dropdown-label" title="{{label.name}}" {{on "click" (fn @onLabelChange label)}}>{{label.name}} </span>
+                        <span class="dropdown-label" title="{{label.name}}" {{on "click" (fn @onLabelChange label)}} data-test-label-filter={{label.slug}}>
+                            {{label.name}}
+                        </span>
                         {{#if label.slug}}
-                            <span class="dropdown-action-icon" {{on "click" (fn @onLabelEdit label.slug)}}> {{svg-jar "pen"}} </span>
+                            <span class="dropdown-action-icon" {{on "click" (fn @onLabelEdit label.slug)}} data-test-edit-label={{label.slug}}> {{svg-jar "pen"}} </span>
                         {{/if}}
                     </a>
                 </li>

--- a/app/components/gh-publishmenu-draft.hbs
+++ b/app/components/gh-publishmenu-draft.hbs
@@ -29,7 +29,7 @@
         </div>
     </div>
 
-    {{#if (and this.canSendEmail showSendEmail)}}
+    {{#if (and this.canSendEmail this.showSendEmail)}}
         <div class="gh-publishmenu-section">
             <div class="gh-publishmenu-radio gh-publishmenu-email">
                 {{#if this.backgroundLoader.isRunning}}

--- a/app/components/modal-delete-members.hbs
+++ b/app/components/modal-delete-members.hbs
@@ -1,15 +1,28 @@
 <header class="modal-header" data-test-modal="delete-members">
-    <h1>Are you sure you want to delete these members?</h1>
+    <h1>Are you sure?</h1>
 </header>
 <a class="close" href="" role="button" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
 
-{{#if (not this.confirmed)}}
-    <div class="modal-body" data-test-state="delete-unconfirmed">
-        <p>
-            You're about to delete
-            <strong data-test-text="delete-count">{{pluralize this.model.memberCount "member"}}</strong>.
-            This is permanent! We warned you, k?
-        </p>
+{{#if (not this.completed)}}
+    <div class="modal-body" data-test-state="delete-incomplete" {{did-insert (action "countPaidMembers")}}>
+        {{#if this.countPaidMembersTask.isRunning}}
+            <div class="flex flex-column items-center">
+                <div class="gh-loading-spinner"></div>
+            </div>
+        {{else}}
+            <p data-test-text="delete-confirmation">
+                {{#if this.paidMemberCount}}
+                    <strong>{{pluralize this.paidMemberCount "member"}}</strong>
+                    {{if (eq this.paidMemberCount 1) "has" "have"}} an active Stripe subscription.
+                    Deleting from Ghost <strong>will not cancel their subscription in Stripe</strong>,
+                    you have to do that manually in Stripe.
+                {{else}}
+                    You're about to delete
+                    <strong data-test-text="delete-count">{{gh-pluralize this.model.memberCount "member"}}</strong>.
+                    This is permanent! We warned you, k?
+                {{/if}}
+            </p>
+        {{/if}}
     </div>
 {{else}}
     <div class="modal-body bg-whitegray-l2 ba b--whitegrey br3 pa4" data-test-state="delete-complete">
@@ -23,24 +36,30 @@
                 </div>
             </div>
         {{else}}
-            <div class="flex items-center">
-                {{svg-jar "check-circle" class="w4 h4 stroke-green mr2"}}
-                <p class="ma0 pa0">
-                    <span class="fw6" data-test-text="deleted-count">{{pluralize this.response.deleted.count "member"}}</span>
-                    deleted
-                </p>
+            <div class="ba b--whitegrey br3 middarkgrey bg-whitegrey-l2">
+                <div class="flex items-start">
+                    <div class="w-50 gh-member-import-result-summary">
+                        <h2 data-test-text="delete-count">{{format-number this.response.deleted.count}}</h2>
+                        <p>{{gh-pluralize this.response.deleted.count "Member" without-count=true}} deleted</p>
+                    </div>
+                    <div class="bl b--whitegrey w-50 gh-member-import-result-summary">
+                        <h2 data-test-text="invalid-count">{{format-number this.response.invalid.count}}</h2>
+                        <p>{{gh-pluralize this.response.invalid.count "Error" without-count=true}}</p>
+                    </div>
+                </div>
             </div>
             {{#if this.response.invalid.count}}
-                <div class="flex items-start mt2" data-test-bulk-delete-errors>
-                    {{svg-jar "warning" class="w4 h4 fill-red mr2 nudge-top--3"}}
-                    <div>
-                        <p class="ma0 pa0">
-                            <span class="fw5" data-test-text="invalid-count">{{pluralize this.response.invalid.count "member"}}</span>
-                            skipped
-                        </p>
-                        {{#each this.response.invalid.errors as |error|}}
-                            <p class="gh-members-import-errordetail">{{error.message}} <span class="fw6">{{error.count}}</span></p>
-                        {{/each}}
+                <div class="mt6 gh-members-upload-errorcontainer error" data-test-bulk-delete-errors>
+                    <div class="flex items-start">
+                        {{svg-jar "warning" class="w5 h5 fill-red nudge-top--3 mr3"}}
+                        <div class="flex-grow w-100">
+                            <p class="ma0 pa0">{{format-number this.response.invalid.count}} {{pluralize this.response.invalid.count "member" without-count=true}} were skipped due to the following errors:</p>
+                            <ul class="ma0 pa0 mt4 list bt b--whitegrey">
+                            {{#each this.response.invalid.errors as |error|}}
+                                <li class="gh-members-import-errormessage" data-test-delete-error>{{error.message}} <span class="fw4">({{format-number error.count}})</span></li>
+                            {{/each}}
+                            </ul>
+                        </div>
                     </div>
                 </div>
             {{/if}}
@@ -49,12 +68,13 @@
 {{/if}}
 
 <div class="modal-footer">
-    {{#if (not this.confirmed)}}
+    {{#if (not this.completed)}}
         <button {{action "closeModal"}} class="gh-btn" data-test-button="cancel">
             <span>Cancel</span>
         </button>
 
         <GhTaskButton
+            @disabled={{this.countPaidMembersTask.isRunning}}
             @buttonText="Delete"
             @successText="Deleted"
             @task={{this.deleteMembersTask}}

--- a/app/components/modal-delete-members.hbs
+++ b/app/components/modal-delete-members.hbs
@@ -1,5 +1,5 @@
 <header class="modal-header" data-test-modal="delete-members">
-    <h1>Are you sure?</h1>
+    <h1>Bulk delete members</h1>
 </header>
 <a class="close" href="" role="button" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span class="hidden">Close</span></a>
 
@@ -10,18 +10,18 @@
                 <div class="gh-loading-spinner"></div>
             </div>
         {{else}}
+        {{#if this.paidMemberCount}}
             <p data-test-text="delete-confirmation">
-                {{#if this.paidMemberCount}}
-                    <strong>{{pluralize this.paidMemberCount "member"}}</strong>
-                    {{if (eq this.paidMemberCount 1) "has" "have"}} an active Stripe subscription.
-                    Deleting from Ghost <strong>will not cancel their subscription in Stripe</strong>,
-                    you have to do that manually in Stripe.
-                {{else}}
-                    You're about to delete
-                    <strong data-test-text="delete-count">{{gh-pluralize this.model.memberCount "member"}}</strong>.
-                    This is permanent! We warned you, k?
-                {{/if}}
+                This will delete <strong data-test-text="delete-count">{{gh-pluralize this.model.memberCount "member account"}}</strong> from Ghost. You can re-import them again later, if needed, as long as you have a backup of their details.
             </p>
+            <p>
+                Active subscriptions in Stripe will <strong>not be changed</strong> in any way, this action will only remove member accounts from Ghost.
+            </p>
+        {{else}}
+            <p data-test-text="delete-confirmation">
+                This will delete <strong data-test-text="delete-count">{{gh-pluralize this.model.memberCount "member account"}}</strong> from Ghost. You can re-import them again later, if needed, as long as you have a backup of their details.
+            </p>
+        {{/if}}
         {{/if}}
     </div>
 {{else}}
@@ -75,7 +75,7 @@
 
         <GhTaskButton
             @disabled={{this.countPaidMembersTask.isRunning}}
-            @buttonText="Delete"
+            @buttonText="Delete {{gh-pluralize this.model.memberCount "member"}}"
             @successText="Deleted"
             @task={{this.deleteMembersTask}}
             @class="gh-btn gh-btn-red gh-btn-icon"

--- a/app/controllers/members.js
+++ b/app/controllers/members.js
@@ -85,11 +85,7 @@ export default class MembersController extends Controller {
         let count = `${formatNumber(members.length)} ${pluralize(members.length, 'member', {withoutCount: true})}`;
 
         if (selectedLabel && selectedLabel.slug) {
-            if (members.length > 1) {
-                return `${count} match current filter`;
-            } else {
-                return `${count} matches current filter`;
-            }
+            return `${count}`;
         }
 
         return count;

--- a/app/helpers/gh-pluralize.js
+++ b/app/helpers/gh-pluralize.js
@@ -1,0 +1,16 @@
+import {formatNumber} from './format-number';
+import {helper} from '@ember/component/helper';
+import {pluralize} from 'ember-inflector';
+
+// like {{pluralize}} but formats the number according to current locale
+export default helper(function ([number, word], {'without-count': withoutCount}) {
+    let output = [];
+
+    if (withoutCount !== true) {
+        output.push(formatNumber(number));
+    }
+
+    output.push(pluralize(number, word, {withoutCount: true}));
+
+    return output.join(' ');
+});

--- a/app/styles/components/lists.css
+++ b/app/styles/components/lists.css
@@ -294,3 +294,46 @@
     height: 9px;
     margin-top: 8px;
 }
+
+.gh-list-header-actioncontainer {
+    display: flex;
+    align-items: center;
+}
+
+.gh-list-actions {
+    display: flex;
+    align-items: center;
+}
+
+.gh-list-action-divider {
+    display: inline-block;
+    border-left: 1px solid var(--lightgrey-d1);
+    height: 24px;
+    margin: 0 12px;
+}
+
+.gh-list-actions button {
+    height: 26px;
+    line-height: 25px;
+    border: 1px solid var(--lightgrey);
+    background: var(--white);
+    outline: none;
+    transition-property: all;
+}
+
+.gh-list-actions button:hover {
+    outline: none;
+    border-color: 1px solid var(--lightgrey-d2);
+    transition-property: all;
+}
+
+.gh-list-actions button span {
+    height: 24px;
+    line-height: 23px;
+}
+
+.gh-list-actions .gh-btn-red span {
+    background: var(--white);
+    color: var(--red);
+    font-weight: 500;
+}

--- a/app/styles/layouts/members.css
+++ b/app/styles/layouts/members.css
@@ -256,8 +256,23 @@ p.gh-members-list-email {
 }
 
 @media (max-width: 900px) {
-    .members-list .gh-list-header, .gh-list-hidecell-m {
+    .members-list .gh-list-row.header {
+        display: flex;
+        background: var(--whitegrey-l2);
+        border-bottom: 1px solid var(--lightgrey);
+        border-top-left-radius: 5px;
+        border-top-right-radius: 5px;
+        margin-bottom: 0;
+    }
+
+    .members-list .gh-list-header:not(:first-of-type) {
         display: none;
+    }
+
+    .members-list .gh-list-header, .gh-list-hidecell-m {
+        display: block;
+        background: none;
+        border-bottom: none;
     }
 
     .gh-members-list-item {

--- a/app/styles/patterns/buttons.css
+++ b/app/styles/patterns/buttons.css
@@ -408,6 +408,11 @@ svg.gh-btn-icon-right {
     color: var(--red);
 }
 
+.gh-btn-red-hover:hover {
+    color: var(--red);
+    border-color: var(--red);
+}
+
 
 /*
 /* Button Variations

--- a/app/templates/members.hbs
+++ b/app/templates/members.hbs
@@ -60,7 +60,16 @@
                 <ol class="members-list gh-list {{unless this.members "no-posts"}}">
                     {{#if this.members}}
                         <li class="gh-list-row header relative">
-                            <div class="gh-list-header" data-test-list-header>{{this.listHeader}}</div>
+                            <div class="gh-list-header" data-test-list-header>
+                                {{this.listHeaderText}}
+                                {{#if this.config.enableDeveloperExperiments}}
+                                {{#if this.canBulkDelete}}
+                                    <button class="gh-btn gh-btn-red" {{on "click" this.toggleDeleteMembersModal}} data-test-button="bulk-delete">
+                                        <span style="height: 20px; line-height: 20px; padding: 0 6px">Delete</span>
+                                    </button>
+                                {{/if}}
+                                {{/if}}
+                            </div>
                             <div class="gh-list-header gh-members-list-geolocation gh-list-cellwidth-20 nowrap">Location</div>
                             <div class="gh-list-header gh-members-list-subscribed-at gh-list-cellwidth-20 nowrap">Created</div>
                             <div class="gh-list-header gh-members-list-chevron gh-list-cellwidth-chevron"></div>
@@ -99,7 +108,10 @@
 {{#if this.showDeleteMembersModal}}
     <GhFullscreenModal
         @modal="delete-members"
-        @model={{hash memberCount=this.members.length}}
+        @model={{hash
+            filterQuery=this.filterQuery
+            memberCount=this.members.length
+        }}
         @confirm={{this.deleteMembers}}
         @close={{this.toggleDeleteMembersModal}}
         @modifier="action wide"

--- a/app/templates/members.hbs
+++ b/app/templates/members.hbs
@@ -61,14 +61,19 @@
                     {{#if this.members}}
                         <li class="gh-list-row header relative">
                             <div class="gh-list-header" data-test-list-header>
+                                <div class="gh-list-header-actioncontainer">
                                 {{this.listHeaderText}}
                                 {{#if this.config.enableDeveloperExperiments}}
-                                {{#if this.canBulkDelete}}
-                                    <button class="gh-btn gh-btn-red" {{on "click" this.toggleDeleteMembersModal}} data-test-button="bulk-delete">
-                                        <span style="height: 20px; line-height: 20px; padding: 0 6px">Delete</span>
-                                    </button>
+                                    {{#if this.canBulkDelete}}
+                                        <div class="gh-list-actions">
+                                            <span class="gh-list-action-divider"></span>
+                                            <button class="gh-btn gh-btn-red-hover" {{on "click" this.toggleDeleteMembersModal}} data-test-button="bulk-delete">
+                                                <span>Delete</span>
+                                            </button>
+                                        </div>
+                                    {{/if}}
                                 {{/if}}
-                                {{/if}}
+                                </div>
                             </div>
                             <div class="gh-list-header gh-members-list-geolocation gh-list-cellwidth-20 nowrap">Location</div>
                             <div class="gh-list-header gh-members-list-subscribed-at gh-list-cellwidth-20 nowrap">Created</div>

--- a/mirage/config/posts.js
+++ b/mirage/config/posts.js
@@ -1,40 +1,8 @@
 import moment from 'moment';
 import {Response} from 'ember-cli-mirage';
 import {dasherize} from '@ember/string';
-import {isArray} from '@ember/array';
+import {extractFilterParam, paginateModelCollection} from '../utils';
 import {isBlank, isEmpty} from '@ember/utils';
-import {paginateModelCollection} from '../utils';
-
-function normalizeBooleanParams(arr) {
-    if (!isArray(arr)) {
-        return arr;
-    }
-
-    return arr.map((i) => {
-        if (i === 'true') {
-            return true;
-        } else if (i === 'false') {
-            return false;
-        } else {
-            return i;
-        }
-    });
-}
-
-// TODO: use GQL to parse filter string?
-function extractFilterParam(param, filter) {
-    let filterRegex = new RegExp(`${param}:(.*?)(?:\\+|$)`);
-    let match;
-
-    let [, result] = filter.match(filterRegex) || [];
-    if (result.startsWith('[')) {
-        match = result.replace(/^\[|\]$/g, '').split(',');
-    } else if (result) {
-        match = [result];
-    }
-
-    return normalizeBooleanParams(match);
-}
 
 // NOTE: mirage requires Model objects when saving relationships, however the
 // `attrs` on POST/PUT requests will contain POJOs for authors and tags so we

--- a/mirage/factories/label.js
+++ b/mirage/factories/label.js
@@ -1,0 +1,10 @@
+import {Factory} from 'ember-cli-mirage';
+
+export default Factory.extend({
+    name(i) { return `Label ${i}`;},
+    slug(i) { return `label-${i}`;},
+    createdAt: '2020-07-23T15:50:00.000Z',
+    createdBy: 1,
+    updatedAt: '2020-07-23T15:50:00.000Z',
+    updatedBy: 1
+});

--- a/mirage/factories/member.js
+++ b/mirage/factories/member.js
@@ -1,6 +1,6 @@
 import faker from 'faker';
 import moment from 'moment';
-import {Factory} from 'ember-cli-mirage';
+import {Factory, trait} from 'ember-cli-mirage';
 
 let randomDate = function randomDate(start = moment().subtract(30, 'days').toDate(), end = new Date()) {
     return new Date(start.getTime() + Math.random() * (end.getTime() - start.getTime()));
@@ -9,5 +9,13 @@ let randomDate = function randomDate(start = moment().subtract(30, 'days').toDat
 export default Factory.extend({
     name() { return `${faker.name.firstName()} ${faker.name.lastName()}`; },
     email: faker.internet.email,
-    createdAt() { return randomDate(); }
+    createdAt() { return randomDate(); },
+
+    paid: trait({
+        subscriptions() {
+            return [{
+                status: 'active'
+            }];
+        }
+    })
 });

--- a/mirage/models/label.js
+++ b/mirage/models/label.js
@@ -1,5 +1,5 @@
 import {Model, hasMany} from 'ember-cli-mirage';
 
 export default Model.extend({
-    labels: hasMany()
+    members: hasMany()
 });

--- a/mirage/models/subscriber.js
+++ b/mirage/models/subscriber.js
@@ -1,4 +1,0 @@
-import {Model} from 'ember-cli-mirage';
-
-export default Model.extend({
-});

--- a/mirage/serializers/label.js
+++ b/mirage/serializers/label.js
@@ -1,0 +1,9 @@
+import BaseSerializer from './application';
+
+export default BaseSerializer.extend({
+    embed: true,
+
+    include(/*request*/) {
+        return [];
+    }
+});

--- a/mirage/serializers/member.js
+++ b/mirage/serializers/member.js
@@ -1,0 +1,9 @@
+import BaseSerializer from './application';
+
+export default BaseSerializer.extend({
+    embed: true,
+
+    include(/*request*/) {
+        return ['labels'];
+    }
+});

--- a/mirage/utils.js
+++ b/mirage/utils.js
@@ -1,5 +1,37 @@
 /* eslint-disable max-statements-per-line */
 import {Response} from 'ember-cli-mirage';
+import {isArray} from '@ember/array';
+
+function _normalizeBooleanParams(arr) {
+    if (!isArray(arr)) {
+        return arr;
+    }
+
+    return arr.map((i) => {
+        if (i === 'true') {
+            return true;
+        } else if (i === 'false') {
+            return false;
+        } else {
+            return i;
+        }
+    });
+}
+
+// TODO: use GQL to parse filter string?
+export function extractFilterParam(param, filter = '') {
+    let filterRegex = new RegExp(`${param}:(.*?)(?:\\+|$)`);
+    let match;
+
+    let [, result = ''] = filter.match(filterRegex) || [];
+    if (result.startsWith('[')) {
+        match = result.replace(/^\[|\]$/g, '').split(',').map(slug => slug.replace(/^['"]|['"]$/g, ''));
+    } else if (result) {
+        match = [result.replace(/^['"]|['"]$/g, '')];
+    }
+
+    return _normalizeBooleanParams(match);
+}
 
 export function paginatedResponse(modelName) {
     return function (schema, request) {

--- a/tests/acceptance/members-test.js
+++ b/tests/acceptance/members-test.js
@@ -201,7 +201,7 @@ describe('Acceptance: Members', function () {
             await click('[data-test-button="bulk-delete"');
 
             expect(find('[data-test-modal="delete-members"]')).to.exist;
-            expect(find('[data-test-text="delete-confirmation"]')).to.contain.text('100 members');
+            expect(find('[data-test-text="delete-confirmation"]')).to.contain.text('100 member accounts');
 
             await click('[data-test-button="confirm"]');
 
@@ -230,7 +230,7 @@ describe('Acceptance: Members', function () {
             await click('[data-test-button="bulk-delete"');
 
             expect(find('[data-test-modal="delete-members"]')).to.exist;
-            expect(find('[data-test-text="delete-confirmation"]')).to.contain.text('10 members');
+            expect(find('[data-test-text="delete-confirmation"]')).to.contain.text('60 member accounts');
 
             await click('[data-test-button="confirm"]');
 


### PR DESCRIPTION
requires TBD

- display a "Delete" button in the members list header whenever a filter or search is applied, clicking the button opens the delete members modal
- added a pre-check when opening the bulk delete modal that queries the API to get a count of all paid members matching the selected filter and displays a warning about bulk delete not cancelling Stripe subscriptions if any exist
- added `{{gh-pluralize}}` helper that is the same as `{{pluralize}}` but formats larger numbers nicely using our `{{format-number}}` helper
- bulked out member/label mocking in mirage
  - added details of label model/relationships and added label factory
  - added basic 'paid' trait to member factory
  - moved `extractFilterParam` out of posts mock into top-level mirage utils file
  - updated 'GET /members/` mock to filter mirage db based on the filter/search/paid query params we currently have in use