### PR TITLE
Added toggle in settings to enable open-tracking configuration

### DIFF
--- a/app/components/gh-members-lab-setting.hbs
+++ b/app/components/gh-members-lab-setting.hbs
@@ -292,7 +292,7 @@
             </div>
         </div>
 
-        <div class="{{if this.mailgunIsConfigured "gh-setting-last" "gh-setting"}}">
+        <div class="gh-setting">
             <div class="gh-setting-content">
                 <h4 class="gh-setting-title">Email addresses</h4>
                 <p class="gh-setting-desc pa0 ma0">Contact information used for newsletters and member login emails</p>
@@ -388,7 +388,7 @@
             </div>
         {{/liquid-if}}
 
-        <div class="gh-setting">
+        <div class="{{if this.mailgunIsConfigured "gh-setting-last" "gh-setting"}}">
             <div class="gh-setting-content">
                 <h4 class="gh-setting-title">Enable newsletter open-rate analytics</h4>
                 <p class="gh-setting-desc pa0 ma0 mb1">Track how many members are readings your emails</p>

--- a/app/components/gh-members-lab-setting.hbs
+++ b/app/components/gh-members-lab-setting.hbs
@@ -395,8 +395,8 @@
             </div>
             <div class="gh-setting-action">
                 <div class="for-switch">
-                    <label class="switch" for="members-allow-self-signup" {{action "toggleSelfSignup" bubbles="false"}}>
-                        <input type="checkbox" checked={{this.allowSelfSignup}} class="gh-input" onclick={{action "toggleSelfSignup"}} data-test-checkbox="members-allow-self-signup">
+                    <label class="switch" for="email-track-opens" {{on "click" (action "toggleEmailTrackOpens")}}>
+                        <input type="checkbox" checked={{this.emailTrackOpens}} class="gh-input" {{on "click" (action "toggleEmailTrackOpens")}} name="email-track-opens" data-test-checkbox="email-track-opens">
                         <span class="input-toggle-component mt1"></span>
                     </label>
                 </div>

--- a/app/components/gh-members-lab-setting.hbs
+++ b/app/components/gh-members-lab-setting.hbs
@@ -390,8 +390,8 @@
 
         <div class="gh-setting">
             <div class="gh-setting-content">
-                <h4 class="gh-setting-title">Allow email open-tracking</h4>
-                <p class="gh-setting-desc pa0 ma0 mb1">If enabled, email opens will be tracked and show up in your post list</p>
+                <h4 class="gh-setting-title">Enable newsletter open-rate analytics</h4>
+                <p class="gh-setting-desc pa0 ma0 mb1">Track how many members are readings your emails</p>
             </div>
             <div class="gh-setting-action">
                 <div class="for-switch">

--- a/app/components/gh-members-lab-setting.hbs
+++ b/app/components/gh-members-lab-setting.hbs
@@ -388,6 +388,21 @@
             </div>
         {{/liquid-if}}
 
+        <div class="gh-setting">
+            <div class="gh-setting-content">
+                <h4 class="gh-setting-title">Allow email open-tracking</h4>
+                <p class="gh-setting-desc pa0 ma0 mb1">If enabled, email opens will be tracked and show up in your post list</p>
+            </div>
+            <div class="gh-setting-action">
+                <div class="for-switch">
+                    <label class="switch" for="members-allow-self-signup" {{action "toggleSelfSignup" bubbles="false"}}>
+                        <input type="checkbox" checked={{this.allowSelfSignup}} class="gh-input" onclick={{action "toggleSelfSignup"}} data-test-checkbox="members-allow-self-signup">
+                        <span class="input-toggle-component mt1"></span>
+                    </label>
+                </div>
+            </div>
+        </div>
+
         {{#unless this.mailgunIsConfigured}}
             <div class="gh-setting-last">
                 <div class="gh-setting-content">

--- a/app/components/gh-members-lab-setting.js
+++ b/app/components/gh-members-lab-setting.js
@@ -68,6 +68,7 @@ export default Component.extend({
     mailgunIsConfigured: reads('config.mailgunIsConfigured'),
 
     allowSelfSignup: reads('settings.membersAllowFreeSignup'),
+    emailTrackOpens: reads('settings.emailTrackOpens'),
 
     /** OLD **/
     stripeDirectPublicKey: reads('settings.stripePublishableKey'),
@@ -197,6 +198,13 @@ export default Component.extend({
 
         setSupportAddress(supportAddress) {
             this.setEmailAddress('supportAddress', supportAddress);
+        },
+
+        toggleEmailTrackOpens(event) {
+            if (event) {
+                event.preventDefault();
+            }
+            this.set('settings.emailTrackOpens', !this.get('emailTrackOpens'));
         },
 
         toggleSelfSignup() {

--- a/app/models/setting.js
+++ b/app/models/setting.js
@@ -42,6 +42,7 @@ export default Model.extend(ValidationEngine, {
     mailgunApiKey: attr('string'),
     mailgunDomain: attr('string'),
     mailgunBaseUrl: attr('string'),
+    emailTrackOpens: attr('boolean'),
     portalButton: attr('boolean'),
     portalName: attr('boolean'),
     portalPlans: attr('json-string'),


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/12390
requires https://github.com/TryGhost/Ghost/pull/12404

- Added toggle for open-tracking in settings (Labs > Members > Email section)