### PR TITLE
Allowed Admin users to impersonate members

### DIFF
--- a/app/templates/member.hbs
+++ b/app/templates/member.hbs
@@ -11,7 +11,7 @@
         </h2>
 
         <section class="view-actions">
-            {{#if this.session.user.isOwner}}
+            {{#if this.session.user.isOwnerOrAdmin}}
                 {{#unless this.member.isNew}}
                     <button
                         class="gh-btn gh-btn-white gh-btn-icon mr2"


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/12126

- Previously, only Owner user was shown option to impersonate a member
- Grants Administrator user ability to impersonate a member as well