### PR TITLE
Fixed issues for member details mobile view

### DIFF
--- a/app/components/gh-member-activity-feed.hbs
+++ b/app/components/gh-member-activity-feed.hbs
@@ -1,10 +1,10 @@
-<div class="gh-member-feed">
+<div class="gh-member-feed" ...attributes>
 
     <div class="flex justify-between mt8">
         <h4 class="midlightgrey f-small fw5 ttu">Member activity</h4>
     </div>
 
-    <div class="flex-auto br4 shadow-1 bg-grouped-table mt2 flex flex-column justify-between items-stretch" ...attributes>
+    <div class="flex-auto br4 shadow-1 bg-grouped-table mt2 flex flex-column justify-between items-stretch">
         <div class="pt5 pb5">
             {{#if this.activities}}
                 {{#each this.firstActivities as |activity|}}

--- a/app/components/gh-member-activity-feed.hbs
+++ b/app/components/gh-member-activity-feed.hbs
@@ -1,30 +1,38 @@
-<div class="flex-auto br4 shadow-1 bg-grouped-table mt2 flex flex-column justify-between items-stretch mr6 gh-member-feed" ...attributes>
-    <div class="pt5 pb5">
-        {{#if this.activities}}
-            {{#each this.firstActivities as |activity|}}
-                <GhMemberActivityFeedItem @activity={{activity}} />
-            {{/each}}
+<div class="gh-member-feed">
 
-            {{#liquid-if this.isShowingAll class="show-overflow"}}
-                {{#each this.remainingActivities as |activity|}}
+    <div class="flex justify-between mt8">
+        <h4 class="midlightgrey f-small fw5 ttu">Member activity</h4>
+    </div>
+
+    <div class="flex-auto br4 shadow-1 bg-grouped-table mt2 flex flex-column justify-between items-stretch" ...attributes>
+        <div class="pt5 pb5">
+            {{#if this.activities}}
+                {{#each this.firstActivities as |activity|}}
                     <GhMemberActivityFeedItem @activity={{activity}} />
                 {{/each}}
-            {{/liquid-if}}
 
-            {{#if (and this.remainingActivities (not this.isShowingAll))}}
-                <button
-                    type="button"
-                    class="mt4 mb1 ml5 gh-btn gh-btn-icon gh-member-btn-expandfeed"
-                    data-test-button="view-all-activity"
-                    {{on "click" this.showAll}}
-                >
-                    <span>View all activity</span>
-                </button>
+                {{#liquid-if this.isShowingAll class="show-overflow"}}
+                    {{#each this.remainingActivities as |activity|}}
+                        <GhMemberActivityFeedItem @activity={{activity}} />
+                    {{/each}}
+                {{/liquid-if}}
+
+                {{#if (and this.remainingActivities (not this.isShowingAll))}}
+                    <button
+                        type="button"
+                        class="mt4 mb1 ml5 gh-btn gh-btn-icon gh-member-btn-expandfeed"
+                        data-test-button="view-all-activity"
+                        {{on "click" this.showAll}}
+                    >
+                        <span>View all activity</span>
+                    </button>
+                {{/if}}
+            {{else}}
+                <p class="ma0 pa8 tc midgrey">No member activity yet</p>
             {{/if}}
-        {{else}}
-            <p class="ma0 pa8 tc midgrey">No member activity yet</p>
-        {{/if}}
+        </div>
     </div>
+
 </div>
 
 {{#if this.emailPreview}}

--- a/app/components/gh-member-settings-form.hbs
+++ b/app/components/gh-member-settings-form.hbs
@@ -1,137 +1,129 @@
-<div class="flex items-start mt2 gh-member-settings">
-    <div class="flex-auto flex flex-column gh-member-settings-primary">
-        <div class="flex-auto br4 shadow-1 bg-grouped-table mt2 flex flex-column justify-between items-stretch mr6 gh-member-details">
-            <div>
-                <div class="flex items-center pa5 pb3">
-                    {{#if (or this.member.name this.member.email)}}
-                        <GhMemberAvatar
-                            @member={{this.member}}
-                            @sizeClass={{if this.member.name 'f-subheadline fw4 lh-zero tracked-1' 'f-headline fw4 lh-zero tracked-1'}}
-                            @containerClass="w20 h20 mr4 gh-member-detail-avatar"
-                        />
-                    {{else}}
-                        <div class="flex items-center justify-center br-100 w18 h18 mr4 gh-new-member-avatar">
-                            <span class="gh-member-avatar-label f-subheadline fw4 lh-zero tracked-1">N</span>
-                        </div>
-                    {{/if}}
-                    <div>
-                        <h3 class="f2 fw6 ma0 pa0">
-                            {{or this.member.name this.member.email}}
-                        </h3>
-                        <p class="f7 pa0 ma0 midlightgrey-d1">
-                            {{#if (and this.member.name this.member.email)}}
-                                <a href="mailto:{{this.member.email}}" class="darkgrey fw5">{{this.member.email}}</a>
-                            {{/if}}
-                        </p>
-                        {{#unless this.member.isNew}}
-                        <p class="f7 pa0 ma0 midgrey {{if this.member.name "nudge-bottom--2"}}">
-                            {{#if this.member.geolocation}}
-                                {{#if (and (eq this.member.geolocation.country_code "US") @member.geolocation.region)}}
-                                    {{this.member.geolocation.region}}, US
-                                {{else}}
-                                    {{or this.member.geolocation.country "Unknown location"}}
-                                {{/if}}
+<div class="mt2 pb2 gh-member-settings">
+    <div class="flex-auto br4 shadow-1 bg-grouped-table mt2 flex flex-column justify-between items-stretch gh-member-details">
+        <div>
+            <div class="flex items-center pa5 pb3">
+                {{#if (or this.member.name this.member.email)}}
+                    <GhMemberAvatar
+                        @member={{this.member}}
+                        @sizeClass={{if this.member.name 'f-subheadline fw4 lh-zero tracked-1' 'f-headline fw4 lh-zero tracked-1'}}
+                        @containerClass="w20 h20 mr4 gh-member-detail-avatar"
+                    />
+                {{else}}
+                    <div class="flex items-center justify-center br-100 w18 h18 mr4 gh-new-member-avatar">
+                        <span class="gh-member-avatar-label f-subheadline fw4 lh-zero tracked-1">N</span>
+                    </div>
+                {{/if}}
+                <div>
+                    <h3 class="f2 fw6 ma0 pa0">
+                        {{or this.member.name this.member.email}}
+                    </h3>
+                    <p class="f7 pa0 ma0 midlightgrey-d1">
+                        {{#if (and this.member.name this.member.email)}}
+                            <a href="mailto:{{this.member.email}}" class="darkgrey fw5">{{this.member.email}}</a>
+                        {{/if}}
+                    </p>
+                    {{#unless this.member.isNew}}
+                    <p class="f7 pa0 ma0 midgrey {{if this.member.name "nudge-bottom--2"}}">
+                        {{#if this.member.geolocation}}
+                            {{#if (and (eq this.member.geolocation.country_code "US") @member.geolocation.region)}}
+                                {{this.member.geolocation.region}}, US
                             {{else}}
-                                Unknown location
+                                {{or this.member.geolocation.country "Unknown location"}}
                             {{/if}}
-                            – Created on {{moment-format @member.createdAtUTC "D MMM YYYY"}}
-                        </p>
-                        {{/unless}}
-                    </div>
+                        {{else}}
+                            Unknown location
+                        {{/if}}
+                        – Created on {{moment-format @member.createdAtUTC "D MMM YYYY"}}
+                    </p>
+                    {{/unless}}
                 </div>
-
-                <div class="flex mb5 pa5 pt3 bb b--whitegrey">
-                    <div class="flex-auto flex flex-column justify-center items-start">
-                        <div class="f8 fw5 midgrey">Emails received</div>
-                        <div class="gh-member-email-stats">{{@member.emailCount}}</div>
-                    </div>
-                    <div class="flex-auto flex flex-column justify-center items-start">
-                        <div class="f8 fw5 midgrey">Emails opened</div>
-                        <div class="gh-member-email-stats">{{@member.emailOpenedCount}}</div>
-                    </div>
-                    <div class="flex-auto flex flex-column justify-center items-start">
-                        <div class="f8 fw5 midgrey">Avg. open rate</div>
-                        <div class="gh-member-email-stats">
-                            {{#if (is-empty @member.emailOpenRate)}}
-                                <span data-tooltip="Insufficient data available">–</span>
-                            {{else}}
-                                {{@member.emailOpenRate}}%
-                            {{/if}}
-                        </div>
-                    </div>
-                </div>
-
-                    <GhFormGroup @errors={{this.member.errors}} @hasValidated={{this.member.hasValidated}} @property="name" @classNames="max-width pl5 pr5">
-                        <label for="member-name">Name</label>
-                        <GhTextInput @id="member-name" @name="name" @value={{this.scratchMember.name}} @tabindex="1"
-                            @focus-out={{action "setProperty" "name" this.scratchMember.name}} />
-                        <GhErrorMessage @errors={{member.errors}} @property="name" />
-                    </GhFormGroup>
-
-                    <GhFormGroup @errors={{this.member.errors}} @hasValidated={{this.member.hasValidated}} @property="email" @classNames="max-width pl5 pr5">
-                        <label for="member-email">Email</label>
-                        <GhTextInput @value={{this.scratchMember.email}} @id="member-email" @name="email" @tabindex="2"
-                            @autocapitalize="off" @autocorrect="off" @autocomplete="off"
-                            @focus-out={{action "setProperty" "email" this.scratchMember.email}} />
-                        <GhErrorMessage @errors={{this.member.errors}} @property="email" />
-                    </GhFormGroup>
             </div>
 
-            <div class="pa5 pb6 bt b--whitegrey">
-                <GhFormGroup @classNames="gh-members-subscribed-checkbox mb0">
-                    <div class="flex justify-between items-center">
-                        <div>
-                            <h4 class="gh-setting-title">Subscribed to newsletter</h4>
-                            <p class="gh-setting-desc">If disabled, member will <em>not</em> receive newsletter emails</p>
-                        </div>
-                        <div class="for-switch">
-                            <label class="switch" for="subscribed-checkbox">
-                                <Input @checked={{this.member.subscribed}} @type="checkbox" @id="subscribed-checkbox"
-                                    @name="subscribed" />
-                                <span class="input-toggle-component"></span>
-                            </label>
-                        </div>
+            <div class="flex mb5 pa5 pt3 bb b--whitegrey">
+                <div class="flex-auto flex flex-column justify-center items-start">
+                    <div class="f8 fw5 midgrey">Emails received</div>
+                    <div class="gh-member-email-stats">{{@member.emailCount}}</div>
+                </div>
+                <div class="flex-auto flex flex-column justify-center items-start">
+                    <div class="f8 fw5 midgrey">Emails opened</div>
+                    <div class="gh-member-email-stats">{{@member.emailOpenedCount}}</div>
+                </div>
+                <div class="flex-auto flex flex-column justify-center items-start">
+                    <div class="f8 fw5 midgrey">Avg. open rate</div>
+                    <div class="gh-member-email-stats">
+                        {{#if (is-empty @member.emailOpenRate)}}
+                            <span data-tooltip="Insufficient data available">–</span>
+                        {{else}}
+                            {{@member.emailOpenRate}}%
+                        {{/if}}
                     </div>
+                </div>
+            </div>
+
+                <GhFormGroup @errors={{this.member.errors}} @hasValidated={{this.member.hasValidated}} @property="name" @classNames="max-width pl5 pr5">
+                    <label for="member-name">Name</label>
+                    <GhTextInput @id="member-name" @name="name" @value={{this.scratchMember.name}} @tabindex="1"
+                        @focus-out={{action "setProperty" "name" this.scratchMember.name}} />
+                    <GhErrorMessage @errors={{member.errors}} @property="name" />
                 </GhFormGroup>
-            </div>
+
+                <GhFormGroup @errors={{this.member.errors}} @hasValidated={{this.member.hasValidated}} @property="email" @classNames="max-width pl5 pr5">
+                    <label for="member-email">Email</label>
+                    <GhTextInput @value={{this.scratchMember.email}} @id="member-email" @name="email" @tabindex="2"
+                        @autocapitalize="off" @autocorrect="off" @autocomplete="off"
+                        @focus-out={{action "setProperty" "email" this.scratchMember.email}} />
+                    <GhErrorMessage @errors={{this.member.errors}} @property="email" />
+                </GhFormGroup>
         </div>
 
-        <div class="flex justify-between mt8 mr6">
-            <h4 class="midlightgrey f-small fw5 ttu">Member activity</h4>
+        <div class="pa5 pb6 bt b--whitegrey">
+            <GhFormGroup @classNames="gh-members-subscribed-checkbox mb0">
+                <div class="flex justify-between items-center">
+                    <div>
+                        <h4 class="gh-setting-title">Subscribed to newsletter</h4>
+                        <p class="gh-setting-desc">If disabled, member will <em>not</em> receive newsletter emails</p>
+                    </div>
+                    <div class="for-switch">
+                        <label class="switch" for="subscribed-checkbox">
+                            <Input @checked={{this.member.subscribed}} @type="checkbox" @id="subscribed-checkbox"
+                                @name="subscribed" />
+                            <span class="input-toggle-component"></span>
+                        </label>
+                    </div>
+                </div>
+            </GhFormGroup>
         </div>
-        <GhMemberActivityFeed @emailRecipients={{this.member.emailRecipients}} />
-
     </div>
 
-    <div class="flex flex-column flex-auto gh-member-settings-secondary">
-        <div class="flex-auto br4 shadow-1 bg-grouped-table mt2 flex flex-column items-stretch gh-member-internal-info">
-            <div class="pa5">
-                <GhFormGroup>
-                    <label for="label-input">Labels</label>
-                 <GhMemberLabelInput @onChange={{action "setLabels"}} @labels={{this.member.labels}} @triggerId="label-input" />
-                </GhFormGroup>
-                <GhFormGroup @errors={{this.member.errors}} @hasValidated={{this.member.hasValidated}} @property="note" @classNames="mb0">
-                    <label for="member-note">Note <span class="midgrey-l2 fw4">(not visible to member)</span></label>
-                    <GhTextarea @id="member-note" @name="note" @class="gh-member-details-textarea" @tabindex="3"
-                        @value={{this.scratchMember.note}} @focus-out={{action "setProperty" "note" this.scratchMember.note}} />
-                    <GhErrorMessage @errors={{this.member.errors}} @property="note" />
-                    <p> Maximum: <b>500</b> characters. You’ve used
-                        {{gh-count-down-characters this.scratchMember.note 500}}</p>
-                </GhFormGroup>
-            </div>
+    <div class="flex-auto br4 shadow-1 bg-grouped-table mt2 flex flex-column items-stretch gh-member-internal-info">
+        <div class="pa5">
+            <GhFormGroup @classNames="gh-member-labels">
+                <label for="label-input">Labels</label>
+                <GhMemberLabelInput @onChange={{action "setLabels"}} @labels={{this.member.labels}} @triggerId="label-input" />
+            </GhFormGroup>
+            <GhFormGroup @errors={{this.member.errors}} @hasValidated={{this.member.hasValidated}} @property="note" @classNames="mb0 gh-member-note">
+                <label for="member-note">Note <span class="midgrey-l2 fw4">(not visible to member)</span></label>
+                <GhTextarea @id="member-note" @name="note" @class="gh-member-details-textarea" @tabindex="3"
+                    @value={{this.scratchMember.note}} @focus-out={{action "setProperty" "note" this.scratchMember.note}} />
+                <GhErrorMessage @errors={{this.member.errors}} @property="note" />
+                <p> Maximum: <b>500</b> characters. You’ve used
+                    {{gh-count-down-characters this.scratchMember.note 500}}</p>
+            </GhFormGroup>
         </div>
+    </div>
 
-        {{#if this.canShowStripeInfo}}
+    {{#if this.canShowStripeInfo}}
+        <div class="gh-member-stripe">
             <h4 class="midlightgrey f-small fw5 ttu mt8 gh-member-label-stripe">Stripe info</h4>
 
             {{#if this.isLoading}}
-                <div class="pa20 br4 shadow-1 bg-grouped-table mt2 gh-member-stripe">
+                <div class="pa20 br4 shadow-1 bg-grouped-table mt2">
                     <div class="flex justify-center flex-auto">
                         <div class="gh-loading-spinner"> </div>
                     </div>
                 </div>
             {{else}}
-                <div class="br4 shadow-1 bg-grouped-table mt2 gh-member-stripe">
+                <div class="br4 shadow-1 bg-grouped-table mt2">
                     {{#if this.subscriptions}}
                         <div class="gh-member-header-stripeinfo">
                             <div class="flex items-center justify-between gh-btn-group w-100 ma5 mb0">
@@ -150,7 +142,7 @@
                                     <div class="flex-auto">
                                         {{#if (eq this.stripeDetailsType "subscription")}}
                                             <table class="gh-member-stripe-table">
-                                                <tr>
+                                                <tr class="gh-member-stripe-row">
                                                     <td class="gh-member-stripe-label">Stripe subscription ID</td>
                                                     <td class="gh-member-stripe-data gh-member-stripe-id">
                                                         <a href="https://dashboard.stripe.com/subscriptions/{{subscription.id}}" target="_blank" rel="noopener"
@@ -159,7 +151,7 @@
                                                         </a>
                                                     </td>
                                                 </tr>
-                                                <tr>
+                                                <tr class="gh-member-stripe-row">
                                                     <td class="gh-member-stripe-label">Plan</td>
                                                     <td class="gh-member-stripe-data">
                                                         {{subscription.plan.nickname}}
@@ -168,7 +160,7 @@
                                                         </span>
                                                     </td>
                                                 </tr>
-                                                <tr>
+                                                <tr class="gh-member-stripe-row">
                                                     <td class="gh-member-stripe-label">Status</td>
                                                     <td class="gh-member-stripe-data">
                                                         {{#if (and subscription.cancelAtPeriodEnd (not-eq subscription.status 'canceled'))}}
@@ -179,14 +171,14 @@
                                                     </td>
                                                 </tr>
                                                 {{#if subscription.cancellationReason}}
-                                                    <tr>
+                                                    <tr class="gh-member-stripe-row">
                                                         <td class="gh-member-stripe-label">Cancellation reason</td>
                                                         <td class="gh-member-stripe-data">
                                                             <span class="gh-member-stripe-cancellation-reason">{{subscription.cancellationReason}}</span>
                                                         </td>
                                                     </tr>
                                                 {{/if}}
-                                                <tr>
+                                                <tr class="gh-member-stripe-row">
                                                     <td class="gh-member-stripe-label">Next renewal date</td>
                                                     <td class="gh-member-stripe-data">
                                                         {{#if subscription.cancelAtPeriodEnd}}
@@ -205,7 +197,7 @@
                                                         @successText=""
                                                         @task={{this.continueSubscription}}
                                                         @taskArgs={{subscription.id}}
-                                                        @class="gh-btn gh-btn-icon gh-member-btn-cancelsub"
+                                                        @class="mt1 mb6 gh-btn gh-btn-icon gh-member-btn-cancelsub"
                                                         data-test-button="continue-subscription"
                                                     />
                                                 {{else}}
@@ -221,7 +213,7 @@
                                             {{/if}}
                                         {{else}}
                                             <table class="gh-member-stripe-table">
-                                                <tr>
+                                                <tr class="gh-member-stripe-row">
                                                     <td class="gh-member-stripe-label">Stripe customer ID</td>
                                                     <td class="gh-member-stripe-data gh-member-stripe-id">
                                                         <a href="https://dashboard.stripe.com/customers/{{subscription.customer.id}}" target="_blank" rel="noopener" data-tooltip="View on Stripe">
@@ -229,7 +221,7 @@
                                                         </a>
                                                     </td>
                                                 </tr>
-                                                <tr>
+                                                <tr class="gh-member-stripe-row">
                                                     <td class="gh-member-stripe-label">Name</td>
                                                     <td class="gh-member-stripe-data">
                                                         {{#if subscription.customer.name}}
@@ -239,7 +231,7 @@
                                                         {{/if}}
                                                     </td>
                                                 </tr>
-                                                <tr>
+                                                <tr class="gh-member-stripe-row">
                                                     <td class="gh-member-stripe-label">Email</td>
                                                     <td class="gh-member-stripe-data gh-member-stripe-email">
                                                         {{#if subscription.customer.email}}
@@ -249,7 +241,7 @@
                                                         {{/if}}
                                                     </td>
                                                 </tr>
-                                                <tr>
+                                                <tr class="gh-member-stripe-row">
                                                     <td class="gh-member-stripe-label">Customer since</td>
                                                     <td class="gh-member-stripe-data">
                                                         {{#if subscription.startDate}}
@@ -272,12 +264,12 @@
                     {{/if}}
                     <div class="pa5 pb0 pt4 flex flex-column justify-between bt b--whitegrey">
                         <GhFormGroup @classNames="gh-members-comped-checkbox">
-                            <div class="flex justify-between items-center">
+                            <div class="flex justify-between items-center gh-members-comped">
                                 <div class="mr5">
                                     <h4 class="gh-setting-title">Complimentary premium plan</h4>
                                     <p class="gh-setting-desc">If enabled, member will be placed onto a free of charge premium subscription</p>
                                 </div>
-                                <div class="for-switch">
+                                <div class="for-switch gh-members-comped-switch">
                                     <label class="switch" for="comped-checkbox">
                                         <Input @checked={{this.member.comped}} @type="checkbox" @id="comped-checkbox" @name="comped" />
                                         <span class="input-toggle-component"></span>
@@ -288,6 +280,9 @@
                     </div>
                 </div>
             {{/if}}
-        {{/if}}
-    </div>
+        </div>
+    {{/if}}
+
+    <GhMemberActivityFeed @emailRecipients={{this.member.emailRecipients}} />
+
 </div>

--- a/app/components/gh-member-settings-form.hbs
+++ b/app/components/gh-member-settings-form.hbs
@@ -1,4 +1,4 @@
-<div class="mt2 pb2 gh-member-settings">
+<div class="mt2 pb2 gh-member-settings" ...attributes>
     <div class="flex-auto br4 shadow-1 bg-grouped-table mt2 flex flex-column justify-between items-stretch gh-member-details">
         <div>
             <div class="flex items-center pa5 pb3">
@@ -63,7 +63,7 @@
                 <GhFormGroup @errors={{this.member.errors}} @hasValidated={{this.member.hasValidated}} @property="name" @classNames="max-width pl5 pr5">
                     <label for="member-name">Name</label>
                     <GhTextInput @id="member-name" @name="name" @value={{this.scratchMember.name}} @tabindex="1"
-                        @focus-out={{action "setProperty" "name" this.scratchMember.name}} />
+                        @focus-out={{action "setProperty" "name" this.scratchMember.name}} data-test-input="member-name" />
                     <GhErrorMessage @errors={{member.errors}} @property="name" />
                 </GhFormGroup>
 
@@ -71,7 +71,7 @@
                     <label for="member-email">Email</label>
                     <GhTextInput @value={{this.scratchMember.email}} @id="member-email" @name="email" @tabindex="2"
                         @autocapitalize="off" @autocorrect="off" @autocomplete="off"
-                        @focus-out={{action "setProperty" "email" this.scratchMember.email}} />
+                        @focus-out={{action "setProperty" "email" this.scratchMember.email}} data-test-input="member-email"/>
                     <GhErrorMessage @errors={{this.member.errors}} @property="email" />
                 </GhFormGroup>
         </div>
@@ -86,7 +86,7 @@
                     <div class="for-switch">
                         <label class="switch" for="subscribed-checkbox">
                             <Input @checked={{this.member.subscribed}} @type="checkbox" @id="subscribed-checkbox"
-                                @name="subscribed" />
+                                @name="subscribed" data-test-checkbox="member-subscribed" />
                             <span class="input-toggle-component"></span>
                         </label>
                     </div>
@@ -99,12 +99,12 @@
         <div class="pa5">
             <GhFormGroup @classNames="gh-member-labels">
                 <label for="label-input">Labels</label>
-                <GhMemberLabelInput @onChange={{action "setLabels"}} @labels={{this.member.labels}} @triggerId="label-input" />
+                <GhMemberLabelInput @onChange={{action "setLabels"}} @labels={{this.member.labels}} @triggerId="label-input" data-test-input="" />
             </GhFormGroup>
             <GhFormGroup @errors={{this.member.errors}} @hasValidated={{this.member.hasValidated}} @property="note" @classNames="mb0 gh-member-note">
                 <label for="member-note">Note <span class="midgrey-l2 fw4">(not visible to member)</span></label>
                 <GhTextarea @id="member-note" @name="note" @class="gh-member-details-textarea" @tabindex="3"
-                    @value={{this.scratchMember.note}} @focus-out={{action "setProperty" "note" this.scratchMember.note}} />
+                    @value={{this.scratchMember.note}} @focus-out={{action "setProperty" "note" this.scratchMember.note}} data-test-input="member-note" />
                 <GhErrorMessage @errors={{this.member.errors}} @property="note" />
                 <p> Maximum: <b>500</b> characters. You’ve used
                     {{gh-count-down-characters this.scratchMember.note 500}}</p>

--- a/app/styles/layouts/members.css
+++ b/app/styles/layouts/members.css
@@ -439,10 +439,15 @@ textarea.gh-member-details-textarea {
     margin: 6px 0 12px;
 }
 
+@media (max-width: 1160px) {
+    .gh-member-stripe-table {
+        max-width: 520px;
+    }
+}
+
 .gh-member-stripe-table td {
     vertical-align: top;
     font-size: 1.3rem;
-    padding: 5px 12px 5px 0;
 }
 
 .gh-member-stripe-id,
@@ -454,6 +459,35 @@ textarea.gh-member-details-textarea {
 .gh-member-stripe-label {
     color: var(--midgrey-d1);
     white-space: nowrap;
+    padding: 5px 12px 5px 0;
+}
+
+.gh-member-stripe-data {
+    padding: 5px 12px 5px 0;
+}
+
+@media (max-width: 1400px) and (min-width: 1160px) {
+    .gh-member-stripe-row {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .gh-member-stripe-label {
+        padding-bottom: 0;
+        font-weight: 500;
+    }
+
+    .gh-member-stripe-data {
+        padding-top: 0;
+    }
+    .gh-members-comped {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .gh-members-comped-switch {
+        margin-top: 2rem;
+    }
 }
 
 .gh-members-subscribed-checkbox,
@@ -505,50 +539,50 @@ textarea.gh-member-details-textarea {
     color: color-mod(var(--blue) l(-7%) saturation(-10%));
 }
 
-@media (max-width: 1240px) {
+.gh-member-details,
+.gh-member-feed {
+    float: left;
+    width: 69%;
+}
+
+.gh-member-internal-info,
+.gh-member-stripe {
+    float: right;
+    width: 29%;
+}
+
+@media (max-width: 1160px) {
     .gh-member-settings {
+        display: flex;
         flex-direction: column;
     }
-}
 
-.gh-member-settings-primary {
-    flex-basis: 800px;
-}
-
-.gh-member-settings-secondary {
-    flex-basis: 348px;
-}
-
-@media (max-width: 1240px) and (min-width: 740px) {
-    .gh-member-settings-secondary {
-        flex-direction: row;
-    }
-
-    .gh-member-label-stripe {
-        display: none;
-    }
-
-    .gh-member-stripe {
-        margin-top: 3.2rem;
-        margin-left: 2rem;
-    }
-}
-
-@media (max-width: 1240px) {
-    .gh-member-settings-primary,
-    .gh-member-settings-secondary {
-        flex-basis: initial;
+    .gh-member-settings > div {
+        float: none;
         width: 100%;
     }
 
-    .gh-member-details,
+    .gh-member-details {
+        order: 1;
+    }
+    
     .gh-member-feed {
-        margin-right: 0;
+        order: 4;
     }
     
     .gh-member-internal-info {
+        order: 2;
         margin-top: 3.2rem;
     }
+    
+    .gh-member-stripe {
+        order: 3;
+    }
+}
+
+.gh-member-labels,
+.gh-member-note {
+    max-width: none;
 }
 
 .gh-member-cancelstripe-checkbox {
@@ -609,10 +643,11 @@ textarea.gh-member-details-textarea {
 
 .gh-member-feed-date {
     margin-left: auto;
-    padding: 10px 0;
+    padding: 10px 0 10px 16px;
     color: var(--midgrey);
     font-size: 1.3rem;
     text-align: right;
+    white-space: nowrap;
 }
 
 .gh-member-btn-expandfeed span {

--- a/app/templates/member.hbs
+++ b/app/templates/member.hbs
@@ -25,7 +25,7 @@
         </section>
     </GhCanvasHeader>
 
-    <form class="mb14 member-basic-info-form">
+    <form class="member-basic-info-form">
         <GhMemberSettingsForm
             @member={{this.member}}
             @scratchMember={{this.scratchMember}}
@@ -34,14 +34,16 @@
     </form>
 
     {{#unless this.member.isNew}}
-        <button
-            type="button"
-            class="gh-btn gh-btn-red gh-btn-icon mt3"
-            {{on "click" this.toggleDeleteMemberModal}}
-            data-test-button="delete-member"
-        >
-            <span>Delete member</span>
-        </button>
+        <div class="w-60">
+            <button
+                type="button"
+                class="gh-btn gh-btn-red gh-btn-icon mt14"
+                {{on "click" this.toggleDeleteMemberModal}}
+                data-test-button="delete-member"
+            >
+                <span>Delete member</span>
+            </button>
+        </div>
     {{/unless}}
 </section>
 

--- a/tests/acceptance/members-test.js
+++ b/tests/acceptance/members-test.js
@@ -86,15 +86,15 @@ describe('Acceptance: Members', function () {
             await wait();
 
             // it shows selected member form
-            expect(find('.gh-member-settings-primary input[name="name"]').value, 'loads correct member into form')
+            expect(find('[data-test-input="member-name"]').value, 'loads correct member into form')
                 .to.equal(member1.name);
 
-            expect(find('.gh-member-settings-primary input[name="email"]').value, 'loads correct email into form')
+            expect(find('[data-test-input="member-email"]').value, 'loads correct email into form')
                 .to.equal(member1.email);
 
             // trigger save
-            await fillIn('.gh-member-settings-primary input[name="name"]', 'New Name');
-            await blur('.gh-member-settings-primary input[name="name"]');
+            await fillIn('[data-test-input="member-name"]', 'New Name');
+            await blur('[data-test-input="member-name"]');
 
             await click('[data-test-button="save"]');
 
@@ -144,20 +144,20 @@ describe('Acceptance: Members', function () {
             });
 
             // save new member
-            await fillIn('.gh-member-settings-primary input[name="name"]', 'New Name');
-            await blur('.gh-member-settings-primary input[name="name"]');
+            await fillIn('[data-test-input="member-name"]', 'New Name');
+            await blur('[data-test-input="member-name"]');
 
-            await fillIn('.gh-member-settings-primary input[name="email"]', 'example@domain.com');
-            await blur('.gh-member-settings-primary input[name="email"]');
+            await fillIn('[data-test-input="member-email"]', 'example@domain.com');
+            await blur('[data-test-input="member-email"]');
 
             await click('[data-test-button="save"]');
 
             await wait();
 
-            expect(find('.gh-member-settings-primary input[name="name"]').value, 'name has been preserved')
+            expect(find('[data-test-input="member-name"]').value, 'name has been preserved')
                 .to.equal('New Name');
 
-            expect(find('.gh-member-settings-primary input[name="email"]').value, 'email has been preserved')
+            expect(find('[data-test-input="member-email"]').value, 'email has been preserved')
                 .to.equal('example@domain.com');
         });
     });


### PR DESCRIPTION
No-ref

- Changed order to display feed at the bottom
- Displayed heading and value vertically between 1400px and 1160px
- Displayed "Complementary plan" copy and switch vertically between 1400px and 1160px
- Added margin below "Continue subscription" button
- Prevented date in feed to wrap