### PR TITLE
🐛 Fixed email design settings not opening 

### DIFF
--- a/lib/koenig-editor/addon/components/koenig-basic-html-input.js
+++ b/lib/koenig-editor/addon/components/koenig-basic-html-input.js
@@ -48,7 +48,7 @@ export default Component.extend({
     /* computed properties -------------------------------------------------- */
 
     cleanHTML: computed('html', function () {
-        return cleanBasicHtml(this.html);
+        return cleanBasicHtml(this.html || '');
     }),
 
     // merge in named options with any passed in `options` property data-bag
@@ -392,7 +392,7 @@ export default Component.extend({
                 return '';
             }
 
-            let html = firstParagraph.innerHTML;
+            let html = firstParagraph.innerHTML || '';
             return cleanBasicHtml(html);
         }
     }


### PR DESCRIPTION
no issue

- Email design settings doesn't open in some cases when footer html is set as null, specifically on import
- Patches html cleanup to use empty string in case of null footer value
