### PR TITLE
Moved Portal settings behind dedicated flag

### DIFF
--- a/app/components/gh-members-lab-setting.hbs
+++ b/app/components/gh-members-lab-setting.hbs
@@ -140,7 +140,7 @@
         {{/if}}
     </section>
 
-    {{#if this.config.enableDeveloperExperiments}}
+    {{#if (or this.config.enableDeveloperExperiments this.config.portal)}}
         <section class="bb b--whitegrey pa5">
             <div class="flex justify-between">
                 <div>


### PR DESCRIPTION
no issue
depends on https://github.com/TryGhost/Ghost/pull/12211

- Other than dev flag, the Portal is now also enabled behind a dedicated `portal` flag
- Shows/hides Portal settings based on dev or Portal flag

