### PR TITLE
Add margin to bottom of Admin when installed as PWA on newer iOS devices

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -11,7 +11,7 @@
 
     <meta name="HandheldFriendly" content="True" />
     <meta name="MobileOptimized" content="320" />
-    <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1, minimal-ui" />
+    <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1, minimal-ui, viewport-fit=cover" />
     <meta name="pinterest" content="nopin" />
 
     <meta http-equiv="cleartype" content="on" />

--- a/app/styles/layouts/main.css
+++ b/app/styles/layouts/main.css
@@ -635,6 +635,12 @@
         padding-bottom: 55px;
     }
 
+    @supports (padding-bottom: env(safe-area-inset-bottom)) {
+        .gh-viewport {
+            padding-bottom: calc(55px + env(safe-area-inset-bottom, 0px));
+        }
+    }
+
     .gh-mobile-nav-bar {
         display: flex;
         align-items: center;
@@ -645,6 +651,12 @@
         right: 0;
         background: #fff;
         border-top: var(--lightgrey) 1px solid;
+    }
+
+    @supports (padding-bottom: env(safe-area-inset-bottom)) {
+        .gh-mobile-nav-bar {
+            padding-bottom: env(safe-area-inset-bottom, 0px);
+        }
     }
 
     .gh-mobile-nav-bar a,


### PR DESCRIPTION
No issue.

On newer iOS devices with no home button, we have this bar at the bottom of the screen instead. When installed as a PWA, the mobile nav sits under that bar. I'm unsure how much Ghost is used this way, but this is a small QOL improvement for those who do.

This PR uses the native `env` CSS custom properties Safari has to add a propriety amount of `padding-bottom` to the mobile nav bar, and also the global container to prevent anything in the iframe from being hidden by the taller nav bar. If the device does not support these `env` vars, is has no adverse affect. In order for this to work, the `<meta name="viewport" />` tag needs `viewport-fit=cover` added to it.

MDN docs for reference: https://developer.mozilla.org/en-US/docs/Web/CSS/env

The screenshots here show a before and after when installed as a PWA, and the other shows these changes having no affect in a typical mobile browser environment. 

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `ember test` from the repo root - will be `core/client` if working from the submodule in Ghost).

![ios-pwa](https://user-images.githubusercontent.com/390392/89731458-10ed3f80-da3f-11ea-8bb4-7bd2ec47d330.jpg)

<img width="386" alt="Screenshot 2020-08-09 at 12 50 49" src="https://user-images.githubusercontent.com/390392/89731463-18144d80-da3f-11ea-870f-00ed5b13df66.png">


