### PR TITLE
Updated magic link expiry to 4 hours

### DIFF
--- a/app/components/modal-impersonate-member.hbs
+++ b/app/components/modal-impersonate-member.hbs
@@ -46,5 +46,5 @@
 </div>
 
 <div>
-    <p class="tc pt4 mb2">This link is only valid for the next <strong>10 minutes</strong></p>
+    <p class="tc pt4 mb2">This link is only valid for the next <strong>4 hours</strong></p>
 </div>


### PR DESCRIPTION
no-issue

Since https://github.com/TryGhost/Ghost/pull/12218 magic links now have
an expiry of 4 hours.