### PR TITLE
Fix GhTokenInput not handling keyboard shortcut bug.

### DIFF
--- a/app/components/gh-token-input.js
+++ b/app/components/gh-token-input.js
@@ -65,6 +65,17 @@ class GhTokenInput extends Component {
             }
         }
 
+        // https://github.com/TryGhost/Ghost/issues/11786
+        // ember-power-select stops propagation of events when ctrl/CMD or meta key is down.
+        // So, we're dispatching KeyboardEvent directly to the root of ghost app.
+        if (event.ctrlKey || event.metaKey) {
+            const copy = new KeyboardEvent(event.type, event);
+            document.getElementsByClassName('gh-app')[0].dispatchEvent(copy);
+            event.preventDefault(); // don't show the save dialog.
+
+            return false;
+        }
+
         // fallback to default
         return true;
     }


### PR DESCRIPTION
closes TryGhost/Ghost#11786

It was because ember-power-select was stopping the propagation of the events when ctrl/cmd or meta key is down.

----

### Explanation in more detail

`GhTokenInput` uses `PowerSelect` component of `ember-power-select` internally in `app/components/gh-token-input/select-multiple`. 

When you open that component, [you can find](https://github.com/cibernox/ember-power-select/blob/d36f38f39eba6a0afad6fd23821d20c06a9a42ef/addon/components/power-select.ts#L262-L278) that it calls `stopImmediatePropagation` when ctrl/cmd or meta key is down.

```js
  handleTriggerKeydown(e: KeyboardEvent) {
    if (this.args.onKeydown && this.args.onKeydown(this.storedAPI, e) === false) {
      e.stopImmediatePropagation();
      return;
    }
    if (e.ctrlKey || e.metaKey) {
      e.stopImmediatePropagation();
      return;
    }
    if ((e.keyCode >= 48 && e.keyCode <= 90) || isNumpadKeyEvent(e)) { // Keys 0-9, a-z or numpad keys
      (this.triggerTypingTask as unknown as Performable).perform(e);
    } else if (e.keyCode === 32) {  // Space
      this._handleKeySpace(this.storedAPI, e);
    } else {
      return this._routeKeydown(this.storedAPI, e);
    }
  }
```

Because of that, I had to dispatch event directly to the root of the Ghost admin app. 


----

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `ember test` from the repo root - will be `core/client` if working from the submodule in Ghost).

More info can be found by clicking the "guidelines for contributing" link above.
