### PR TITLE
Remove spinner when login attempt failed

### DIFF
--- a/app/controllers/signin.js
+++ b/app/controllers/signin.js
@@ -76,6 +76,8 @@ export default Controller.extend(ValidationEngine, {
                     {type: 'error', key: 'session.authenticate.failed'}
                 );
             }
+
+            return false;
         }
     }).drop(),
 
@@ -94,8 +96,7 @@ export default Controller.extend(ValidationEngine, {
         try {
             yield this.validate({property: 'signin'});
             return yield this.authenticate
-                .perform(authStrategy, [signin.get('identification'), signin.get('password')])
-                .then(() => true);
+                .perform(authStrategy, [signin.get('identification'), signin.get('password')]);
         } catch (error) {
             this.set('flowErrors', 'Please fill out the form to sign in.');
         }


### PR DESCRIPTION
closes TryGhost/Ghost#12189

This bug happened because authenticate function always returned success(true) even when it is failed.

I intentionally didn't add tests because it can be flaky.

----

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `ember test` from the repo root - will be `core/client` if working from the submodule in Ghost).

More info can be found by clicking the "guidelines for contributing" link above.
