### PR TITLE
🐛 Changed caret color to white in code editor on Night Shift

### DIFF
--- a/app/styles/app-dark.css
+++ b/app/styles/app-dark.css
@@ -359,6 +359,10 @@ input:focus,
     border-color: #fff;
 }
 
+.koenig-card-html--editor .CodeMirror-cursor {
+    border-color: #fff;
+}
+
 .gh-logo,
 .gh-unsplash-logo {
     filter: invert(100%) brightness(150%);


### PR DESCRIPTION
no issue
Adds a new css class selector to app-dark.css to mimic the same effect as created in the gh-markdown-editor. The class keonig-card-html--editor is applied conditionally when the card is in edit mode, as per its template file. This now makes the cursor the same color as the text and easier to read.

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `ember test` from the repo root - will be `core/client` if working from the submodule in Ghost).

More info can be found by clicking the "guidelines for contributing" link above.
