### PR TITLE
Increase the user bio field length to 800 characters.

### DIFF
--- a/app/validators/user.js
+++ b/app/validators/user.js
@@ -31,7 +31,7 @@ const userValidator = BaseValidator.extend(PasswordValidatorMixin, {
         let bio = model.get('bio');
 
         if (this.isActive(model)) {
-            if (!validator.isLength(bio || '', 0, 200)) {
+            if (!validator.isLength(bio || '', 0, 800)) {
                 model.get('errors').add('bio', 'Bio is too long');
                 this.invalidate();
             }


### PR DESCRIPTION
There have been a [few posts about this in the forum][1]. The primary
use case here is to have a longer bio for an author. This is an
arbitrary number that I chose - if it should be longer am absolutely
open to suggests!

[1]: https://forum.ghost.org/t/bio-length-for-users/1084
