### PR TITLE
:art Improved UI for 'locked' staff users

### DIFF
--- a/app/components/gh-user-list-item.hbs
+++ b/app/components/gh-user-list-item.hbs
@@ -1,4 +1,4 @@
-<div class="apps-grid-cell">
+<div class="apps-grid-cell" data-tooltip="{{ if user.isLocked 'Requires password reset to log in'}}">
     <LinkTo @route="staff.user" @model={{user.slug}} data-test-user-id={{user.id}}>
     <article class="apps-card-app">
         <div class="apps-card-left">
@@ -16,7 +16,7 @@
                     <span class="gh-badge author">Suspended</span>
                 {{else}}
                     {{#if user.isLocked}}
-                        <span class="gh-badge author">Locked</span>
+                        <span>{{svg-jar "lock"}}</span>
                     {{/if}}
                     {{#unless this.session.user.isAuthorOrContributor}}
                         {{#each user.roles as |role|}}


### PR DESCRIPTION
closes TryGhost/Ghost#12086

The current UI shows a 'Locked' label that looks like a user role label. This is unclear because it does not indicate why the user is locked; it is also presented as a user label even though it is not in the same category of information as the role. As suggested in the issue, this was improved in 2 ways:
  - Replaced 'Locked' word by a lock icon
  - Hovering over staff user shows a tooltip with the text 'Requires password reset to log in' above the user information

**Before**
![previous_ui](https://user-images.githubusercontent.com/120485/88628087-95eb6700-d0d7-11ea-87ed-2582dab8373e.png)

**After**:
![ghost_admin_locked_ui](https://user-images.githubusercontent.com/4773657/89742166-ce0b8600-da97-11ea-9dda-827762ca6f9f.png)


**Info**:
- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `ember test` from the repo root - will be `core/client` if working from the submodule in Ghost).
