### PR TITLE
Added new portal link for free plan

### DIFF
--- a/app/components/gh-portal-links.hbs
+++ b/app/components/gh-portal-links.hbs
@@ -82,6 +82,27 @@
                 </td>
             </tr>
             <tr>
+                <td class='pagename'>Sign up/Free</td>
+                <td class='page-url'>
+                    <div class="gh-portal-page-url-container">
+                        <div class="page-url-label">
+                            {{#if isLink}}
+                                <span class="page-url-disabled">{{this.siteUrl}}/</span><span>#/portal/signup/free</span>
+                            {{else}}
+                                data-portal="signup/free"
+                            {{/if}}
+                        </div>
+                        <button type="button" {{action (perform this.copySignupFree (if isLink '#/portal/signup/free' 'data-portal="signup/free"'))}} class="gh-portal-setting-copy">
+                            {{#if this.copySignupFree.isRunning}}
+                                {{svg-jar "check-circle" class="w3 v-mid mr2 stroke-darkgrey"}} Copied
+                            {{else}}
+                                <span data-tooltip="Copy">{{svg-jar "copy" class="w4 v-mid fill-darkgrey"}}</span>
+                            {{/if}}
+                        </button>
+                    </div>
+                </td>
+            </tr>
+            <tr>
                 <td class='pagename'>Sign up/Monthly</td>
                 <td class='page-url'>
                     <div class="gh-portal-page-url-container">

--- a/app/components/gh-portal-links.js
+++ b/app/components/gh-portal-links.js
@@ -43,6 +43,10 @@ export default Component.extend({
         copyTextToClipboard(data);
         yield timeout(this.isTesting ? 50 : 3000);
     }),
+    copySignupFree: task(function* (data) {
+        copyTextToClipboard(data);
+        yield timeout(this.isTesting ? 50 : 3000);
+    }),
     copySignin: task(function* (data) {
         copyTextToClipboard(data);
         yield timeout(this.isTesting ? 50 : 3000);


### PR DESCRIPTION
refs TryGhost/Ghost#12365

Portal allows direct free signup link or data attributes, allowing members to directly share or link to only free plan in Portal popup if available

- A new portal signup link for free plan - `/signup/free`
