### PR TITLE
Added `past_due` and `unpaid` subscriptions for members

### DIFF
--- a/app/components/gh-member-settings-form.hbs
+++ b/app/components/gh-member-settings-form.hbs
@@ -168,7 +168,7 @@
                                         {{#if subscription.cancelAtPeriodEnd}}
                                             <span class="gh-member-cancels-on-label">Cancels on {{subscription.validUntil}}</span>
                                         {{else}}
-                                            <span class="gh-member-stripe-status">{{subscription.status}}</span>
+                                            <span class="gh-member-stripe-status">{{subscription.statusLabel}}</span>
                                         {{/if}}
                                     </td>
                                 </tr>

--- a/app/components/gh-member-settings-form.js
+++ b/app/components/gh-member-settings-form.js
@@ -33,13 +33,14 @@ export default Component.extend({
         let subscriptions = this.member.get('stripe');
         if (subscriptions && subscriptions.length > 0) {
             return subscriptions.map((subscription) => {
-                const status = subscription.status === 'past_due' ? 'Past due' : subscription.status;
+                const statusLabel = subscription.status === 'past_due' ? 'Past due' : subscription.status;
                 return {
                     id: subscription.id,
                     customer: subscription.customer,
                     name: subscription.name || '',
                     email: subscription.email || '',
-                    status: status,
+                    status: subscription.status,
+                    statusLabel: statusLabel,
                     startDate: subscription.start_date ? moment(subscription.start_date).format('D MMM YYYY') : '-',
                     plan: subscription.plan,
                     amount: parseInt(subscription.plan.amount) ? (subscription.plan.amount / 100) : 0,

--- a/app/components/gh-member-settings-form.js
+++ b/app/components/gh-member-settings-form.js
@@ -33,12 +33,13 @@ export default Component.extend({
         let subscriptions = this.member.get('stripe');
         if (subscriptions && subscriptions.length > 0) {
             return subscriptions.map((subscription) => {
+                const status = subscription.status === 'past_due' ? 'Past due' : subscription.status;
                 return {
                     id: subscription.id,
                     customer: subscription.customer,
                     name: subscription.name || '',
                     email: subscription.email || '',
-                    status: subscription.status,
+                    status: status,
                     startDate: subscription.start_date ? moment(subscription.start_date).format('D MMM YYYY') : '-',
                     plan: subscription.plan,
                     amount: parseInt(subscription.plan.amount) ? (subscription.plan.amount / 100) : 0,

--- a/app/components/modal-delete-member.js
+++ b/app/components/modal-delete-member.js
@@ -25,7 +25,7 @@ export default ModalComponent.extend({
         }
 
         let firstActiveStripeSubscription = subscriptions.find((subscription) => {
-            return subscription.status === 'active' || subscription.status === 'trialing';
+            return ['active', 'trialing', 'unpaid', 'past_due'].includes(subscription.status);
         });
 
         return firstActiveStripeSubscription !== undefined;


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/12256 , https://github.com/TryGhost/Ghost/issues/12255

Currently when listing subscriptions for Members, we only show the subscriptions which have a status of trialing or active.

Based on discussion, the `unpaid` and `past_due` states on Stripe also represent owner's intention of considering a subscription as active instead of `cancelled`, so we allow any subscriptions under these 2 states to be also listed for a member and consider them as `paid`.

- Subscriptions will go into a past_due state if the payment is missed, this should be considered a grace period where the member still has access.

- After this the subscriptions will either go to the unpaid or the cancelled state - this can be configured on an account by account basis in the Stripe dashboard. `unpaid` is considered as an intention to keep the subscription to allow for re-activation later.