### PR TITLE
Changed post list layout to display email stats

### DIFF
--- a/app/components/gh-posts-list-item.hbs
+++ b/app/components/gh-posts-list-item.hbs
@@ -17,21 +17,37 @@
                     in <span class="midgrey-l2 fw5">{{@post.primaryTag.name}}</span>
                 {{/if}}
 
-                {{#if (eq @post.email.status "submitted")}}
-                    • Sent to <span class="midgrey-l2 fw5">{{gh-pluralize @post.email.emailCount "member"}}</span>
-                {{/if}}
+                 • {{gh-format-post-time @post.updatedAtUTC draft=true}}
 
-                {{#if @post.isScheduled}}
-                    – <span class="gh-schedule-time">Will be published {{this.scheduledText}}</span>
-                {{/if}}
             </span>
         </p>
+    </LinkTo>
+
+    <LinkTo @route="editor.edit" @models={{array @post.displayName @post.id}} class="permalink gh-list-data gh-post-list-recipients" @title="Edit this post">
+        <div class="flex fw4">
+            
+            {{#if @post.isScheduled}}
+                <span class="gh-schedule-plan">Paid</span>
+            {{/if}}
+
+            {{#if (eq @post.email.status "submitted")}}
+                Paid (<span class="fw5">{{@post.email.emailCount}}</span>)
+            {{/if}}
+        </div>
+    </LinkTo>
+
+    <LinkTo @route="editor.edit" @models={{array @post.displayName @post.id}} class="permalink gh-list-data gh-post-list-opens" @title="Edit this post">
+        <div class="flex fw4">
+            {{#if (eq @post.email.status "submitted")}}
+                <span class="flex-basis-1-3 darkgrey fw6">57%&nbsp;</span><span class="flex-basis-2-3 fw4">opens</span>
+            {{/if}}
+        </div>
     </LinkTo>
 
     <LinkTo @route="editor.edit" @models={{array @post.displayName @post.id}} class="permalink gh-list-data gh-post-list-status" @title="Edit this post">
         <div class="flex items-center">
             {{#if @post.isScheduled}}
-            <span class="gh-content-status-draft gh-badge nowrap">
+            <span class="gh-content-status-draft gh-badge nowrap" title="Scheduled" data-tooltip="{{this.scheduledText}}">
                 Scheduled
             </span>
             {{/if}}
@@ -47,30 +63,6 @@
                 Published
             </span>
             {{/if}}
-
-            {{#if this.session.user.isOwnerOrAdmin}}
-                {{#if (or @post.email (and @post.isScheduled this.sendEmailWhenPublished))}}
-                    {{#if (eq @post.email.status "failed")}}
-                        <span data-tooltip="Failed to send post by email" class="gh-content-status-emailed error">
-                            {{svg-jar "send-email" class="stroke-red"}}
-                        </span>
-                    {{else}}
-                        {{#if @post.isScheduled}}
-                            <span title="To be send by email" data-tooltip="To be sent by email" class="gh-content-status-emailed scheduled">
-                                {{svg-jar "send-email" class="stroke-green-d2"}}
-                            </span>
-                        {{else}}
-                            <span title="Sent by email" data-tooltip="Sent by email" class="gh-content-status-emailed">
-                                {{svg-jar "send-email" class="stroke-midgrey"}}
-                            </span>
-                        {{/if}}
-                    {{/if}}
-                {{/if}}
-            {{/if}}
         </div>
-    </LinkTo>
-
-    <LinkTo @route="editor.edit" @models={{array @post.displayName @post.id}} class="permalink gh-list-data gh-post-list-updated" @title="Edit this post">
-        <span class="nowrap">{{gh-format-post-time @post.updatedAtUTC draft=true}}</span>
     </LinkTo>
 </li>

--- a/app/components/gh-posts-list-item.hbs
+++ b/app/components/gh-posts-list-item.hbs
@@ -32,7 +32,10 @@
                     {{/if}}
 
                     {{#if (eq @post.email.status "submitted")}}
-                        {{capitalize @post.email.recipientFilter}} (<span class="fw5" data-tooltip="(delivered / total)">{{or @post.email.deliveredCount "-"}} / {{@post.email.emailCount}}</span>)
+                        <span class="flex flex-column fw4 gh-content-email-stats" data-tooltip="{{or @post.email.deliveredCount "-"}} delivered">
+                            <h3>{{@post.email.emailCount}}&nbsp;</h3>
+                            <span class="midgrey-l2">{{capitalize @post.email.recipientFilter}} members</span>
+                        </span>
                     {{/if}}
                 {{/if}}
             </div>
@@ -41,11 +44,12 @@
 
     {{#if (eq @post.displayName "post")}}
         <LinkTo @route="editor.edit" @models={{array @post.displayName @post.id}} class="permalink gh-list-data gh-post-list-opens" @title="Edit this post">
-            <div class="flex fw4">
-                {{#if (and @post.email.trackOpens (eq @post.email.status "submitted"))}}
-                    <span class="flex-basis-1-3 darkgrey fw6">{{@post.email.openRate}}%&nbsp;</span><span class="flex-basis-2-3 fw4">opens</span>
-                {{/if}}
-            </div>
+            {{#if (and @post.email.trackOpens (eq @post.email.status "submitted"))}}
+                <div class="flex flex-column fw4 gh-content-email-stats">
+                    <h3>{{@post.email.openRate}}%&nbsp;</h3>
+                    <span class="midgrey-l2">opens</span>
+                </div>
+            {{/if}}
         </LinkTo>
     {{/if}}
 

--- a/app/components/gh-posts-list-item.hbs
+++ b/app/components/gh-posts-list-item.hbs
@@ -25,21 +25,22 @@
 
     <LinkTo @route="editor.edit" @models={{array @post.displayName @post.id}} class="permalink gh-list-data gh-post-list-recipients" @title="Edit this post">
         <div class="flex fw4">
-            
-            {{#if @post.isScheduled}}
-                <span class="gh-schedule-plan">Paid</span>
-            {{/if}}
+            {{#if (or @post.email @post.willEmail)}}
+                {{#if @post.isScheduled}}
+                    <span class="gh-schedule-plan">{{capitalize @post.emailRecipientFilter}}</span>
+                {{/if}}
 
-            {{#if (eq @post.email.status "submitted")}}
-                Paid (<span class="fw5">{{@post.email.emailCount}}</span>)
+                {{#if (eq @post.email.status "submitted")}}
+                    {{capitalize @post.email.recipientFilter}} (<span class="fw5">{{@post.email.emailCount}}</span>)
+                {{/if}}
             {{/if}}
         </div>
     </LinkTo>
 
     <LinkTo @route="editor.edit" @models={{array @post.displayName @post.id}} class="permalink gh-list-data gh-post-list-opens" @title="Edit this post">
         <div class="flex fw4">
-            {{#if (eq @post.email.status "submitted")}}
-                <span class="flex-basis-1-3 darkgrey fw6">57%&nbsp;</span><span class="flex-basis-2-3 fw4">opens</span>
+            {{#if (and @post.email.trackOpens (eq @post.email.status "submitted"))}}
+                <span class="flex-basis-1-3 darkgrey fw6">{{@post.email.openRate}}%&nbsp;</span><span class="flex-basis-2-3 fw4">opens</span>
             {{/if}}
         </div>
     </LinkTo>

--- a/app/components/gh-posts-list-item.hbs
+++ b/app/components/gh-posts-list-item.hbs
@@ -1,4 +1,8 @@
-<li class="gh-list-row gh-posts-list-item" ...attributes>
+<li class="gh-list-row gh-posts-list-item"
+    {{on "mouseover" this.mouseOver}}
+    {{on "mouseleave" this.mouseLeave}}
+    ...attributes
+>
     <LinkTo @route="editor.edit" @models={{array @post.displayName @post.id}} class="permalink gh-list-data gh-post-list-featured" @title="Edit this post">
         {{#if @post.isFeatured}}
             <span data-tooltip="Featured" class="dib pl1 pr1 nr1 nl1">{{svg-jar "star-filled" class="fill-blue w3 h3"}}</span>
@@ -46,7 +50,13 @@
         <LinkTo @route="editor.edit" @models={{array @post.displayName @post.id}} class="permalink gh-list-data gh-post-list-opens" @title="Edit this post">
             {{#if (and @post.email.trackOpens (eq @post.email.status "submitted"))}}
                 <div class="flex flex-column fw4 gh-content-email-stats">
-                    <h3>{{@post.email.openRate}}%&nbsp;</h3>
+                    <h3>
+                        {{#if this.isHovered}}
+                            {{@post.email.openedCount}}
+                        {{else}}
+                            {{@post.email.openRate}}%&nbsp;
+                        {{/if}}
+                    </h3>
                     <span class="midgrey-l2">opens</span>
                 </div>
             {{/if}}

--- a/app/components/gh-posts-list-item.hbs
+++ b/app/components/gh-posts-list-item.hbs
@@ -31,7 +31,7 @@
                 {{/if}}
 
                 {{#if (eq @post.email.status "submitted")}}
-                    {{capitalize @post.email.recipientFilter}} (<span class="fw5">{{@post.email.emailCount}}</span>)
+                    {{capitalize @post.email.recipientFilter}} (<span class="fw5" data-tooltip="(delivered / total)">{{or @post.email.deliveredCount "-"}} / {{@post.email.emailCount}}</span>)
                 {{/if}}
             {{/if}}
         </div>

--- a/app/components/gh-posts-list-item.hbs
+++ b/app/components/gh-posts-list-item.hbs
@@ -23,27 +23,31 @@
         </p>
     </LinkTo>
 
-    <LinkTo @route="editor.edit" @models={{array @post.displayName @post.id}} class="permalink gh-list-data gh-post-list-recipients" @title="Edit this post">
-        <div class="flex fw4">
-            {{#if (or @post.email @post.willEmail)}}
-                {{#if @post.isScheduled}}
-                    <span class="gh-schedule-plan">{{capitalize @post.emailRecipientFilter}}</span>
-                {{/if}}
+    {{#if (eq @post.displayName "post")}}
+        <LinkTo @route="editor.edit" @models={{array @post.displayName @post.id}} class="permalink gh-list-data gh-post-list-recipients" @title="Edit this post">
+            <div class="flex fw4">
+                {{#if (or @post.email @post.willEmail)}}
+                    {{#if @post.isScheduled}}
+                        <span class="gh-schedule-plan">{{capitalize @post.emailRecipientFilter}}</span>
+                    {{/if}}
 
-                {{#if (eq @post.email.status "submitted")}}
-                    {{capitalize @post.email.recipientFilter}} (<span class="fw5" data-tooltip="(delivered / total)">{{or @post.email.deliveredCount "-"}} / {{@post.email.emailCount}}</span>)
+                    {{#if (eq @post.email.status "submitted")}}
+                        {{capitalize @post.email.recipientFilter}} (<span class="fw5" data-tooltip="(delivered / total)">{{or @post.email.deliveredCount "-"}} / {{@post.email.emailCount}}</span>)
+                    {{/if}}
                 {{/if}}
-            {{/if}}
-        </div>
-    </LinkTo>
+            </div>
+        </LinkTo>
+    {{/if}}
 
-    <LinkTo @route="editor.edit" @models={{array @post.displayName @post.id}} class="permalink gh-list-data gh-post-list-opens" @title="Edit this post">
-        <div class="flex fw4">
-            {{#if (and @post.email.trackOpens (eq @post.email.status "submitted"))}}
-                <span class="flex-basis-1-3 darkgrey fw6">{{@post.email.openRate}}%&nbsp;</span><span class="flex-basis-2-3 fw4">opens</span>
-            {{/if}}
-        </div>
-    </LinkTo>
+    {{#if (eq @post.displayName "post")}}
+        <LinkTo @route="editor.edit" @models={{array @post.displayName @post.id}} class="permalink gh-list-data gh-post-list-opens" @title="Edit this post">
+            <div class="flex fw4">
+                {{#if (and @post.email.trackOpens (eq @post.email.status "submitted"))}}
+                    <span class="flex-basis-1-3 darkgrey fw6">{{@post.email.openRate}}%&nbsp;</span><span class="flex-basis-2-3 fw4">opens</span>
+                {{/if}}
+            </div>
+        </LinkTo>
+    {{/if}}
 
     <LinkTo @route="editor.edit" @models={{array @post.displayName @post.id}} class="permalink gh-list-data gh-post-list-status" @title="Edit this post">
         <div class="flex items-center">

--- a/app/components/gh-posts-list-item.hbs
+++ b/app/components/gh-posts-list-item.hbs
@@ -32,9 +32,9 @@
             <div class="flex fw4">
                 {{#if (or @post.email @post.willEmail)}}
                     {{#if (eq @post.email.status "submitted")}}
-                        <span class="flex fw4" data-tooltip="{{capitalize @post.email.recipientFilter}} members">
-                            <h3 class="gh-content-email-stats">{{@post.email.emailCount}}</h3>
-                            <span class="midgrey-l2 gh-content-email-stats-mobile">{{gh-pluralize @post.email.emailCount "send"}}</span>
+                        <span class="flex" data-tooltip="{{capitalize @post.email.recipientFilter}} members">
+                            <span class="f7 darkgrey fw6 gh-content-email-stats">{{@post.email.emailCount}}</span>
+                            <span class="midgrey-l2 fw4 gh-content-email-stats-mobile">{{gh-pluralize @post.email.emailCount "send"}}</span>
                         </span>
                     {{/if}}
                 {{/if}}
@@ -45,15 +45,15 @@
     {{#if (eq @post.displayName "post")}}
         <LinkTo @route="editor.edit" @models={{array @post.displayName @post.id}} class="permalink gh-list-data gh-post-list-opens" @title="Edit this post">
             {{#if (and @post.email.trackOpens (eq @post.email.status "submitted"))}}
-                <div class="flex fw4">
-                    <h3 class="gh-content-email-stats">
+                <div class="flex">
+                    <span class="f7 darkgrey fw6 gh-content-email-stats">
                         {{#if this.isHovered}}
                             {{@post.email.openedCount}}
                         {{else}}
                             {{@post.email.openRate}}%&nbsp;
                         {{/if}}
-                    </h3>
-                    <span class="midgrey-l2 gh-content-email-stats-mobile">{{@post.email.openRate}}% opens</span>
+                    </span>
+                    <span class="midgrey-l2 fw4 gh-content-email-stats-mobile">{{@post.email.openRate}}% opens</span>
                 </div>
             {{/if}}
         </LinkTo>

--- a/app/components/gh-posts-list-item.hbs
+++ b/app/components/gh-posts-list-item.hbs
@@ -31,14 +31,10 @@
         <LinkTo @route="editor.edit" @models={{array @post.displayName @post.id}} class="permalink gh-list-data gh-post-list-recipients" @title="Edit this post">
             <div class="flex fw4">
                 {{#if (or @post.email @post.willEmail)}}
-                    {{#if @post.isScheduled}}
-                        <span class="gh-schedule-plan">{{capitalize @post.emailRecipientFilter}}</span>
-                    {{/if}}
-
                     {{#if (eq @post.email.status "submitted")}}
-                        <span class="flex flex-column fw4 gh-content-email-stats" data-tooltip="{{or @post.email.deliveredCount "-"}} delivered">
-                            <h3>{{@post.email.emailCount}}&nbsp;</h3>
-                            <span class="midgrey-l2">{{capitalize @post.email.recipientFilter}} members</span>
+                        <span class="flex fw4" data-tooltip="{{capitalize @post.email.recipientFilter}} members">
+                            <h3 class="gh-content-email-stats">{{@post.email.emailCount}}</h3>
+                            <span class="midgrey-l2 gh-content-email-stats-mobile">{{gh-pluralize @post.email.emailCount "send"}}</span>
                         </span>
                     {{/if}}
                 {{/if}}
@@ -49,15 +45,15 @@
     {{#if (eq @post.displayName "post")}}
         <LinkTo @route="editor.edit" @models={{array @post.displayName @post.id}} class="permalink gh-list-data gh-post-list-opens" @title="Edit this post">
             {{#if (and @post.email.trackOpens (eq @post.email.status "submitted"))}}
-                <div class="flex flex-column fw4 gh-content-email-stats">
-                    <h3>
+                <div class="flex fw4">
+                    <h3 class="gh-content-email-stats">
                         {{#if this.isHovered}}
                             {{@post.email.openedCount}}
                         {{else}}
                             {{@post.email.openRate}}%&nbsp;
                         {{/if}}
                     </h3>
-                    <span class="midgrey-l2">opens</span>
+                    <span class="midgrey-l2 gh-content-email-stats-mobile">{{@post.email.openRate}}% opens</span>
                 </div>
             {{/if}}
         </LinkTo>
@@ -66,7 +62,7 @@
     <LinkTo @route="editor.edit" @models={{array @post.displayName @post.id}} class="permalink gh-list-data gh-post-list-status" @title="Edit this post">
         <div class="flex items-center">
             {{#if @post.isScheduled}}
-            <span class="gh-content-status-draft gh-badge nowrap" title="Scheduled" data-tooltip="{{this.scheduledText}}">
+            <span class="gh-content-status-draft gh-badge nowrap" title="Scheduled" data-tooltip="{{this.scheduledText}} to {{capitalize @post.emailRecipientFilter}} members">
                 Scheduled
             </span>
             {{/if}}

--- a/app/components/gh-posts-list-item.js
+++ b/app/components/gh-posts-list-item.js
@@ -19,10 +19,6 @@ export default class GhPostsListItemComponent extends Component {
         let {post} = this.args;
         let text = [];
 
-        if (post.emailRecipientFilter && post.emailRecipientFilter !== 'none') {
-            text.push(`and sent to ${post.emailRecipientFilter} members`);
-        }
-
         let formattedTime = formatPostTime(
             post.publishedAtUTC,
             {timezone: this.settings.get('timezone'), scheduled: true}

--- a/app/components/gh-posts-list-item.js
+++ b/app/components/gh-posts-list-item.js
@@ -1,10 +1,14 @@
 import Component from '@glimmer/component';
+import {action} from '@ember/object';
 import {formatPostTime} from 'ghost-admin/helpers/gh-format-post-time';
 import {inject as service} from '@ember/service';
+import {tracked} from '@glimmer/tracking';
 
 export default class GhPostsListItemComponent extends Component {
     @service session;
     @service settings;
+
+    @tracked isHovered = false;
 
     get authorNames() {
         return this.args.post.authors.map(author => author.name || author.email).join(', ');
@@ -26,5 +30,15 @@ export default class GhPostsListItemComponent extends Component {
         text.push(formattedTime);
 
         return text.join(' ');
+    }
+
+    @action
+    mouseOver() {
+        this.isHovered = true;
+    }
+
+    @action
+    mouseLeave() {
+        this.isHovered = false;
     }
 }

--- a/app/models/email.js
+++ b/app/models/email.js
@@ -30,14 +30,14 @@ export default Model.extend({
     isSuccess: equal('status', 'submitted'),
     isFailure: equal('status', 'failed'),
 
-    openRate: computed('deliveredCount', 'openedCount', function () {
-        let {deliveredCount, openedCount} = this;
+    openRate: computed('emailCount', 'openedCount', function () {
+        let {emailCount, openedCount} = this;
 
-        if (deliveredCount === 0) {
+        if (emailCount === 0) {
             return 0;
         }
 
-        return openedCount / deliveredCount * 100;
+        return openedCount / emailCount * 100;
     }),
 
     retry() {

--- a/app/models/email.js
+++ b/app/models/email.js
@@ -13,10 +13,10 @@ export default Model.extend({
     uuid: attr('string'),
     recipientFilter: attr('string'),
 
-    emailCount: attr('number'),
-    deliveredCount: attr('number'),
-    openedCount: attr('number'),
-    failedCount: attr('number'),
+    emailCount: attr('number', {defaultValue: 0}),
+    deliveredCount: attr('number', {defaultValue: 0}),
+    openedCount: attr('number', {defaultValue: 0}),
+    failedCount: attr('number', {defaultValue: 0}),
 
     trackOpens: attr('boolean'),
 
@@ -32,6 +32,11 @@ export default Model.extend({
 
     openRate: computed('deliveredCount', 'openedCount', function () {
         let {deliveredCount, openedCount} = this;
+
+        if (deliveredCount === 0) {
+            return 0;
+        }
+
         return openedCount / deliveredCount * 100;
     }),
 

--- a/app/models/email.js
+++ b/app/models/email.js
@@ -37,7 +37,7 @@ export default Model.extend({
             return 0;
         }
 
-        return openedCount / emailCount * 100;
+        return Math.round(openedCount / emailCount * 100);
     }),
 
     retry() {

--- a/app/models/email.js
+++ b/app/models/email.js
@@ -1,8 +1,8 @@
 import Model, {attr, belongsTo} from '@ember-data/model';
+import {computed} from '@ember/object';
 import {equal} from '@ember/object/computed';
 
 export default Model.extend({
-    emailCount: attr('number'),
     error: attr('string'),
     html: attr('string'),
     plaintext: attr('string'),
@@ -11,6 +11,14 @@ export default Model.extend({
     subject: attr('string'),
     submittedAtUTC: attr('moment-utc'),
     uuid: attr('string'),
+    recipientFilter: attr('string'),
+
+    emailCount: attr('number'),
+    deliveredCount: attr('number'),
+    openedCount: attr('number'),
+    failedCount: attr('number'),
+
+    trackOpens: attr('boolean'),
 
     createdAtUTC: attr('moment-utc'),
     createdBy: attr('string'),
@@ -21,6 +29,11 @@ export default Model.extend({
 
     isSuccess: equal('status', 'submitted'),
     isFailure: equal('status', 'failed'),
+
+    openRate: computed('deliveredCount', 'openedCount', function () {
+        let {deliveredCount, openedCount} = this;
+        return openedCount / deliveredCount * 100;
+    }),
 
     retry() {
         return this.store.adapterFor('email').retry(this);

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -149,6 +149,10 @@ export default Model.extend(Comparable, ValidationEngine, {
     internalTags: filterBy('tags', 'isInternal', true),
     isScheduled: equal('status', 'scheduled'),
 
+    willEmail: computed('emailRecipientFilter', function () {
+        return this.emailRecipientFilter !== 'none';
+    }),
+
     previewUrl: computed('uuid', 'ghostPaths.url', 'config.blogUrl', function () {
         let blogUrl = this.get('config.blogUrl');
         let uuid = this.uuid;

--- a/app/styles/layouts/content.css
+++ b/app/styles/layouts/content.css
@@ -161,7 +161,7 @@
 }
 
 .gh-posts-status-header {
-    width: 160px;
+    width: 140px;
 }
 
 .gh-posts-lastupdate-header {
@@ -179,7 +179,9 @@
 }
 
 .gh-post-list-updated,
-.gh-post-list-author {
+.gh-post-list-author,
+.gh-post-list-recipients,
+.gh-post-list-opens {
     color: var(--middarkgrey);
     font-size: 1.3rem;
 }
@@ -201,7 +203,7 @@
     color: var(--middarkgrey);
 }
 
-.gh-schedule-time {
+.gh-schedule-plan {
     color: var(--green-d1);
 }
 
@@ -340,9 +342,10 @@
         padding: 20px 28px 4px;
     }
 
-    .gh-post-list-status {
+    .gh-post-list-status,
+    .gh-post-list-recipients,
+    .gh-post-list-opens {
         display: inline-block;
-        order: 3;
         border: none;
         padding: 0 4px 20px 28px;
         font-size: 1.3rem;
@@ -352,9 +355,21 @@
         text-overflow: ellipsis;
     }
 
+    .gh-post-list-status {
+        order: 3;
+    }
+
+    .gh-post-list-recipients {
+        order: 4;
+    }
+
+    .gh-post-list-opens {
+        order: 5;
+    }
+
     .gh-post-list-updated {
         display: inline-block;
-        order: 4;
+        order: 6;
         border: none;
         padding: 0 4px 20px;
         font-size: 1.3rem;
@@ -366,7 +381,7 @@
 
     .gh-post-list-author {
         display: inline-block;
-        order: 5;
+        order: 7;
         border: none;
         padding: 0 4px 20px 0;
         font-size: 1.3rem;

--- a/app/styles/layouts/content.css
+++ b/app/styles/layouts/content.css
@@ -217,6 +217,10 @@
     margin-right: 3px;
 }
 
+.gh-content-email-stats-mobile {
+    display: none;
+}
+
 .gh-content-status-draft,
 .gh-content-status-published,
 .gh-content-status-scheduled,
@@ -397,7 +401,11 @@
     }
 
     .gh-content-email-stats {
-        flex-direction: row;
+        display: none;
+    }
+
+    .gh-content-email-stats-mobile {
+        display: inherit;
     }
 
     .post-header {

--- a/app/styles/layouts/content.css
+++ b/app/styles/layouts/content.css
@@ -160,8 +160,13 @@
     padding-left: 10px;
 }
 
-.gh-posts-status-header {
+.gh-posts-sends-header,
+.gh-posts-opens-header {
     width: 120px;
+}
+
+.gh-posts-status-header {
+    width: 140px;
 }
 
 .gh-post-list-title {

--- a/app/styles/layouts/content.css
+++ b/app/styles/layouts/content.css
@@ -164,10 +164,6 @@
     width: 140px;
 }
 
-.gh-posts-lastupdate-header {
-    width: 160px;
-}
-
 .gh-post-list-title {
     padding-left: 10px;
 }
@@ -398,6 +394,10 @@
     .gh-post-headers,
     .gh-post-list-actions {
         display: none;
+    }
+
+    .gh-content-email-stats {
+        flex-direction: row;
     }
 
     .post-header {

--- a/app/styles/layouts/content.css
+++ b/app/styles/layouts/content.css
@@ -161,7 +161,7 @@
 }
 
 .gh-posts-status-header {
-    width: 140px;
+    width: 120px;
 }
 
 .gh-post-list-title {

--- a/app/templates/pages.hbs
+++ b/app/templates/pages.hbs
@@ -33,7 +33,6 @@
                     <div class="gh-list-header no-padding">{{!--Favorite indicator column: no header--}}</div>
                     <div class="gh-list-header gh-posts-title-header">Title</div>
                     <div class="gh-list-header gh-posts-status-header">Status</div>
-                    <div class="gh-list-header gh-posts-lastupdate-header">Last update</div>
                 </li>
             {{/if}}
 

--- a/app/templates/posts.hbs
+++ b/app/templates/posts.hbs
@@ -32,8 +32,9 @@
                 <li class="gh-list-row header">
                     <div class="gh-list-header no-padding">{{!--Favorite indicator column: no header--}}</div>
                     <div class="gh-list-header gh-posts-title-header">Title</div>
+                    <div class="gh-list-header gh-posts-status-header">Recipients</div>
+                    <div class="gh-list-header gh-posts-status-header">Opens</div>
                     <div class="gh-list-header gh-posts-status-header">Status</div>
-                    <div class="gh-list-header gh-posts-lastupdate-header">Last update</div>
                 </li>
             {{/if}}
 

--- a/app/templates/posts.hbs
+++ b/app/templates/posts.hbs
@@ -32,7 +32,7 @@
                 <li class="gh-list-row header">
                     <div class="gh-list-header no-padding">{{!--Favorite indicator column: no header--}}</div>
                     <div class="gh-list-header gh-posts-title-header">Title</div>
-                    <div class="gh-list-header gh-posts-status-header">Recipients</div>
+                    <div class="gh-list-header gh-posts-status-header">Sends</div>
                     <div class="gh-list-header gh-posts-status-header">Opens</div>
                     <div class="gh-list-header gh-posts-status-header">Status</div>
                 </li>

--- a/app/templates/posts.hbs
+++ b/app/templates/posts.hbs
@@ -32,8 +32,8 @@
                 <li class="gh-list-row header">
                     <div class="gh-list-header no-padding">{{!--Favorite indicator column: no header--}}</div>
                     <div class="gh-list-header gh-posts-title-header">Title</div>
-                    <div class="gh-list-header gh-posts-status-header">Sends</div>
-                    <div class="gh-list-header gh-posts-status-header">Opens</div>
+                    <div class="gh-list-header gh-posts-sends-header">Sends</div>
+                    <div class="gh-list-header gh-posts-opens-header">Opens</div>
                     <div class="gh-list-header gh-posts-status-header">Status</div>
                 </li>
             {{/if}}


### PR DESCRIPTION
No issue

- Added stats-related fields to the `Email` and `EmailRecipients` models
- Moved update time to entry-meta
- Got rid of email icons
- Added columns for recipients and opens
- Added tooltip on hovering scheduled state
- Changed column order on mobile
